### PR TITLE
 Fix contract creation in contracts

### DIFF
--- a/quarkchain/evm/messages.py
+++ b/quarkchain/evm/messages.py
@@ -14,27 +14,33 @@ from quarkchain.evm import transactions
 from quarkchain.evm import opcodes
 from quarkchain.evm import vm
 from quarkchain.evm.specials import specials as default_specials
-from quarkchain.evm.exceptions import InvalidNonce, InsufficientStartGas, UnsignedTransaction, \
-    BlockGasLimitReached, InsufficientBalance, InvalidTransaction
+from quarkchain.evm.exceptions import (
+    InvalidNonce,
+    InsufficientStartGas,
+    UnsignedTransaction,
+    BlockGasLimitReached,
+    InsufficientBalance,
+    InvalidTransaction,
+)
 from quarkchain.evm.slogging import get_logger
 
 
-null_address = b'\xff' * 20
+null_address = b"\xff" * 20
 
-log = get_logger('eth.block')
-log_tx = get_logger('eth.pb.tx')
-log_msg = get_logger('eth.pb.msg')
-log_state = get_logger('eth.pb.msg.state')
+log = get_logger("eth.block")
+log_tx = get_logger("eth.pb.tx")
+log_msg = get_logger("eth.pb.msg")
+log_state = get_logger("eth.pb.msg.state")
 
 # contract creating transactions send to an empty address
-CREATE_CONTRACT_ADDRESS = b''
+CREATE_CONTRACT_ADDRESS = b""
 
 # DEV OPTIONS
 SKIP_MEDSTATES = False
 
 
 def rp(tx, what, actual, target):
-    return '%r: %r actual:%r target:%r' % (tx, what, actual, target)
+    return "%r: %r actual:%r target:%r" % (tx, what, actual, target)
 
 
 class Log(rlp.Serializable):
@@ -42,9 +48,9 @@ class Log(rlp.Serializable):
     # TODO: original version used zpad (here replaced by int32.serialize); had
     # comment "why zpad"?
     fields = [
-        ('address', Binary.fixed_length(20, allow_empty=True)),
-        ('topics', CountableList(BigEndianInt(32))),
-        ('data', binary)
+        ("address", Binary.fixed_length(20, allow_empty=True)),
+        ("topics", CountableList(BigEndianInt(32))),
+        ("data", binary),
     ]
 
     def __init__(self, address, topics, data):
@@ -60,28 +66,41 @@ class Log(rlp.Serializable):
         return {
             "bloom": encode_hex(bloom.b64(bloom.bloom_from_list(self.bloomables()))),
             "address": encode_hex(self.address),
-            "data": b'0x' + encode_hex(self.data),
-            "topics": [encode_hex(utils.int32.serialize(t))
-                       for t in self.topics]
+            "data": b"0x" + encode_hex(self.data),
+            "topics": [encode_hex(utils.int32.serialize(t)) for t in self.topics],
         }
 
     def __repr__(self):
-        return '<Log(address=%r, topics=%r, data=%r)>' %  \
-            (encode_hex(self.address), self.topics, self.data)
+        return "<Log(address=%r, topics=%r, data=%r)>" % (
+            encode_hex(self.address),
+            self.topics,
+            self.data,
+        )
 
 
 class Receipt(rlp.Serializable):
 
     fields = [
-        ('state_root', binary),
-        ('gas_used', big_endian_int),   # TODO: this is actually the cumulative gas used. fix it.
-        ('bloom', int256),
-        ('logs', CountableList(Log)),
-        ('contract_address', Binary.fixed_length(20, allow_empty=True)),
-        ('contract_full_shard_id', BigEndianInt(4)),
+        ("state_root", binary),
+        (
+            "gas_used",
+            big_endian_int,
+        ),  # TODO: this is actually the cumulative gas used. fix it.
+        ("bloom", int256),
+        ("logs", CountableList(Log)),
+        ("contract_address", Binary.fixed_length(20, allow_empty=True)),
+        ("contract_full_shard_id", BigEndianInt(4)),
     ]
 
-    def __init__(self, state_root, gas_used, logs, contract_address, contract_full_shard_id, bloom=None):
+    def __init__(
+        self,
+        state_root,
+        gas_used,
+        logs,
+        contract_address,
+        contract_full_shard_id,
+        bloom=None,
+    ):
         # does not call super.__init__ as bloom should not be an attribute but
         # a property
         self.state_root = state_root
@@ -101,7 +120,13 @@ class Receipt(rlp.Serializable):
 
 
 def mk_receipt(state, success, logs, contract_address, contract_full_shard_id):
-    o = Receipt(b'\x01' if success else b'', state.gas_used, logs, contract_address, contract_full_shard_id)
+    o = Receipt(
+        b"\x01" if success else b"",
+        state.gas_used,
+        logs,
+        contract_address,
+        contract_full_shard_id,
+    )
     return o
 
 
@@ -110,12 +135,12 @@ def config_fork_specific_validation(config, blknum, tx):
     _ = tx.sender
     if _ is None:
         pass
-    if blknum >= config['CONSTANTINOPLE_FORK_BLKNUM']:
+    if blknum >= config["CONSTANTINOPLE_FORK_BLKNUM"]:
         tx.check_low_s_metropolis()
     else:
         if tx.sender == null_address:
             raise InvalidTransaction("EIP86 transactions not available yet")
-        if blknum >= config['HOMESTEAD_FORK_BLKNUM']:
+        if blknum >= config["HOMESTEAD_FORK_BLKNUM"]:
             tx.check_low_s_homestead()
 
     if tx.network_id != config["NETWORK_ID"]:
@@ -136,14 +161,13 @@ def validate_transaction(state, tx):
     #     sender account's current nonce);
     req_nonce = 0 if tx.sender == null_address else state.get_nonce(tx.sender)
     if req_nonce != tx.nonce:
-        raise InvalidNonce(rp(tx, 'nonce', tx.nonce, req_nonce))
+        raise InvalidNonce(rp(tx, "nonce", tx.nonce, req_nonce))
 
     # (3) the gas limit is no smaller than the intrinsic gas,
     # g0, used by the transaction;
     total_gas = tx.intrinsic_gas_used
     if tx.startgas < total_gas:
-        raise InsufficientStartGas(
-            rp(tx, 'startgas', tx.startgas, total_gas))
+        raise InsufficientStartGas(rp(tx, "startgas", tx.startgas, total_gas))
 
     # (4) the sender account balance contains at least the
     # cost, v0, required in up-front payment.
@@ -151,17 +175,18 @@ def validate_transaction(state, tx):
 
     if state.get_balance(tx.sender) < total_cost:
         raise InsufficientBalance(
-            rp(tx, 'balance', state.get_balance(tx.sender), total_cost))
+            rp(tx, "balance", state.get_balance(tx.sender), total_cost)
+        )
 
     # check block gas limit
     if state.gas_used + tx.startgas > state.gas_limit:
         raise BlockGasLimitReached(
-            rp(tx, 'gaslimit', state.gas_used + tx.startgas, state.gas_limit))
+            rp(tx, "gaslimit", state.gas_used + tx.startgas, state.gas_limit)
+        )
 
     # EIP86-specific restrictions
     if tx.sender == null_address and (tx.value != 0 or tx.gasprice != 0):
-        raise InvalidTransaction(
-            "EIP86 transactions must have 0 value and gasprice")
+        raise InvalidTransaction("EIP86 transactions must have 0 value and gasprice")
 
     return True
 
@@ -171,7 +196,7 @@ def apply_message(state, msg=None, **kwargs):
         msg = vm.Message(**kwargs)
     else:
         assert not kwargs
-    ext = VMExt(state, transactions.Transaction(0, 0, 21000, b'', 0, b''))
+    ext = VMExt(state, transactions.Transaction(0, 0, 21000, b"", 0, b""))
     result, gas_remained, data = apply_msg(ext, msg)
     return bytearray_to_bytestr(data) if result else None
 
@@ -188,7 +213,7 @@ def apply_transaction(state, tx: transactions.Transaction, tx_wrapper_hash):
     state.full_shard_id = tx.to_full_shard_id
 
     intrinsic_gas = tx.intrinsic_gas_used
-    log_tx.debug('TX NEW', txdict=tx.to_dict())
+    log_tx.debug("TX NEW", txdict=tx.to_dict())
 
     # start transacting #################
     if tx.sender != null_address:
@@ -215,46 +240,49 @@ def apply_transaction(state, tx: transactions.Transaction, tx_wrapper_hash):
     # MESSAGE
     ext = VMExt(state, tx)
 
