### PR TITLE
Fix unexpected hanging during mining

### DIFF
--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -652,8 +652,7 @@ class MasterServer:
 
     async def start_mining(self):
         await self.__send_mining_config_to_slaves(True)
-        self.root_miner.enable()
-        self.root_miner.mine_new_block_async()
+        self.root_miner.start()
         Logger.warning(
             "Mining started with root block time {} s, minor block time {} s".format(
                 self.get_artificial_tx_config().target_root_block_time,
@@ -999,8 +998,6 @@ class MasterServer:
             )
             result_list = await asyncio.gather(*future_list)
             check(all([resp.error_code == 0 for _, resp, _ in result_list]))
-
-            self.root_miner.mine_new_block_async()
 
     async def add_raw_minor_block(self, branch, block_data):
         if branch.value not in self.branch_to_slaves:

--- a/quarkchain/cluster/miner.py
+++ b/quarkchain/cluster/miner.py
@@ -70,6 +70,10 @@ class Miner:
         self.input_q = AioQueue()  # [(block, target_time)]
         self.output_q = AioQueue()  # [block]
 
+    def start(self):
+        self.enable()
+        self._mine_new_block_async()
+
     def is_enabled(self):
         return self.enabled
 
@@ -80,17 +84,18 @@ class Miner:
         """Stop the mining process if there is one"""
         self.enabled = False
 
-    def mine_new_block_async(self):
+    def _mine_new_block_async(self):
         async def handle_mined_block(instance: Miner):
             while True:
                 block = await instance.output_q.coro_get()
                 if not block:
                     return
+                # start mining before processing and propagating mined block
+                instance._mine_new_block_async()
                 try:
                     await instance.add_block_async_func(block)
                 except Exception as ex:
                     GLOG.exception(ex)
-                    instance.mine_new_block_async()
 
         async def mine_new_block(instance: Miner):
             """Get a new block and start mining.

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -545,9 +545,6 @@ class Shard:
 
         self.add_block_futures[block.header.get_hash()] = self.loop.create_future()
 
-        # Start mining new one before propagating inside cluster
-        # The propagation should be done by the time the new block is mined
-        self.miner.mine_new_block_async()
         prev_root_height = self.state.db.get_root_block_by_hash(
             block.header.hash_prev_root_block
         ).header.height

--- a/quarkchain/cluster/slave.py
+++ b/quarkchain/cluster/slave.py
@@ -789,8 +789,7 @@ class SlaveServer:
                 futures.append(shard.init_from_root_block(root_block))
                 self.shards[branch] = shard
                 if self.mining:
-                    shard.miner.enable()
-                    shard.miner.mine_new_block_async()
+                    shard.miner.start()
 
         await asyncio.gather(*futures)
 
@@ -803,8 +802,7 @@ class SlaveServer:
                     branch.get_shard_id(), artificial_tx_config.target_minor_block_time
                 )
             )
-            shard.miner.enable()
-            shard.miner.mine_new_block_async()
+            shard.miner.start()
 
     def create_transactions(self, num_tx_per_shard, x_shard_percent, tx: Transaction):
         for shard in self.shards.values():

--- a/quarkchain/cluster/tests/test_miner.py
+++ b/quarkchain/cluster/tests/test_miner.py
@@ -42,13 +42,12 @@ class TestMiner(unittest.TestCase):
         async def add(block):
             nonlocal miner
             self.added_blocks.append(block)
-            miner.mine_new_block_async()
 
         for consensus in (ConsensusType.POW_SIMULATE, ConsensusType.POW_ETHASH):
             miner = self.miner_gen(consensus, create, add)
             # should generate 5 blocks and then end
             loop = asyncio.get_event_loop()
-            loop.run_until_complete(miner.mine_new_block_async())
+            loop.run_until_complete(miner._mine_new_block_async())
             self.assertEqual(len(self.added_blocks), 5)
 
     def test_simulate_mine_handle_block_exception(self):
@@ -71,14 +70,13 @@ class TestMiner(unittest.TestCase):
                     raise Exception("(╯°□°）╯︵ ┻━┻")
                 else:
                     self.added_blocks.append(block)
-                    miner.mine_new_block_async()
             finally:
                 i += 1
 
         miner = self.miner_gen(ConsensusType.POW_SIMULATE, create, add)
         # only 2 blocks can be added
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(miner.mine_new_block_async())
+        loop.run_until_complete(miner._mine_new_block_async())
         self.assertEqual(len(self.added_blocks), 2)
 
     def test_mine_ethash_new_block_overwrite(self):
@@ -110,6 +108,6 @@ class TestMiner(unittest.TestCase):
         for _ in range(5):
             miner.input_q.put((block, {}))
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(miner.mine_new_block_async())
+        loop.run_until_complete(miner._mine_new_block_async())
         # will only have 1 block mined
         self.assertEqual(len(self.added_blocks), 1)


### PR DESCRIPTION
fixes #96

1. always start mining before processing / propagating blocks (race
   condition possible, but shouldn't affect much)
1. removed mining call in slave and master, and moved to miner
1. added `miner.start` and make `mine_block_async` private
1. fixed tests