### PR TITLE
Unify some serialized fields for blocks

### DIFF
--- a/quarkchain/core.py
+++ b/quarkchain/core.py
@@ -839,9 +839,9 @@ class RootBlockHeader(Serializable):
         ("hash_merkle_root", hash256),
         ("coinbase_address", Address),
         ("coinbase_amount", uint256),
-        ("create_time", uint32),
+        ("create_time", uint64),
         ("difficulty", biguint),
-        ("nonce", uint32),
+        ("nonce", uint64),
         ("extra_data", PrependedSizeBytesSerializer(2)),
         ("mixhash", hash256),
     ]

--- a/quarkchain/tests/test_core.py
+++ b/quarkchain/tests/test_core.py
@@ -18,7 +18,7 @@ from quarkchain.core import (
 )
 from quarkchain.tests.test_utils import create_random_test_transaction
 
-SIZE_LIST = [(RootBlockHeader, 175), (MinorBlockHeader, 481), (MinorBlockMeta, 186)]
+SIZE_LIST = [(RootBlockHeader, 183), (MinorBlockHeader, 481), (MinorBlockMeta, 186)]
 
 
 class TestDataSize(unittest.TestCase):


### PR DESCRIPTION
...so that `RootBlockHeader` and `MinorBlockHeader` have same serialziation formats for nonce and create time