-    contract_address = b''
-    if tx.to != b'':
+    contract_address = b""
+    if tx.to != b"":
         result, gas_remained, data = apply_msg(ext, message)
     else:  # CREATE
         result, gas_remained, data = create_contract(ext, message)
-        contract_address = data if data else b''  # data could be [] when vm failed execution
+        contract_address = (
+            data if data else b""
+        )  # data could be [] when vm failed execution
 
     assert gas_remained >= 0
 
-    log_tx.debug("TX APPLIED", result=result, gas_remained=gas_remained,
-                 data=data)
+    log_tx.debug("TX APPLIED", result=result, gas_remained=gas_remained, data=data)
 
     gas_used = tx.startgas - gas_remained
 
     # Transaction failed
     if not result:
-        log_tx.debug('TX FAILED', reason='out of gas',
-                     startgas=tx.startgas, gas_remained=gas_remained)
+        log_tx.debug(
+            "TX FAILED",
+            reason="out of gas",
+            startgas=tx.startgas,
+            gas_remained=gas_remained,
+        )
         state.delta_balance(tx.sender, tx.gasprice * gas_remained)
         state.delta_balance(state.block_coinbase, tx.gasprice * gas_used)
         state.block_fee += tx.gasprice * gas_used
-        output = b''
+        output = b""
         success = 0
     # Transaction success
     else:
-        log_tx.debug('TX SUCCESS', data=data)
+        log_tx.debug("TX SUCCESS", data=data)
         state.refunds += len(set(state.suicides)) * opcodes.GSUICIDEREFUND
         if state.refunds > 0:
