### PR TITLE
Change timestamp to milliseconds

### DIFF
--- a/quarkchain/cluster/filter.py
+++ b/quarkchain/cluster/filter.py
@@ -1,10 +1,9 @@
-import time
 from typing import List, Optional
 
 from quarkchain.cluster.shard_db_operator import ShardDbOperator
 from quarkchain.core import Address, Log, MinorBlock
 from quarkchain.evm.bloom import bloom
-from quarkchain.utils import Logger
+from quarkchain.utils import Logger, time_ms
 
 
 class Filter:
@@ -13,7 +12,7 @@ class Filter:
     TODO: For now only supports filtering logs.
     """
 
-    TIMEOUT = 10  # seconds
+    TIMEOUT = 10 * 1000  # ms, = 10 sec
 
     def __init__(
         self,
@@ -78,7 +77,7 @@ class Filter:
             if not should_skip_block:
                 ret.append(block)
 
-            if (1 + i) % 100 == 0 and time.time() - self.start_ts > Filter.TIMEOUT:
+            if (1 + i) % 100 == 0 and time_ms() - self.start_ts > Filter.TIMEOUT:
                 raise Exception("Filter timeout")
 
         return ret
@@ -95,7 +94,7 @@ class Filter:
                         continue
                     if self._log_topics_match(log):
                         ret.append(log)
-            if (1 + b_i) % 100 == 0 and time.time() - self.start_ts > Filter.TIMEOUT:
+            if (1 + b_i) % 100 == 0 and time_ms() - self.start_ts > Filter.TIMEOUT:
                 raise Exception("Filter timeout")
         return ret
 
@@ -114,7 +113,7 @@ class Filter:
         return True
 
     def run(self) -> List[Log]:
-        self.start_ts = time.time()
+        self.start_ts = time_ms()
         candidate_blocks = self._get_block_candidates()
         logs = self._get_logs(candidate_blocks)
         return logs

--- a/quarkchain/cluster/miner.py
+++ b/quarkchain/cluster/miner.py
@@ -130,7 +130,7 @@ class Miner:
         is_root = isinstance(block, RootBlock)
         shard = "R" if is_root else block.header.branch.get_shard_id()
         count = len(block.minor_block_header_list) if is_root else len(block.tx_list)
-        elapsed = time.time() - block.header.create_time
+        elapsed = time_ms() - block.header.create_time
         Logger.info_every_sec(
             "[{}] {} [{}] ({:.2f}) {}".format(
                 shard,
@@ -188,7 +188,7 @@ class Miner:
             except Exception:
                 # got nothing from queue
                 pass
-            if time.time() > target_time:
+            if time_ms() > target_time:
                 Miner.__log_status(block)
                 block.header.nonce = random.randint(0, 2 ** 32 - 1)
                 Miner._post_process_mined_block(block)

--- a/quarkchain/cluster/root_state.py
+++ b/quarkchain/cluster/root_state.py
@@ -184,12 +184,12 @@ class RootState:
 
     def get_next_block_difficulty(self, create_time=None):
         if create_time is None:
-            create_time = max(self.tip.create_time + 1, int(time.time()))
+            create_time = max(self.tip.create_time + 1, time_ms())
         return self.diff_calc.calculate_diff_with_parent(self.tip, create_time)
 
     def create_block_to_mine(self, m_header_list, address, create_time=None):
         if create_time is None:
-            create_time = max(self.tip.create_time + 1, int(time.time()))
+            create_time = max(self.tip.create_time + 1, time_ms())
         extra_data = {
             "inception": time_ms(),
             "cluster": self.env.cluster_config.MONITORING.CLUSTER_ID,

--- a/quarkchain/cluster/rpc.py
+++ b/quarkchain/cluster/rpc.py
@@ -30,7 +30,7 @@ class Ping(Serializable):
     FIELDS = [
         ("id", PrependedSizeBytesSerializer(4)),
         ("shard_mask_list", PrependedSizeListSerializer(4, ShardMask)),
-        ("root_tip", Optional(RootBlock)),   # Initialize ShardState if not None
+        ("root_tip", Optional(RootBlock)),  # Initialize ShardState if not None
     ]
 
     def __init__(self, id, shard_mask_list, root_tip):
@@ -527,7 +527,7 @@ class ShardStats(Serializable):
         ("total_tx_count", uint32),
         ("block_count60s", uint32),
         ("stale_block_count60s", uint32),
-        ("last_block_time", uint32),
+        ("last_block_time", uint64),
     ]
 
     def __init__(

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -557,7 +557,7 @@ class ShardState:
         Returns a list of CrossShardTransactionDeposit from block.
         Raises on any error.
         """
-        start_time = time.time()
+        start_time_sec = time.time()
         start_ms = time_ms()
         if self.header_tip.height - block.header.height > 700:
             Logger.info(
@@ -663,7 +663,7 @@ class ShardState:
         )
         Logger.debug(
             "Add block took {} seconds for {} tx".format(
-                time.time() - start_time, len(block.tx_list)
+                time.time() - start_time_sec, len(block.tx_list)
             )
         )
         if block.meta.extra_data.decode("utf-8") != "":
@@ -747,7 +747,7 @@ class ShardState:
 
     def get_next_block_difficulty(self, create_time=None):
         if not create_time:
-            create_time = max(int(time.time()), self.header_tip.create_time + 1)
+            create_time = max(time_ms(), self.header_tip.create_time + 1)
         return self.diff_calc.calculate_diff_with_parent(self.header_tip, create_time)
 
     def get_next_block_reward(self):
@@ -863,13 +863,13 @@ class ShardState:
     def create_block_to_mine(self, create_time=None, address=None, gas_limit=None):
         """ Create a block to append and include TXs to maximize rewards
         """
-        start_time = time.time()
+        start_time_sec = time.time()
         extra_data = {
             "inception": time_ms(),
             "cluster": self.env.cluster_config.MONITORING.CLUSTER_ID,
         }
         if not create_time:
-            create_time = max(int(time.time()), self.header_tip.create_time + 1)
+            create_time = max(time_ms(), self.header_tip.create_time + 1)
         difficulty = self.get_next_block_difficulty(create_time)
         block = self.get_tip().create_block_to_append(
             create_time=create_time, address=address, difficulty=difficulty
@@ -907,10 +907,9 @@ class ShardState:
         block.meta.extra_data = json.dumps(extra_data).encode("utf-8")
         block.finalize(evm_state=evm_state)
 
-        end_time = time.time()
         Logger.debug(
             "Create block to mine took {} seconds for {} tx".format(
-                end_time - start_time, len(block.tx_list)
+                time.time() - start_time_sec, len(block.tx_list)
             )
         )
         return block

--- a/quarkchain/cluster/tests/test_cluster.py
+++ b/quarkchain/cluster/tests/test_cluster.py
@@ -1,5 +1,4 @@
 import unittest
-from quarkchain.genesis import GenesisManager
 from quarkchain.cluster.tests.test_utils import (
     create_transfer_transaction,
     ClusterContext,

--- a/quarkchain/cluster/tests/test_miner.py
+++ b/quarkchain/cluster/tests/test_miner.py
@@ -1,12 +1,12 @@
 import asyncio
 import functools
-import time
 import unittest
 from typing import Optional
 
 from quarkchain.cluster.miner import Miner, validate_seal
 from quarkchain.config import ConsensusType
 from quarkchain.core import RootBlock, RootBlockHeader
+from quarkchain.utils import time_ms
 
 
 class TestMiner(unittest.TestCase):
@@ -34,9 +34,7 @@ class TestMiner(unittest.TestCase):
             if len(self.added_blocks) >= 5:
                 return None  # stop the game
             return RootBlock(
-                RootBlockHeader(
-                    create_time=int(time.time()), extra_data="{}".encode("utf-8")
-                )
+                RootBlockHeader(create_time=time_ms(), extra_data="{}".encode("utf-8"))
             )
 
         async def add(block):
@@ -62,9 +60,7 @@ class TestMiner(unittest.TestCase):
             if i >= 5:
                 return None
             return RootBlock(
-                RootBlockHeader(
-                    create_time=int(time.time()), extra_data="{}".encode("utf-8")
-                )
+                RootBlockHeader(create_time=time_ms(), extra_data="{}".encode("utf-8"))
             )
 
         async def add(block):

--- a/quarkchain/cluster/tx_generator.py
+++ b/quarkchain/cluster/tx_generator.py
@@ -52,7 +52,7 @@ class TransactionGenerator:
         )
         if num_tx <= 0:
             return
-        start_time = time.time()
+        start_time_sec = time.time()
         tx_list = []
         total = 0
         sample_evm_tx = sample_tx.code.get_evm_transaction()
@@ -73,10 +73,9 @@ class TransactionGenerator:
             if total >= num_tx:
                 break
 
-        end_time = time.time()
         Logger.info(
             "[{}] generated {} transactions in {:.2f} seconds".format(
-                self.shard_id, total, end_time - start_time
+                self.shard_id, total, time.time() - start_time_sec
             )
         )
         self.running = False

--- a/quarkchain/config.py
+++ b/quarkchain/config.py
@@ -103,7 +103,7 @@ class ConsensusType(Enum):
 
 
 class POWConfig(BaseConfig):
-    TARGET_BLOCK_TIME = 10
+    TARGET_BLOCK_TIME = 10 * 1000
 
 
 class ShardConfig(BaseConfig):

--- a/quarkchain/tests/test_config.py
+++ b/quarkchain/tests/test_config.py
@@ -71,7 +71,7 @@ class TestShardConfig(unittest.TestCase):
         {
             "CONSENSUS_TYPE": "POW_SHA3SHA3",
             "CONSENSUS_CONFIG": {
-                "TARGET_BLOCK_TIME": 10
+                "TARGET_BLOCK_TIME": 10000
             },
             "GENESIS": {
                 "ROOT_HEIGHT": 0,
@@ -91,7 +91,7 @@ class TestShardConfig(unittest.TestCase):
         {
             "CONSENSUS_TYPE": "POW_SHA3SHA3",
             "CONSENSUS_CONFIG": {
-                "TARGET_BLOCK_TIME": 10
+                "TARGET_BLOCK_TIME": 10000
             },
             "GENESIS": {
                 "ROOT_HEIGHT": 0,


### PR DESCRIPTION
just to be future-proof.

all timestamps should be regarded as milliseconds unless specified otherwise (like using a `_sec` suffix for variable naming).