### PR TITLE
Fix difficulty data type in EcoInfo RPC

### DIFF
--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -847,7 +847,7 @@ class MasterServer:
         for response in responses:
             _, response, _ = response
             if response.error_code != 0:
-                return (None, None)
+                return None, None
             for eco_info in response.eco_info_list:
                 branch_value_to_eco_info[eco_info.branch.value] = eco_info
 

--- a/quarkchain/cluster/rpc.py
+++ b/quarkchain/cluster/rpc.py
@@ -343,7 +343,7 @@ class EcoInfo(Serializable):
         ("branch", Branch),
         ("height", uint64),
         ("coinbase_amount", uint256),
-        ("difficulty", uint64),
+        ("difficulty", biguint),
         ("unconfirmed_headers_coinbase_amount", uint256),
     ]
 


### PR DESCRIPTION
theoretically non-breaking, but could cause incompatibility problems during deploying if some hosts use the old data types and some use new