-            log_tx.debug(
-                'Refunding',
-                gas_refunded=min(
-                    state.refunds,
-                    gas_used // 2))
+            log_tx.debug("Refunding", gas_refunded=min(state.refunds, gas_used // 2))
             gas_remained += min(state.refunds, gas_used // 2)
             gas_used -= min(state.refunds, gas_used // 2)
             state.refunds = 0
         # sell remaining gas
         state.delta_balance(tx.sender, tx.gasprice * gas_remained)
         # if x-shard, reserve part of the gas for the target shard miner
-        fee = tx.gasprice * (gas_used - (opcodes.GTXXSHARDCOST if tx.is_cross_shard() else 0))
+        fee = tx.gasprice * (
+            gas_used - (opcodes.GTXXSHARDCOST if tx.is_cross_shard() else 0)
+        )
         state.delta_balance(state.block_coinbase, fee)
         state.block_fee += fee
         if tx.to:
@@ -283,18 +311,17 @@ def apply_transaction(state, tx: transactions.Transaction, tx_wrapper_hash):
     r = mk_receipt(state, success, state.logs, contract_address, state.full_shard_id)
     state.logs = []
     state.add_receipt(r)
-    state.set_param('bloom', state.bloom | r.bloom)
-    state.set_param('txindex', state.txindex + 1)
+    state.set_param("bloom", state.bloom | r.bloom)
+    state.set_param("txindex", state.txindex + 1)
 
     return success, output
 
 
 # VM interface
-class VMExt():
-
+class VMExt:
     def __init__(self, state, tx):
         self.specials = {k: v for k, v in default_specials.items()}
-        for k, v in state.config['CUSTOM_SPECIALS']:
+        for k, v in state.config["CUSTOM_SPECIALS"]:
             self.specials[k] = v
         self._state = state
         self.get_code = state.get_code
@@ -308,20 +335,20 @@ class VMExt():
         self.get_storage_data = state.get_storage_data
         self.log_storage = lambda x: state.account_to_dict(x)
         self.add_suicide = lambda x: state.add_suicide(x)
-        self.add_refund = lambda x: \
-            state.set_param('refunds', state.refunds + x)
-        self.block_hash = lambda x: state.get_block_hash(state.block_number - x - 1) \
-            if (1 <= state.block_number - x <= 256 and x <= state.block_number) else b''
+        self.add_refund = lambda x: state.set_param("refunds", state.refunds + x)
+        self.block_hash = (
+            lambda x: state.get_block_hash(state.block_number - x - 1)
+            if (1 <= state.block_number - x <= 256 and x <= state.block_number)
+            else b""
+        )
         self.block_coinbase = state.block_coinbase
         self.block_timestamp = state.timestamp
         self.block_number = state.block_number
         self.block_difficulty = state.block_difficulty
         self.block_gas_limit = state.gas_limit
-        self.log = lambda addr, topics, data: \
-            state.add_log(Log(addr, topics, data))
+        self.log = lambda addr, topics, data: state.add_log(Log(addr, topics, data))
         self.create = lambda msg: create_contract(self, msg)
-        self.msg = lambda msg: _apply_msg(
-            self, msg, self.get_code(msg.code_address))
+        self.msg = lambda msg: _apply_msg(self, msg, self.get_code(msg.code_address))
         self.account_exists = state.account_exists
         self.post_homestead_hardfork = lambda: state.is_HOMESTEAD()
         self.post_metropolis_hardfork = lambda: state.is_METROPOLIS()
@@ -329,14 +356,16 @@ class VMExt():
         self.post_serenity_hardfork = lambda: state.is_SERENITY()
         self.post_anti_dos_hardfork = lambda: state.is_ANTI_DOS()
         self.post_spurious_dragon_hardfork = lambda: state.is_SPURIOUS_DRAGON()
-        self.blockhash_store = state.config['METROPOLIS_BLOCKHASH_STORE']
+        self.blockhash_store = state.config["METROPOLIS_BLOCKHASH_STORE"]
         self.snapshot = state.snapshot
         self.revert = state.revert
         self.transfer_value = state.transfer_value
         self.deduct_value = state.deduct_value
-        self.add_cross_shard_transaction_deposit = lambda deposit: state.xshard_list.append(deposit)
+        self.add_cross_shard_transaction_deposit = lambda deposit: state.xshard_list.append(
+            deposit
+        )
         self.reset_storage = state.reset_storage
-        self.tx_origin = tx.sender if tx else b'\x00' * 20
+        self.tx_origin = tx.sender if tx else b"\x00" * 20
         self.tx_gasprice = tx.gasprice if tx else 0
 
 
@@ -345,16 +374,22 @@ def apply_msg(ext, msg):
 
 
 def _apply_msg(ext, msg, code):
-    trace_msg = log_msg.is_active('trace')
+    trace_msg = log_msg.is_active("trace")
     if trace_msg:
-        log_msg.debug("MSG APPLY", sender=encode_hex(msg.sender), to=encode_hex(msg.to),
-                      gas=msg.gas, value=msg.value, codelen=len(code),
-                      data=encode_hex(
-            msg.data.extract_all()) if msg.data.size < 2500 else (
-            "data<%d>" %
-            msg.data.size),
+        log_msg.debug(
+            "MSG APPLY",
+            sender=encode_hex(msg.sender),
+            to=encode_hex(msg.to),
+            gas=msg.gas,
+            value=msg.value,
+            codelen=len(code),
+            data=encode_hex(msg.data.extract_all())
+            if msg.data.size < 2500
+            else ("data<%d>" % msg.data.size),
             pre_storage=ext.log_storage(msg.to),
-            static=msg.static, depth=msg.depth)
+            static=msg.static,
+            depth=msg.depth,
+        )
 
     # transfer value, quit if not enough
     snapshot = ext.snapshot()
@@ -365,14 +400,18 @@ def _apply_msg(ext, msg, code):
             ext.add_cross_shard_transaction_deposit(
                 quarkchain.core.CrossShardTransactionDeposit(
                     tx_hash=msg.tx_hash,
-                    from_address=quarkchain.core.Address(msg.sender, msg.from_full_shard_id),
+                    from_address=quarkchain.core.Address(
+                        msg.sender, msg.from_full_shard_id
+                    ),
                     to_address=quarkchain.core.Address(msg.to, msg.to_full_shard_id),
                     value=msg.value,
-                    gas_price=ext.tx_gasprice)
+                    gas_price=ext.tx_gasprice,
+                )
             )
         elif not ext.transfer_value(msg.sender, msg.to, msg.value):
-            log_msg.debug('MSG TRANSFER FAILED', have=ext.get_balance(msg.to),
-                          want=msg.value)
+            log_msg.debug(
+                "MSG TRANSFER FAILED", have=ext.get_balance(msg.to), want=msg.value
+            )
             return 1, msg.gas, []
 
     if msg.is_cross_shard:
@@ -386,27 +425,33 @@ def _apply_msg(ext, msg, code):
         res, gas, dat = vm.vm_execute(ext, msg, code)
 
     if trace_msg:
-        log_msg.debug('MSG APPLIED', gas_remained=gas,
-                      sender=encode_hex(msg.sender), to=encode_hex(msg.to),
-                      data=dat if len(dat) < 2500 else ("data<%d>" % len(dat)),
-                      post_storage=ext.log_storage(msg.to))
+        log_msg.debug(
+            "MSG APPLIED",
+            gas_remained=gas,
+            sender=encode_hex(msg.sender),
+            to=encode_hex(msg.to),
+            data=dat if len(dat) < 2500 else ("data<%d>" % len(dat)),
+            post_storage=ext.log_storage(msg.to),
+        )
 
     if res == 0:
-        log_msg.debug('REVERTING')
+        log_msg.debug("REVERTING")
         ext.revert(snapshot)
 
     return res, gas, dat
 
 
 def mk_contract_address(sender, full_shard_id, nonce):
-    return utils.sha3(rlp.encode([utils.normalize_address(sender), full_shard_id, nonce]))[12:]
+    return utils.sha3(
+        rlp.encode([utils.normalize_address(sender), full_shard_id, nonce])
+    )[12:]
 
 
 def create_contract(ext, msg):
-    log_msg.debug('CONTRACT CREATION')
+    log_msg.debug("CONTRACT CREATION")
 
     if msg.is_cross_shard:
-        return 0, msg.gas, b''
+        return 0, msg.gas, b""
 
     code = msg.data.extract_all()
 
@@ -421,15 +466,16 @@ def create_contract(ext, msg):
         msg.to = mk_contract_address(msg.sender, msg.to_full_shard_id, nonce)
 
     if ext.post_metropolis_hardfork() and (
-            ext.get_nonce(msg.to) or len(ext.get_code(msg.to))):
-        log_msg.debug('CREATING CONTRACT ON TOP OF EXISTING CONTRACT')
-        return 0, 0, b''
+        ext.get_nonce(msg.to) or len(ext.get_code(msg.to))
+    ):
+        log_msg.debug("CREATING CONTRACT ON TOP OF EXISTING CONTRACT")
+        return 0, 0, b""
 
     b = ext.get_balance(msg.to)
     if b > 0:
         ext.set_balance(msg.to, b)
         ext.set_nonce(msg.to, 0)
-        ext.set_code(msg.to, b'')
+        ext.set_code(msg.to, b"")
         # ext.reset_storage(msg.to)
 
     msg.is_create = True
@@ -441,12 +487,11 @@ def create_contract(ext, msg):
     res, gas, dat = _apply_msg(ext, msg, code)
 
     log_msg.debug(
-        'CONTRACT CREATION FINISHED',
+        "CONTRACT CREATION FINISHED",
         res=res,
         gas=gas,
-        dat=dat if len(dat) < 2500 else (
-            "data<%d>" %
-            len(dat)))
+        dat=dat if len(dat) < 2500 else ("data<%d>" % len(dat)),
+    )
 
     if res:
         if not len(dat):
@@ -454,20 +499,22 @@ def create_contract(ext, msg):
             return 1, gas, msg.to
         gcost = len(dat) * opcodes.GCONTRACTBYTE
         if gas >= gcost and (
-                len(dat) <= 24576 or not ext.post_spurious_dragon_hardfork()):
+            len(dat) <= 24576 or not ext.post_spurious_dragon_hardfork()
+        ):
             gas -= gcost
         else:
             dat = []
             log_msg.debug(
-                'CONTRACT CREATION FAILED',
+                "CONTRACT CREATION FAILED",
                 have=gas,
                 want=gcost,
-                block_number=ext.block_number)
+                block_number=ext.block_number,
+            )
             if ext.post_homestead_hardfork():
                 ext.revert(snapshot)
-                return 0, 0, b''
+                return 0, 0, b""
         ext.set_code(msg.to, bytearray_to_bytestr(dat))
-        log_msg.debug('SETTING CODE', addr=encode_hex(msg.to), lendat=len(dat))
+        log_msg.debug("SETTING CODE", addr=encode_hex(msg.to), lendat=len(dat))
         return 1, gas, msg.to
     else:
         ext.revert(snapshot)

--- a/quarkchain/evm/vm.py
+++ b/quarkchain/evm/vm.py
@@ -15,13 +15,13 @@ verify_stack_after_op = False
 #  ######################################
 
 sys.setrecursionlimit(10000)
-log_log = get_logger('eth.vm.log')
-log_msg = get_logger('eth.pb.msg')
-log_vm_exit = get_logger('eth.vm.exit')
-log_vm_op = get_logger('eth.vm.op')
-log_vm_op_stack = get_logger('eth.vm.op.stack')
-log_vm_op_memory = get_logger('eth.vm.op.memory')
-log_vm_op_storage = get_logger('eth.vm.op.storage')
+log_log = get_logger("eth.vm.log")
+log_msg = get_logger("eth.pb.msg")
+log_vm_exit = get_logger("eth.vm.exit")
+log_vm_op = get_logger("eth.vm.op")
+log_vm_op_stack = get_logger("eth.vm.op.stack")
+log_vm_op_memory = get_logger("eth.vm.op.memory")
+log_vm_op_storage = get_logger("eth.vm.op.storage")
 
 TT256 = 2 ** 256
 TT256M1 = 2 ** 256 - 1
@@ -36,7 +36,6 @@ MAX_DEPTH = 1024
 # copying. Instead we just copy the reference to the parent memory
 # slice plus the start and end of the slice
 class CallData(object):
-
     def __init__(self, parent_memory, offset=0, size=None):
         self.data = parent_memory
         self.offset = offset
@@ -45,7 +44,7 @@ class CallData(object):
 
     # Convert calldata to bytes
     def extract_all(self):
-        d = self.data[self.offset: self.offset + self.size]
+        d = self.data[self.offset : self.offset + self.size]
         d.extend(bytearray(self.size - len(d)))
         return bytes(bytearray(d))
 
@@ -53,7 +52,7 @@ class CallData(object):
     def extract32(self, i):
         if i >= self.size:
             return 0
-        o = self.data[self.offset + i: min(self.offset + i + 32, self.rlimit)]
+        o = self.data[self.offset + i : min(self.offset + i + 32, self.rlimit)]
         o.extend(bytearray(32 - len(o)))
         return utils.bytearray_to_int(o)
 
@@ -69,16 +68,32 @@ class CallData(object):
 # Stores a message object, including context data like sender,
 # destination, gas, whether or not it is a STATICCALL, etc
 class Message(object):
-
-    def __init__(self, sender, to, value=0, gas=1000000, data='', depth=0,
-                 code_address=None, is_create=False, transfers_value=True, static=False,
-                 is_cross_shard=False, from_full_shard_id=None, to_full_shard_id=None, tx_hash=None):
+    def __init__(
+        self,
+        sender,
+        to,
+        value=0,
+        gas=1000000,
+        data="",
+        depth=0,
+        code_address=None,
+        is_create=False,
+        transfers_value=True,
+        static=False,
+        is_cross_shard=False,
+        from_full_shard_id=None,
+        to_full_shard_id=None,
+        tx_hash=None,
+    ):
         self.sender = sender
         self.to = to
         self.value = value
         self.gas = gas
-        self.data = CallData(list(map(utils.safe_ord, data))) if isinstance(
-            data, (str, bytes)) else data
+        self.data = (
+            CallData(list(map(utils.safe_ord, data)))
+            if isinstance(data, (str, bytes))
+            else data
+        )
         self.depth = depth
         self.logs = []
         self.code_address = to if code_address is None else code_address
@@ -88,15 +103,16 @@ class Message(object):
         self.is_cross_shard = is_cross_shard
         self.from_full_shard_id = from_full_shard_id
         self.to_full_shard_id = to_full_shard_id
-        self.tx_hash = tx_hash  # quarkchain.core.Transaction hash (NOT the evm Transaction hash)
+        self.tx_hash = (
+            tx_hash
+        )  # quarkchain.core.Transaction hash (NOT the evm Transaction hash)
 
     def __repr__(self):
-        return '<Message(to:%s...)>' % self.to[:8]
+        return "<Message(to:%s...)>" % self.to[:8]
 
 
 # Virtual machine state of the current EVM instance
-class Compustate():
-
+class Compustate:
     def __init__(self, **kwargs):
         self.memory = bytearray()
         self.stack = []
@@ -128,14 +144,13 @@ def preprocess_code(code):
     o = 0
     i = 0
     pushcache = {}
-    code = code + b'\x00' * 32
+    code = code + b"\x00" * 32
     while i < len(code) - 32:
         codebyte = safe_ord(code[i])
         if codebyte == 0x5b:
             o |= 1 << i
         if 0x60 <= codebyte <= 0x7f:
-            pushcache[i] = utils.big_endian_to_int(
-                code[i + 1: i + codebyte - 0x5e])
+            pushcache[i] = utils.big_endian_to_int(code[i + 1 : i + codebyte - 0x5e])
             i += codebyte - 0x5e
         else:
             i += 1
@@ -146,11 +161,13 @@ def preprocess_code(code):
 def mem_extend(mem, compustate, op, start, sz):
     if sz and start + sz > len(mem):
         oldsize = len(mem) // 32
-        old_totalfee = oldsize * opcodes.GMEMORY + \
-            oldsize ** 2 // opcodes.GQUADRATICMEMDENOM
+        old_totalfee = (
+            oldsize * opcodes.GMEMORY + oldsize ** 2 // opcodes.GQUADRATICMEMDENOM
+        )
         newsize = utils.ceil32(start + sz) // 32
-        new_totalfee = newsize * opcodes.GMEMORY + \
-            newsize**2 // opcodes.GQUADRATICMEMDENOM
+        new_totalfee = (
+            newsize * opcodes.GMEMORY + newsize ** 2 // opcodes.GQUADRATICMEMDENOM
+        )
         memfee = new_totalfee - old_totalfee
         if compustate.gas < memfee:
             compustate.gas = 0
@@ -183,19 +200,19 @@ def all_but_1n(x, n):
 
 # Throws a VM exception
 def vm_exception(error, **kargs):
-    log_vm_exit.trace('EXCEPTION', cause=error, **kargs)
+    log_vm_exit.trace("EXCEPTION", cause=error, **kargs)
     return 0, 0, []
 
 
 # Peacefully exits the VM
 def peaceful_exit(cause, gas, data, **kargs):
-    log_vm_exit.trace('EXIT', cause=cause, **kargs)
+    log_vm_exit.trace("EXIT", cause=cause, **kargs)
     return 1, gas, data
 
 
 # Exits with the REVERT opcode
 def revert(gas, data, **kargs):
-    log_vm_exit.trace('REVERT', **kargs)
+    log_vm_exit.trace("REVERT", **kargs)
     return 0, gas, data
 
 
@@ -210,32 +227,43 @@ def vm_trace(ext, msg, compustate, opcode, pushcache, tracer=log_vm_op):
     op, in_args, out_args, fee = opcodes.opcodes[opcode]
 
     trace_data = {}
-    trace_data['stack'] = list(map(to_string, list(compustate.prev_stack)))
-    if compustate.prev_prev_op in ('MLOAD', 'MSTORE', 'MSTORE8', 'SHA3', 'CALL',
-                                   'CALLCODE', 'CREATE', 'CALLDATACOPY', 'CODECOPY', 'EXTCODECOPY'):
+    trace_data["stack"] = list(map(to_string, list(compustate.prev_stack)))
+    if compustate.prev_prev_op in (
+        "MLOAD",
+        "MSTORE",
+        "MSTORE8",
+        "SHA3",
+        "CALL",
+        "CALLCODE",
+        "CREATE",
+        "CALLDATACOPY",
+        "CODECOPY",
+        "EXTCODECOPY",
+    ):
         if len(compustate.prev_memory) < 4096:
-            trace_data['memory'] = \
-                ''.join([encode_hex(ascii_chr(x)) for x in compustate.prev_memory])
+            trace_data["memory"] = "".join(
+                [encode_hex(ascii_chr(x)) for x in compustate.prev_memory]
+            )
         else:
-            trace_data['sha3memory'] = \
-                encode_hex(utils.sha3(b''.join([ascii_chr(x) for
-                                      x in compustate.prev_memory])))
-    if compustate.prev_prev_op in ('SSTORE',) or compustate.steps == 0:
-        trace_data['storage'] = ext.log_storage(msg.to)
-    trace_data['gas'] = to_string(compustate.prev_gas)
-    trace_data['gas_cost'] = to_string(compustate.prev_gas - compustate.gas)
-    trace_data['fee'] = fee
-    trace_data['inst'] = opcode
-    trace_data['pc'] = to_string(compustate.prev_pc)
+            trace_data["sha3memory"] = encode_hex(
+                utils.sha3(b"".join([ascii_chr(x) for x in compustate.prev_memory]))
+            )
+    if compustate.prev_prev_op in ("SSTORE",) or compustate.steps == 0:
+        trace_data["storage"] = ext.log_storage(msg.to)
+    trace_data["gas"] = to_string(compustate.prev_gas)
+    trace_data["gas_cost"] = to_string(compustate.prev_gas - compustate.gas)
+    trace_data["fee"] = fee
+    trace_data["inst"] = opcode
+    trace_data["pc"] = to_string(compustate.prev_pc)
     if compustate.steps == 0:
-        trace_data['depth'] = msg.depth
-        trace_data['address'] = msg.to
-    trace_data['steps'] = compustate.steps
-    trace_data['depth'] = msg.depth
-    if op[:4] == 'PUSH':
+        trace_data["depth"] = msg.depth
+        trace_data["address"] = msg.to
+    trace_data["steps"] = compustate.steps
+    trace_data["depth"] = msg.depth
+    if op[:4] == "PUSH":
         print(repr(pushcache))
-        trace_data['pushvalue'] = pushcache[compustate.prev_pc]
-    tracer.trace('vm', op=op, **trace_data)
+        trace_data["pushvalue"] = pushcache[compustate.prev_pc]
+    tracer.trace("vm", op=op, **trace_data)
     compustate.steps += 1
     compustate.prev_prev_op = op
 
@@ -244,7 +272,7 @@ def vm_trace(ext, msg, compustate, opcode, pushcache, tracer=log_vm_op):
 def vm_execute(ext, msg, code):
     # precompute trace flag
     # if we trace vm, we're in slow mode anyway
-    trace_vm = log_vm_op.is_active('trace')
+    trace_vm = log_vm_op.is_active("trace")
 
     # Initialize stack, memory, program counter, etc
     compustate = Compustate(gas=msg.gas)
@@ -265,10 +293,10 @@ def vm_execute(ext, msg, code):
 
         # Invalid operation
         if opcode not in opcodes.opcodes:
-            return vm_exception('INVALID OP', opcode=opcode)
+            return vm_exception("INVALID OP", opcode=opcode)
 
         if opcode in opcodes.opcodesMetropolis and not ext.post_metropolis_hardfork():
-            return vm_exception('INVALID OP (not yet enabled)', opcode=opcode)
+            return vm_exception("INVALID OP (not yet enabled)", opcode=opcode)
 
         op, in_args, out_args, fee = opcodes.opcodes[opcode]
 
@@ -287,49 +315,63 @@ def vm_execute(ext, msg, code):
             like 'eth.vm.op.stack'
             """
             trace_data = {}
-            trace_data['stack'] = list(map(to_string, list(compustate.stack)))
-            if _prevop in ('MLOAD', 'MSTORE', 'MSTORE8', 'SHA3', 'CALL',
-                           'CALLCODE', 'CREATE', 'CALLDATACOPY', 'CODECOPY',
-                           'EXTCODECOPY'):
+            trace_data["stack"] = list(map(to_string, list(compustate.stack)))
+            if _prevop in (
+                "MLOAD",
+                "MSTORE",
+                "MSTORE8",
+                "SHA3",
+                "CALL",
+                "CALLCODE",
+                "CREATE",
+                "CALLDATACOPY",
+                "CODECOPY",
+                "EXTCODECOPY",
+            ):
                 if len(compustate.memory) < 4096:
-                    trace_data['memory'] = \
-                        ''.join([encode_hex(ascii_chr(x)) for x
-                                 in compustate.memory])
+                    trace_data["memory"] = "".join(
+                        [encode_hex(ascii_chr(x)) for x in compustate.memory]
+                    )
                 else:
-                    trace_data['sha3memory'] = \
-                        encode_hex(utils.sha3(b''.join([ascii_chr(x) for
-                                                        x in compustate.memory])))
-            if _prevop in ('SSTORE',) or steps == 0:
-                trace_data['storage'] = ext.log_storage(msg.to)
-            trace_data['gas'] = to_string(compustate.gas + fee)
-            trace_data['inst'] = opcode
-            trace_data['pc'] = to_string(compustate.pc - 1)
+                    trace_data["sha3memory"] = encode_hex(
+                        utils.sha3(b"".join([ascii_chr(x) for x in compustate.memory]))
+                    )
+            if _prevop in ("SSTORE",) or steps == 0:
+                trace_data["storage"] = ext.log_storage(msg.to)
+            trace_data["gas"] = to_string(compustate.gas + fee)
+            trace_data["inst"] = opcode
+            trace_data["pc"] = to_string(compustate.pc - 1)
             if steps == 0:
-                trace_data['depth'] = msg.depth
-                trace_data['address'] = msg.to
-            trace_data['steps'] = steps
-            trace_data['depth'] = msg.depth
-            if op[:4] == 'PUSH':
-                trace_data['pushvalue'] = pushcache[compustate.pc - 1]
-            log_vm_op.trace('vm', op=op, **trace_data)
+                trace_data["depth"] = msg.depth
+                trace_data["address"] = msg.to
+            trace_data["steps"] = steps
+            trace_data["depth"] = msg.depth
+            if op[:4] == "PUSH":
+                trace_data["pushvalue"] = pushcache[compustate.pc - 1]
+            log_vm_op.trace("vm", op=op, **trace_data)
             steps += 1
             _prevop = op
 
         # out of gas error
         if compustate.gas < 0:
-            return vm_exception('OUT OF GAS')
+            return vm_exception("OUT OF GAS")
 
         # empty stack error
         if in_args > len(compustate.stack):
-            return vm_exception('INSUFFICIENT STACK',
-                                op=op, needed=to_string(in_args),
-                                available=to_string(len(compustate.stack)))
+            return vm_exception(
+                "INSUFFICIENT STACK",
+                op=op,
+                needed=to_string(in_args),
+                available=to_string(len(compustate.stack)),
+            )
 
         # overfull stack error
         if len(compustate.stack) - in_args + out_args > 1024:
-            return vm_exception('STACK SIZE LIMIT EXCEEDED',
-                                op=op,
-                                pre_height=to_string(len(compustate.stack)))
+            return vm_exception(
+                "STACK SIZE LIMIT EXCEEDED",
+                op=op,
+                pre_height=to_string(len(compustate.stack)),
+            )
 
         # Valid operations
         # Pushes first because they are very frequent
@@ -339,35 +381,41 @@ def vm_execute(ext, msg, code):
             compustate.pc += opcode - 0x5f
         # Arithmetic
         elif opcode < 0x10:
-            if op == 'STOP':
-                return peaceful_exit('STOP', compustate.gas, [])
-            elif op == 'ADD':
+            if op == "STOP":
+                return peaceful_exit("STOP", compustate.gas, [])
+            elif op == "ADD":
                 stk.append((stk.pop() + stk.pop()) & TT256M1)
-            elif op == 'SUB':
+            elif op == "SUB":
                 stk.append((stk.pop() - stk.pop()) & TT256M1)
-            elif op == 'MUL':
+            elif op == "MUL":
                 stk.append((stk.pop() * stk.pop()) & TT256M1)
-            elif op == 'DIV':
+            elif op == "DIV":
                 s0, s1 = stk.pop(), stk.pop()
                 stk.append(0 if s1 == 0 else s0 // s1)
-            elif op == 'MOD':
+            elif op == "MOD":
                 s0, s1 = stk.pop(), stk.pop()
                 stk.append(0 if s1 == 0 else s0 % s1)
-            elif op == 'SDIV':
+            elif op == "SDIV":
                 s0, s1 = utils.to_signed(stk.pop()), utils.to_signed(stk.pop())
-                stk.append(0 if s1 == 0 else (abs(s0) // abs(s1) *
-                                              (-1 if s0 * s1 < 0 else 1)) & TT256M1)
-            elif op == 'SMOD':
+                stk.append(
+                    0
+                    if s1 == 0
+                    else (abs(s0) // abs(s1) * (-1 if s0 * s1 < 0 else 1)) & TT256M1
+                )
+            elif op == "SMOD":
                 s0, s1 = utils.to_signed(stk.pop()), utils.to_signed(stk.pop())
-                stk.append(0 if s1 == 0 else (abs(s0) % abs(s1) *
-                                              (-1 if s0 < 0 else 1)) & TT256M1)
-            elif op == 'ADDMOD':
+                stk.append(
+                    0
+                    if s1 == 0
+                    else (abs(s0) % abs(s1) * (-1 if s0 < 0 else 1)) & TT256M1
+                )
+            elif op == "ADDMOD":
                 s0, s1, s2 = stk.pop(), stk.pop(), stk.pop()
                 stk.append((s0 + s1) % s2 if s2 else 0)
-            elif op == 'MULMOD':
+            elif op == "MULMOD":
                 s0, s1, s2 = stk.pop(), stk.pop(), stk.pop()
                 stk.append((s0 * s1) % s2 if s2 else 0)
-            elif op == 'EXP':
+            elif op == "EXP":
                 base, exponent = stk.pop(), stk.pop()
                 # fee for exponent is dependent on its bytes
                 # calc n bytes to represent exponent
@@ -377,10 +425,10 @@ def vm_execute(ext, msg, code):
                     expfee += opcodes.EXP_SUPPLEMENTAL_GAS * nbytes
                 if compustate.gas < expfee:
                     compustate.gas = 0
-                    return vm_exception('OOG EXPONENT')
+                    return vm_exception("OOG EXPONENT")
                 compustate.gas -= expfee
                 stk.append(pow(base, exponent, TT256))
-            elif op == 'SIGNEXTEND':
+            elif op == "SIGNEXTEND":
                 s0, s1 = stk.pop(), stk.pop()
                 if s0 <= 31:
                     testbit = s0 * 8 + 7
@@ -392,29 +440,29 @@ def vm_execute(ext, msg, code):
                     stk.append(s1)
         # Comparisons
         elif opcode < 0x20:
-            if op == 'LT':
+            if op == "LT":
                 stk.append(1 if stk.pop() < stk.pop() else 0)
-            elif op == 'GT':
+            elif op == "GT":
                 stk.append(1 if stk.pop() > stk.pop() else 0)
-            elif op == 'SLT':
+            elif op == "SLT":
                 s0, s1 = utils.to_signed(stk.pop()), utils.to_signed(stk.pop())
                 stk.append(1 if s0 < s1 else 0)
-            elif op == 'SGT':
+            elif op == "SGT":
                 s0, s1 = utils.to_signed(stk.pop()), utils.to_signed(stk.pop())
                 stk.append(1 if s0 > s1 else 0)
-            elif op == 'EQ':
+            elif op == "EQ":
                 stk.append(1 if stk.pop() == stk.pop() else 0)
-            elif op == 'ISZERO':
+            elif op == "ISZERO":
                 stk.append(0 if stk.pop() else 1)
-            elif op == 'AND':
+            elif op == "AND":
                 stk.append(stk.pop() & stk.pop())
-            elif op == 'OR':
+            elif op == "OR":
                 stk.append(stk.pop() | stk.pop())
-            elif op == 'XOR':
+            elif op == "XOR":
                 stk.append(stk.pop() ^ stk.pop())
-            elif op == 'NOT':
+            elif op == "NOT":
                 stk.append(TT256M1 - stk.pop())
-            elif op == 'BYTE':
+            elif op == "BYTE":
                 s0, s1 = stk.pop(), stk.pop()
                 if s0 >= 32:
                     stk.append(0)
@@ -422,87 +470,86 @@ def vm_execute(ext, msg, code):
                     stk.append((s1 // 256 ** (31 - s0)) % 256)
         # SHA3 and environment info
         elif opcode < 0x40:
-            if op == 'SHA3':
+            if op == "SHA3":
                 s0, s1 = stk.pop(), stk.pop()
                 compustate.gas -= opcodes.GSHA3WORD * (utils.ceil32(s1) // 32)
                 if compustate.gas < 0:
-                    return vm_exception('OOG PAYING FOR SHA3')
+                    return vm_exception("OOG PAYING FOR SHA3")
                 if not mem_extend(mem, compustate, op, s0, s1):
-                    return vm_exception('OOG EXTENDING MEMORY')
-                data = bytearray_to_bytestr(mem[s0: s0 + s1])
+                    return vm_exception("OOG EXTENDING MEMORY")
+                data = bytearray_to_bytestr(mem[s0 : s0 + s1])
                 stk.append(utils.big_endian_to_int(utils.sha3(data)))
-            elif op == 'ADDRESS':
+            elif op == "ADDRESS":
                 stk.append(utils.coerce_to_int(msg.to))
-            elif op == 'BALANCE':
+            elif op == "BALANCE":
                 if ext.post_anti_dos_hardfork():
-                    if not eat_gas(compustate,
-                                   opcodes.BALANCE_SUPPLEMENTAL_GAS):
+                    if not eat_gas(compustate, opcodes.BALANCE_SUPPLEMENTAL_GAS):
                         return vm_exception("OUT OF GAS")
-                addr = utils.coerce_addr_to_hex(stk.pop() % 2**160)
+                addr = utils.coerce_addr_to_hex(stk.pop() % 2 ** 160)
                 stk.append(ext.get_balance(addr))
-            elif op == 'ORIGIN':
+            elif op == "ORIGIN":
                 stk.append(utils.coerce_to_int(ext.tx_origin))
-            elif op == 'CALLER':
+            elif op == "CALLER":
                 stk.append(utils.coerce_to_int(msg.sender))
-            elif op == 'CALLVALUE':
+            elif op == "CALLVALUE":
                 stk.append(msg.value)
-            elif op == 'CALLDATALOAD':
+            elif op == "CALLDATALOAD":
                 stk.append(msg.data.extract32(stk.pop()))
-            elif op == 'CALLDATASIZE':
+            elif op == "CALLDATASIZE":
                 stk.append(msg.data.size)
-            elif op == 'CALLDATACOPY':
+            elif op == "CALLDATACOPY":
                 mstart, dstart, size = stk.pop(), stk.pop(), stk.pop()
                 if not mem_extend(mem, compustate, op, mstart, size):
-                    return vm_exception('OOG EXTENDING MEMORY')
+                    return vm_exception("OOG EXTENDING MEMORY")
                 if not data_copy(compustate, size):
-                    return vm_exception('OOG COPY DATA')
+                    return vm_exception("OOG COPY DATA")
                 msg.data.extract_copy(mem, mstart, dstart, size)
-            elif op == 'CODESIZE':
+            elif op == "CODESIZE":
                 stk.append(codelen)
-            elif op == 'CODECOPY':
+            elif op == "CODECOPY":
                 mstart, dstart, size = stk.pop(), stk.pop(), stk.pop()
                 if not mem_extend(mem, compustate, op, mstart, size):
-                    return vm_exception('OOG EXTENDING MEMORY')
+                    return vm_exception("OOG EXTENDING MEMORY")
                 if not data_copy(compustate, size):
-                    return vm_exception('OOG COPY DATA')
+                    return vm_exception("OOG COPY DATA")
                 for i in range(size):
                     if dstart + i < codelen:
                         mem[mstart + i] = safe_ord(code[dstart + i])
                     else:
                         mem[mstart + i] = 0
-            elif op == 'RETURNDATACOPY':
+            elif op == "RETURNDATACOPY":
                 mstart, dstart, size = stk.pop(), stk.pop(), stk.pop()
                 if not mem_extend(mem, compustate, op, mstart, size):
-                    return vm_exception('OOG EXTENDING MEMORY')
+                    return vm_exception("OOG EXTENDING MEMORY")
                 if not data_copy(compustate, size):
-                    return vm_exception('OOG COPY DATA')
+                    return vm_exception("OOG COPY DATA")
                 if dstart + size > len(compustate.last_returned):
-                    return vm_exception('RETURNDATACOPY out of range')
-                mem[mstart: mstart + size] = compustate.last_returned[dstart: dstart + size]
-            elif op == 'RETURNDATASIZE':
+                    return vm_exception("RETURNDATACOPY out of range")
+                mem[mstart : mstart + size] = compustate.last_returned[
+                    dstart : dstart + size
+                ]
+            elif op == "RETURNDATASIZE":
                 stk.append(len(compustate.last_returned))
-            elif op == 'GASPRICE':
+            elif op == "GASPRICE":
                 stk.append(ext.tx_gasprice)
-            elif op == 'EXTCODESIZE':
+            elif op == "EXTCODESIZE":
                 if ext.post_anti_dos_hardfork():
-                    if not eat_gas(compustate,
-                                   opcodes.EXTCODELOAD_SUPPLEMENTAL_GAS):
+                    if not eat_gas(compustate, opcodes.EXTCODELOAD_SUPPLEMENTAL_GAS):
                         return vm_exception("OUT OF GAS")
-                addr = utils.coerce_addr_to_hex(stk.pop() % 2**160)
-                stk.append(len(ext.get_code(addr) or b''))
-            elif op == 'EXTCODECOPY':
+                addr = utils.coerce_addr_to_hex(stk.pop() % 2 ** 160)
+                stk.append(len(ext.get_code(addr) or b""))
+            elif op == "EXTCODECOPY":
                 if ext.post_anti_dos_hardfork():
-                    if not eat_gas(compustate,
-                                   opcodes.EXTCODELOAD_SUPPLEMENTAL_GAS):
+                    if not eat_gas(compustate, opcodes.EXTCODELOAD_SUPPLEMENTAL_GAS):
                         return vm_exception("OUT OF GAS")
-                addr = utils.coerce_addr_to_hex(stk.pop() % 2**160)
+                addr = utils.coerce_addr_to_hex(stk.pop() % 2 ** 160)
                 start, s2, size = stk.pop(), stk.pop(), stk.pop()
-                extcode = ext.get_code(addr) or b''
+                extcode = ext.get_code(addr) or b""
                 assert utils.is_string(extcode)
                 if not mem_extend(mem, compustate, op, start, size):
-                    return vm_exception('OOG EXTENDING MEMORY')
+                    return vm_exception("OOG EXTENDING MEMORY")
                 if not data_copy(compustate, size):
-                    return vm_exception('OOG COPY DATA')
+                    return vm_exception("OOG COPY DATA")
                 for i in range(size):
                     if s2 + i < len(extcode):
                         mem[start + i] = safe_ord(extcode[s2 + i])
@@ -510,54 +557,50 @@ def vm_execute(ext, msg, code):
                         mem[start + i] = 0
         # Block info
         elif opcode < 0x50:
-            if op == 'BLOCKHASH':
+            if op == "BLOCKHASH":
                 if ext.post_constantinople_hardfork() and False:
                     bh_addr = ext.blockhash_store
                     stk.append(ext.get_storage_data(bh_addr, stk.pop()))
                 else:
-                    stk.append(
-                        utils.big_endian_to_int(
-                            ext.block_hash(
-                                stk.pop())))
-            elif op == 'COINBASE':
+                    stk.append(utils.big_endian_to_int(ext.block_hash(stk.pop())))
+            elif op == "COINBASE":
                 stk.append(utils.big_endian_to_int(ext.block_coinbase))
-            elif op == 'TIMESTAMP':
+            elif op == "TIMESTAMP":
                 stk.append(ext.block_timestamp)
-            elif op == 'NUMBER':
+            elif op == "NUMBER":
                 stk.append(ext.block_number)
-            elif op == 'DIFFICULTY':
+            elif op == "DIFFICULTY":
                 stk.append(ext.block_difficulty)
-            elif op == 'GASLIMIT':
+            elif op == "GASLIMIT":
                 stk.append(ext.block_gas_limit)
         # VM state manipulations
         elif opcode < 0x60:
-            if op == 'POP':
+            if op == "POP":
                 stk.pop()
-            elif op == 'MLOAD':
+            elif op == "MLOAD":
                 s0 = stk.pop()
                 if not mem_extend(mem, compustate, op, s0, 32):
-                    return vm_exception('OOG EXTENDING MEMORY')
-                stk.append(utils.bytes_to_int(mem[s0: s0 + 32]))
-            elif op == 'MSTORE':
+                    return vm_exception("OOG EXTENDING MEMORY")
+                stk.append(utils.bytes_to_int(mem[s0 : s0 + 32]))
+            elif op == "MSTORE":
                 s0, s1 = stk.pop(), stk.pop()
                 if not mem_extend(mem, compustate, op, s0, 32):
-                    return vm_exception('OOG EXTENDING MEMORY')
-                mem[s0: s0 + 32] = utils.encode_int32(s1)
-            elif op == 'MSTORE8':
+                    return vm_exception("OOG EXTENDING MEMORY")
+                mem[s0 : s0 + 32] = utils.encode_int32(s1)
+            elif op == "MSTORE8":
                 s0, s1 = stk.pop(), stk.pop()
                 if not mem_extend(mem, compustate, op, s0, 1):
-                    return vm_exception('OOG EXTENDING MEMORY')
+                    return vm_exception("OOG EXTENDING MEMORY")
                 mem[s0] = s1 % 256
-            elif op == 'SLOAD':
+            elif op == "SLOAD":
                 if ext.post_anti_dos_hardfork():
                     if not eat_gas(compustate, opcodes.SLOAD_SUPPLEMENTAL_GAS):
                         return vm_exception("OUT OF GAS")
                 stk.append(ext.get_storage_data(msg.to, stk.pop()))
-            elif op == 'SSTORE':
+            elif op == "SSTORE":
                 s0, s1 = stk.pop(), stk.pop()
                 if msg.static:
-                    return vm_exception(
-                        'Cannot SSTORE inside a static context')
+                    return vm_exception("Cannot SSTORE inside a static context")
                 if ext.get_storage_data(msg.to, s0):
                     gascost = opcodes.GSTORAGEMOD if s1 else opcodes.GSTORAGEKILL
                     refund = 0 if s1 else opcodes.GSTORAGEREFUND
@@ -565,41 +608,43 @@ def vm_execute(ext, msg, code):
                     gascost = opcodes.GSTORAGEADD if s1 else opcodes.GSTORAGEMOD
                     refund = 0
                 if compustate.gas < gascost:
-                    return vm_exception('OUT OF GAS')
+                    return vm_exception("OUT OF GAS")
                 compustate.gas -= gascost
                 # adds neg gascost as a refund if below zero
                 ext.add_refund(refund)
                 ext.set_storage_data(msg.to, s0, s1)
-            elif op == 'JUMP':
+            elif op == "JUMP":
                 compustate.pc = stk.pop()
                 if compustate.pc >= codelen or not (
-                        (1 << compustate.pc) & jumpdest_mask):
-                    return vm_exception('BAD JUMPDEST')
-            elif op == 'JUMPI':
+                    (1 << compustate.pc) & jumpdest_mask
+                ):
+                    return vm_exception("BAD JUMPDEST")
+            elif op == "JUMPI":
                 s0, s1 = stk.pop(), stk.pop()
                 if s1:
                     compustate.pc = s0
                     if compustate.pc >= codelen or not (
-                            (1 << compustate.pc) & jumpdest_mask):
-                        return vm_exception('BAD JUMPDEST')
-            elif op == 'PC':
+                        (1 << compustate.pc) & jumpdest_mask
+                    ):
+                        return vm_exception("BAD JUMPDEST")
+            elif op == "PC":
                 stk.append(compustate.pc - 1)
-            elif op == 'MSIZE':
+            elif op == "MSIZE":
                 stk.append(len(mem))
-            elif op == 'GAS':
+            elif op == "GAS":
                 stk.append(compustate.gas)  # AFTER subtracting cost 1
         # DUPn (eg. DUP1: a b c -> a b c c, DUP3: a b c -> a b c a)
-        elif op[:3] == 'DUP':
+        elif op[:3] == "DUP":
             # 0x7f - opcode is a negative number, -1 for 0x80 ... -16 for 0x8f
             stk.append(stk[0x7f - opcode])
         # SWAPn (eg. SWAP1: a b c d -> a b d c, SWAP3: a b c d -> d b c a)
-        elif op[:4] == 'SWAP':
+        elif op[:4] == "SWAP":
             # 0x8e - opcode is a negative number, -2 for 0x90 ... -17 for 0x9f
             temp = stk[0x8e - opcode]
             stk[0x8e - opcode] = stk[-1]
             stk[-1] = temp
         # Logs (aka "events")
-        elif op[:3] == 'LOG':
+        elif op[:3] == "LOG":
             """
             0xa0 ... 0xa4, 32/64/96/128/160 + len(data) gas
             a. Opcodes LOG0...LOG4 are added, takes 2-6 stack arguments
@@ -617,62 +662,90 @@ def vm_execute(ext, msg, code):
             topics = [stk.pop() for x in range(depth)]
             compustate.gas -= msz * opcodes.GLOGBYTE
             if msg.static:
-                return vm_exception('Cannot LOG inside a static context')
+                return vm_exception("Cannot LOG inside a static context")
             if not mem_extend(mem, compustate, op, mstart, msz):
-                return vm_exception('OOG EXTENDING MEMORY')
-            data = bytearray_to_bytestr(mem[mstart: mstart + msz])
+                return vm_exception("OOG EXTENDING MEMORY")
+            data = bytearray_to_bytestr(mem[mstart : mstart + msz])
             ext.log(msg.to, topics, data)
-            log_log.trace('LOG', to=msg.to, topics=topics,
-                          data=list(map(utils.safe_ord, data)))
+            log_log.trace(
+                "LOG", to=msg.to, topics=topics, data=list(map(utils.safe_ord, data))
+            )
             # print('LOG', msg.to, topics, list(map(ord, data)))
         # Create a new contract
-        elif op == 'CREATE':
+        elif op == "CREATE":
             value, mstart, msz = stk.pop(), stk.pop(), stk.pop()
             if not mem_extend(mem, compustate, op, mstart, msz):
-                return vm_exception('OOG EXTENDING MEMORY')
+                return vm_exception("OOG EXTENDING MEMORY")
             if msg.static:
-                return vm_exception('Cannot CREATE inside a static context')
+                return vm_exception("Cannot CREATE inside a static context")
             if ext.get_balance(msg.to) >= value and msg.depth < MAX_DEPTH:
                 cd = CallData(mem, mstart, msz)
                 ingas = compustate.gas
                 if ext.post_anti_dos_hardfork():
                     ingas = all_but_1n(ingas, opcodes.CALL_CHILD_LIMIT_DENOM)
-                create_msg = Message(msg.to, b'', value, ingas, cd, msg.depth + 1)
+                create_msg = Message(
+                    msg.to,
+                    b"",
+                    value,
+                    ingas,
+                    cd,
+                    msg.depth + 1,
+                    from_full_shard_id=msg.from_full_shard_id,
+                    to_full_shard_id=msg.to_full_shard_id,
+                )
                 o, gas, data = ext.create(create_msg)
                 if o:
                     stk.append(utils.coerce_to_int(data))
-                    compustate.last_returned = bytearray(b'')
+                    compustate.last_returned = bytearray(b"")
                 else:
                     stk.append(0)
                     compustate.last_returned = bytearray(data)
                 compustate.gas = compustate.gas - ingas + gas
             else:
                 stk.append(0)
-                compustate.last_returned = bytearray(b'')
+                compustate.last_returned = bytearray(b"")
         # Calls
-        elif op in ('CALL', 'CALLCODE', 'DELEGATECALL', 'STATICCALL'):
+        elif op in ("CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"):
             # Pull arguments from the stack
-            if op in ('CALL', 'CALLCODE'):
-                gas, to, value, meminstart, meminsz, memoutstart, memoutsz = \
-                    stk.pop(), stk.pop(), stk.pop(), stk.pop(), stk.pop(), stk.pop(), stk.pop()
+            if op in ("CALL", "CALLCODE"):
+                gas, to, value, meminstart, meminsz, memoutstart, memoutsz = (
+                    stk.pop(),
+                    stk.pop(),
+                    stk.pop(),
+                    stk.pop(),
+                    stk.pop(),
+                    stk.pop(),
+                    stk.pop(),
+                )
             else:
-                gas, to, meminstart, meminsz, memoutstart, memoutsz = \
-                    stk.pop(), stk.pop(), stk.pop(), stk.pop(), stk.pop(), stk.pop()
+                gas, to, meminstart, meminsz, memoutstart, memoutsz = (
+                    stk.pop(),
+                    stk.pop(),
+                    stk.pop(),
+                    stk.pop(),
+                    stk.pop(),
+                    stk.pop(),
+                )
                 value = 0
             # Static context prohibition
-            if msg.static and value > 0 and op == 'CALL':
+            if msg.static and value > 0 and op == "CALL":
                 return vm_exception(
-                    'Cannot make a non-zero-value call inside a static context')
+                    "Cannot make a non-zero-value call inside a static context"
+                )
             # Expand memory
-            if not mem_extend(mem, compustate, op, meminstart, meminsz) or \
-                    not mem_extend(mem, compustate, op, memoutstart, memoutsz):
-                return vm_exception('OOG EXTENDING MEMORY')
+            if not mem_extend(
+                mem, compustate, op, meminstart, meminsz
+            ) or not mem_extend(mem, compustate, op, memoutstart, memoutsz):
+                return vm_exception("OOG EXTENDING MEMORY")
             to = utils.int_to_addr(to)
             # Extra gas costs based on various factors
             extra_gas = 0
             # Creating a new account
-            if op == 'CALL' and not ext.account_exists(to) and (
-                    value > 0 or not ext.post_spurious_dragon_hardfork()):
+            if (
+                op == "CALL"
+                and not ext.account_exists(to)
+                and (value > 0 or not ext.post_spurious_dragon_hardfork())
+            ):
                 extra_gas += opcodes.GCALLNEWACCOUNT
             # Value transfer
             if value > 0:
@@ -683,42 +756,75 @@ def vm_execute(ext, msg, code):
             # Compute child gas limit
             if ext.post_anti_dos_hardfork():
                 if compustate.gas < extra_gas:
-                    return vm_exception('OUT OF GAS', needed=extra_gas)
+                    return vm_exception("OUT OF GAS", needed=extra_gas)
                 gas = min(
                     gas,
                     all_but_1n(
-                        compustate.gas -
-                        extra_gas,
-                        opcodes.CALL_CHILD_LIMIT_DENOM))
+                        compustate.gas - extra_gas, opcodes.CALL_CHILD_LIMIT_DENOM
+                    ),
+                )
             else:
                 if compustate.gas < gas + extra_gas:
-                    return vm_exception('OUT OF GAS', needed=gas + extra_gas)
+                    return vm_exception("OUT OF GAS", needed=gas + extra_gas)
             submsg_gas = gas + opcodes.GSTIPEND * (value > 0)
             # Verify that there is sufficient balance and depth
             if ext.get_balance(msg.to) < value or msg.depth >= MAX_DEPTH:
-                compustate.gas -= (gas + extra_gas - submsg_gas)
+                compustate.gas -= gas + extra_gas - submsg_gas
                 stk.append(0)
-                compustate.last_returned = bytearray(b'')
+                compustate.last_returned = bytearray(b"")
             else:
                 # Subtract gas from parent
-                compustate.gas -= (gas + extra_gas)
+                compustate.gas -= gas + extra_gas
                 assert compustate.gas >= 0
                 cd = CallData(mem, meminstart, meminsz)
                 # Generate the message
-                if op == 'CALL':
-                    call_msg = Message(msg.to, to, value, submsg_gas, cd,
-                                       msg.depth + 1, code_address=to, static=msg.static)
-                elif ext.post_homestead_hardfork() and op == 'DELEGATECALL':
-                    call_msg = Message(msg.sender, msg.to, msg.value, submsg_gas, cd,
-                                       msg.depth + 1, code_address=to, transfers_value=False, static=msg.static)
-                elif ext.post_metropolis_hardfork() and op == 'STATICCALL':
-                    call_msg = Message(msg.to, to, value, submsg_gas, cd,
-                                       msg.depth + 1, code_address=to, static=True)
-                elif op in ('DELEGATECALL', 'STATICCALL'):
-                    return vm_exception('OPCODE %s INACTIVE' % op)
-                elif op == 'CALLCODE':
-                    call_msg = Message(msg.to, msg.to, value, submsg_gas, cd,
-                                       msg.depth + 1, code_address=to, static=msg.static)
+                if op == "CALL":
+                    call_msg = Message(
+                        msg.to,
+                        to,
+                        value,
+                        submsg_gas,
+                        cd,
+                        msg.depth + 1,
+                        code_address=to,
+                        static=msg.static,
+                    )
+                elif ext.post_homestead_hardfork() and op == "DELEGATECALL":
+                    call_msg = Message(
+                        msg.sender,
+                        msg.to,
+                        msg.value,
+                        submsg_gas,
+                        cd,
+                        msg.depth + 1,
+                        code_address=to,
+                        transfers_value=False,
+                        static=msg.static,
+                    )
+                elif ext.post_metropolis_hardfork() and op == "STATICCALL":
+                    call_msg = Message(
+                        msg.to,
+                        to,
+                        value,
+                        submsg_gas,
+                        cd,
+                        msg.depth + 1,
+                        code_address=to,
+                        static=True,
+                    )
+                elif op in ("DELEGATECALL", "STATICCALL"):
+                    return vm_exception("OPCODE %s INACTIVE" % op)
+                elif op == "CALLCODE":
+                    call_msg = Message(
+                        msg.to,
+                        msg.to,
+                        value,
+                        submsg_gas,
+                        cd,
+                        msg.depth + 1,
+                        code_address=to,
+                        static=msg.static,
+                    )
                 else:
                     raise Exception("Lolwut")
                 # Get result
@@ -733,42 +839,45 @@ def vm_execute(ext, msg, code):
                 compustate.gas += gas
                 compustate.last_returned = bytearray(data)
         # Return opcode
-        elif op == 'RETURN':
+        elif op == "RETURN":
             s0, s1 = stk.pop(), stk.pop()
             if not mem_extend(mem, compustate, op, s0, s1):
-                return vm_exception('OOG EXTENDING MEMORY')
-            return peaceful_exit('RETURN', compustate.gas, mem[s0: s0 + s1])
+                return vm_exception("OOG EXTENDING MEMORY")
+            return peaceful_exit("RETURN", compustate.gas, mem[s0 : s0 + s1])
         # Revert opcode (Metropolis)
-        elif op == 'REVERT':
+        elif op == "REVERT":
             if not ext.post_metropolis_hardfork():
-                return vm_exception('Opcode not yet enabled')
+                return vm_exception("Opcode not yet enabled")
             s0, s1 = stk.pop(), stk.pop()
             if not mem_extend(mem, compustate, op, s0, s1):
-                return vm_exception('OOG EXTENDING MEMORY')
-            return revert(compustate.gas, mem[s0: s0 + s1])
+                return vm_exception("OOG EXTENDING MEMORY")
+            return revert(compustate.gas, mem[s0 : s0 + s1])
         # SUICIDE opcode (also called SELFDESTRUCT)
-        elif op == 'SUICIDE':
+        elif op == "SUICIDE":
             if msg.static:
-                return vm_exception('Cannot SUICIDE inside a static context')
+                return vm_exception("Cannot SUICIDE inside a static context")
             to = utils.encode_int(stk.pop())
-            to = ((b'\x00' * (32 - len(to))) + to)[12:]
+            to = ((b"\x00" * (32 - len(to))) + to)[12:]
             xfer = ext.get_balance(msg.to)
             if ext.post_anti_dos_hardfork():
-                extra_gas = opcodes.SUICIDE_SUPPLEMENTAL_GAS + \
-                    (not ext.account_exists(to)) * (xfer > 0 or not ext.post_spurious_dragon_hardfork()) * \
-                    opcodes.GCALLNEWACCOUNT
+                extra_gas = (
+                    opcodes.SUICIDE_SUPPLEMENTAL_GAS
+                    + (not ext.account_exists(to))
+                    * (xfer > 0 or not ext.post_spurious_dragon_hardfork())
+                    * opcodes.GCALLNEWACCOUNT
+                )
                 if not eat_gas(compustate, extra_gas):
                     return vm_exception("OUT OF GAS")
             ext.set_balance(to, ext.get_balance(to) + xfer)
             ext.set_balance(msg.to, 0)
             ext.add_suicide(msg.to)
             log_msg.debug(
-                'SUICIDING',
-                addr=utils.checksum_encode(
-                    msg.to),
+                "SUICIDING",
+                addr=utils.checksum_encode(msg.to),
                 to=utils.checksum_encode(to),
-                xferring=xfer)
-            return peaceful_exit('SUICIDED', compustate.gas, [])
+                xferring=xfer,
+            )
+            return peaceful_exit("SUICIDED", compustate.gas, [])
 
         if trace_vm:
             vm_trace(ext, msg, compustate, opcode, pushcache)
@@ -776,15 +885,14 @@ def vm_execute(ext, msg, code):
     if trace_vm:
         compustate.reset_prev()
         vm_trace(ext, msg, compustate, 0, None)
-    return peaceful_exit('CODE OUT OF RANGE', compustate.gas, [])
+    return peaceful_exit("CODE OUT OF RANGE", compustate.gas, [])
 
 
 # A stub that's mainly here to show what you would need to implement to
 # hook into the EVM
-class VmExtBase():
-
+class VmExtBase:
     def __init__(self):
-        self.get_code = lambda addr: b''
+        self.get_code = lambda addr: b""
         self.get_balance = lambda addr: 0
         self.set_balance = lambda addr, balance: 0
         self.set_storage_data = lambda addr, key, value: 0
@@ -799,7 +907,7 @@ class VmExtBase():
         self.block_difficulty = 0
         self.block_gas_limit = 0
         self.log = lambda addr, topics, data: 0
-        self.tx_origin = b'0' * 40
+        self.tx_origin = b"0" * 40
         self.tx_gasprice = 0
         self.create = lambda msg: 0, 0, 0
         self.call = lambda msg: 0, 0, 0

--- a/quarkchain/evm/vm.py
+++ b/quarkchain/evm/vm.py
@@ -690,8 +690,7 @@ def vm_execute(ext, msg, code):
                     ingas,
                     cd,
                     msg.depth + 1,
-                    from_full_shard_id=msg.from_full_shard_id,
-                    to_full_shard_id=msg.to_full_shard_id,
+                    to_full_shard_id=msg.from_full_shard_id,
                 )
                 o, gas, data = ext.create(create_msg)
                 if o:


### PR DESCRIPTION
root cause: when contract is created during contract execution,
`to_full_shard_id` is not specified, thus
`mk_contract_address(msg.sender, msg.to_full_shard_id, nonce)` will fail
since rlp can't encode None.

fixes #113 