### PR TITLE
add discovery and test from py-evm

### DIFF
--- a/quarkchain/p2p/discovery.py
+++ b/quarkchain/p2p/discovery.py
@@ -1,0 +1,1303 @@
+"""
+The Node Discovery protocol provides a way to find RLPx nodes that can be connected to. It uses a
+Kademlia-like protocol to maintain a distributed database of the IDs and endpoints of all
+listening nodes.
+
+More information at https://github.com/ethereum/devp2p/blob/master/rlpx.md#node-discovery
+"""
+import asyncio
+import collections
+import contextlib
+import logging
+import random
+import socket
+import time
+from typing import (
+    Any,
+    Callable,
+    cast,
+    Dict,
+    Hashable,
+    Iterable,
+    Iterator,
+    List,
+    Sequence,
+    Set,
+    Text,
+    Tuple,
+    Type,
+    TYPE_CHECKING,
+    Union,
+)
+
+import cytoolz
+
+import rlp
+
+from eth_typing import Hash32
+
+from eth_utils import (
+    encode_hex,
+    remove_0x_prefix,
+    text_if_str,
+    to_bytes,
+    to_list,
+    to_tuple,
+    int_to_big_endian,
+    big_endian_to_int,
+)
+
+from eth_keys import keys
+from eth_keys import datatypes
+
+from eth_hash.auto import keccak
+
+from eth.tools.logging import TraceLogger, TRACE_LEVEL_NUM
+
+from cancel_token import CancelToken, OperationCancelled
+
+from p2p.exceptions import AlreadyWaitingDiscoveryResponse, NoEligibleNodes, UnableToGetDiscV5Ticket
+from p2p import kademlia
+from p2p import protocol
+from p2p.peer import BasePeerPool
+from p2p.service import BaseService
+
+if TYPE_CHECKING:
+    # Promoted workaround for inheriting from generic stdlib class
+    # https://github.com/python/mypy/issues/5264#issuecomment-399407428
+    UserDict = collections.UserDict[Hashable, 'CallbackLock']
+else:
+    UserDict = collections.UserDict
+
+# V4 handler methods take a Node, payload and msg_hash as arguments.
+V4_HANDLER_TYPE = Callable[[kademlia.Node, Tuple[Any, ...], Hash32], None]
+# V5 handler methods take a Node, payload, msg_hash and msg as arguments.
+V5_HANDLER_TYPE = Callable[[kademlia.Node, Tuple[Any, ...], Hash32, bytes], None]
+
+MAX_ENTRIES_PER_TOPIC = 50
+# UDP packet constants.
+V5_ID_STRING = b"temporary discovery v5"
+MAC_SIZE = 256 // 8  # 32
+SIG_SIZE = 520 // 8  # 65
+HEAD_SIZE = MAC_SIZE + SIG_SIZE  # 97
+HEAD_SIZE_V5 = len(V5_ID_STRING) + SIG_SIZE  # 87
+EXPIRATION = 60  # let messages expire after N secondes
+PROTO_VERSION = 4
+PROTO_VERSION_V5 = 5
+
+
+class DefectiveMessage(Exception):
+    pass
+
+
+class WrongMAC(DefectiveMessage):
+    pass
+
+
+class DiscoveryCommand:
+    def __init__(self, name: str, id: int, elem_count: int) -> None:
+        self.name = name
+        self.id = id
+        # Number of required top-level list elements for this cmd.
+        # Elements beyond this length must be trimmed.
+        self.elem_count = elem_count
+
+    def __repr__(self) -> str:
+        return 'Command(%s:%d)' % (self.name, self.id)
+
+
+CMD_PING = DiscoveryCommand("ping", 1, 4)
+CMD_PONG = DiscoveryCommand("pong", 2, 3)
+CMD_FIND_NODE = DiscoveryCommand("find_node", 3, 2)
+CMD_NEIGHBOURS = DiscoveryCommand("neighbours", 4, 2)
+CMD_ID_MAP = dict((cmd.id, cmd) for cmd in [CMD_PING, CMD_PONG, CMD_FIND_NODE, CMD_NEIGHBOURS])
+
+CMD_PING_V5 = DiscoveryCommand("ping", 1, 5)
+CMD_PONG_V5 = DiscoveryCommand("pong", 2, 6)
+CMD_FIND_NODEHASH = DiscoveryCommand("find_nodehash", 5, 2)
+CMD_TOPIC_REGISTER = DiscoveryCommand("topic_register", 6, 3)
+CMD_TOPIC_QUERY = DiscoveryCommand("topic_query", 7, 2)
+CMD_TOPIC_NODES = DiscoveryCommand("topic_nodes", 8, 2)
+CMD_ID_MAP_V5 = dict(
+    (cmd.id, cmd)
+    for cmd in [
+        CMD_PING_V5,
+        CMD_PONG_V5,
+        CMD_FIND_NODE,
+        CMD_NEIGHBOURS,
+        CMD_FIND_NODEHASH,
+        CMD_TOPIC_REGISTER,
+        CMD_TOPIC_QUERY,
+        CMD_TOPIC_NODES])
+
+
+class DiscoveryProtocol(asyncio.DatagramProtocol):
+    """A Kademlia-like protocol to discover RLPx nodes."""
+    logger: TraceLogger = cast(TraceLogger, logging.getLogger("p2p.discovery.DiscoveryProtocol"))
+    transport: asyncio.DatagramTransport = None
+    use_v5 = False
+    _max_neighbours_per_packet_cache = None
+
+    def __init__(self,
+                 privkey: datatypes.PrivateKey,
+                 address: kademlia.Address,
+                 bootstrap_nodes: Tuple[kademlia.Node, ...],
+                 cancel_token: CancelToken) -> None:
+        self.privkey = privkey
+        self.address = address
+        self.bootstrap_nodes = bootstrap_nodes
+        self.this_node = kademlia.Node(self.pubkey, address)
+        self.routing = kademlia.RoutingTable(self.this_node)
+        self.topic_table = TopicTable(self.logger)
+        self.pong_callbacks = CallbackManager()
+        self.ping_callbacks = CallbackManager()
+        self.neighbours_callbacks = CallbackManager()
+        self.topic_nodes_callbacks = CallbackManager()
+        self.parity_pong_tokens: Dict[Hash32, Hash32] = {}
+        self.cancel_token = CancelToken('DiscoveryProtocol').chain(cancel_token)
+
+    def update_routing_table(self, node: kademlia.Node) -> None:
+        """Update the routing table entry for the given node."""
+        eviction_candidate = self.routing.add_node(node)
+        if eviction_candidate:
+            # This means we couldn't add the node because its bucket is full, so schedule a bond()
+            # with the least recently seen node on that bucket. If the bonding fails the node will
+            # be removed from the bucket and a new one will be picked from the bucket's
+            # replacement cache.
+            asyncio.ensure_future(self.bond(eviction_candidate))
+
+    async def bond(self, node: kademlia.Node) -> bool:
+        """Bond with the given node.
+
+        Bonding consists of pinging the node, waiting for a pong and maybe a ping as well.
+        It is necessary to do this at least once before we send find_node requests to a node.
+        """
+        if node in self.routing:
+            return True
+        elif node == self.this_node:
+            return False
+
+        if self.use_v5:
+            token = self.send_ping_v5(node, [])
+        else:
+            token = self.send_ping_v4(node)
+
+        try:
+            if self.use_v5:
+                got_pong, _, _ = await self.wait_pong_v5(node, token)
+            else:
+                got_pong = await self.wait_pong_v4(node, token)
+        except AlreadyWaitingDiscoveryResponse:
+            self.logger.debug("bonding failed, already waiting for pong")
+            return False
+
+        if not got_pong:
+            self.logger.debug("bonding failed, didn't receive pong from %s", node)
+            self.routing.remove_node(node)
+            return False
+
+        try:
+            # Give the remote node a chance to ping us before we move on and
+            # start sending find_node requests. It is ok for wait_ping() to
+            # timeout and return false here as that just means the remote
+            # remembers us.
+            await self.wait_ping(node)
+        except AlreadyWaitingDiscoveryResponse:
+            self.logger.debug("binding failed, already waiting for ping")
+            return False
+
+        self.logger.trace("bonding completed successfully with %s", node)
+        self.update_routing_table(node)
+        return True
+
+    async def wait_ping(self, remote: kademlia.Node) -> bool:
+        """Wait for a ping from the given remote.
+
+        This coroutine adds a callback to ping_callbacks and yields control until that callback is
+        called or a timeout (k_request_timeout) occurs. At that point it returns whether or not
+        a ping was received from the given node.
+        """
+        event = asyncio.Event()
+
+        with self.ping_callbacks.acquire(remote, event.set):
+            got_ping = False
+            try:
+                got_ping = await self.cancel_token.cancellable_wait(
+                    event.wait(), timeout=kademlia.k_request_timeout)
+                self.logger.trace('got expected ping from %s', remote)
+            except TimeoutError:
+                self.logger.trace('timed out waiting for ping from %s', remote)
+
+        return got_ping
+
+    async def wait_pong_v4(self, remote: kademlia.Node, token: Hash32) -> bool:
+        event = asyncio.Event()
+        callback = event.set
+        return await self._wait_pong(remote, token, event, callback)
+
+    async def _wait_pong(
+            self, remote: kademlia.Node, token: Hash32, event: asyncio.Event,
+            callback: Callable[..., Any]) -> bool:
+        """Wait for a pong from the given remote containing the given token.
+
+        This coroutine adds a callback to pong_callbacks and yields control until the given event
+        is set or a timeout (k_request_timeout) occurs. At that point it returns whether or not
+        a pong was received with the given pingid.
+        """
+        pingid = self._mkpingid(token, remote)
+
+        with self.pong_callbacks.acquire(pingid, callback):
+            got_pong = False
+            try:
+                got_pong = await self.cancel_token.cancellable_wait(
+                    event.wait(), timeout=kademlia.k_request_timeout)
+                self.logger.trace('got expected pong with token %s', encode_hex(token))
+            except TimeoutError:
+                self.logger.trace(
+                    'timed out waiting for pong from %s (token == %s)',
+                    remote,
+                    encode_hex(token),
+                )
+
+        return got_pong
+
+    async def wait_neighbours(self, remote: kademlia.Node) -> Tuple[kademlia.Node, ...]:
+        """Wait for a neihgbours packet from the given node.
+
+        Returns the list of neighbours received.
+        """
+        event = asyncio.Event()
+        neighbours: List[kademlia.Node] = []
+
+        def process(response: List[kademlia.Node]) -> None:
+            neighbours.extend(response)
+            # This callback is expected to be called multiple times because nodes usually
+            # split the neighbours replies into multiple packets, so we only call event.set() once
+            # we've received enough neighbours.
+            if len(neighbours) >= kademlia.k_bucket_size:
+                event.set()
+
+        with self.neighbours_callbacks.acquire(remote, process):
+            try:
+                await self.cancel_token.cancellable_wait(
+                    event.wait(), timeout=kademlia.k_request_timeout)
+                self.logger.trace('got expected neighbours response from %s', remote)
+            except TimeoutError:
+                self.logger.trace(
+                    'timed out waiting for %d neighbours from %s', kademlia.k_bucket_size, remote)
+
+        return tuple(n for n in neighbours if n != self.this_node)
+
+    def _mkpingid(self, token: Hash32, node: kademlia.Node) -> Hash32:
+        return token + node.pubkey.to_bytes()
+
+    def _send_find_node(self, node: kademlia.Node, target_node_id: int) -> None:
+        if self.use_v5:
+            self.send_find_node_v5(node, target_node_id)
+        else:
+            self.send_find_node_v4(node, target_node_id)
+
+    async def lookup(self, node_id: int) -> Tuple[kademlia.Node, ...]:
+        """Lookup performs a network search for nodes close to the given target.
+
+        It approaches the target by querying nodes that are closer to it on each iteration.  The
+        given target does not need to be an actual node identifier.
+        """
+        nodes_asked: Set[kademlia.Node] = set()
+        nodes_seen: Set[kademlia.Node] = set()
+
+        async def _find_node(node_id: int, remote: kademlia.Node) -> Tuple[kademlia.Node, ...]:
+            # Short-circuit in case our token has been triggered to avoid trying to send requests
+            # over a transport that is probably closed already.
+            self.cancel_token.raise_if_triggered()
+            self._send_find_node(remote, node_id)
+            candidates = await self.wait_neighbours(remote)
+            if not candidates:
+                self.logger.debug("got no candidates from %s, returning", remote)
+                return tuple()
+            all_candidates = tuple(c for c in candidates if c not in nodes_seen)
+            candidates = tuple(
+                c for c in all_candidates
+                if (not self.ping_callbacks.locked(c) and not self.pong_callbacks.locked(c))
+            )
+            self.logger.trace("got %s new candidates", len(candidates))
+            # Add new candidates to nodes_seen so that we don't attempt to bond with failing ones
+            # in the future.
+            nodes_seen.update(candidates)
+            bonded = await asyncio.gather(*(self.bond(c) for c in candidates))
+            self.logger.trace("bonded with %s candidates", bonded.count(True))
+            return tuple(c for c in candidates if bonded[candidates.index(c)])
+
+        def _exclude_if_asked(nodes: Iterable[kademlia.Node]) -> List[kademlia.Node]:
+            nodes_to_ask = list(set(nodes).difference(nodes_asked))
+            return kademlia.sort_by_distance(nodes_to_ask, node_id)[:kademlia.k_find_concurrency]
+
+        closest = self.routing.neighbours(node_id)
+        self.logger.debug("starting lookup; initial neighbours: %s", closest)
+        nodes_to_ask = _exclude_if_asked(closest)
+        while nodes_to_ask:
+            self.logger.trace("node lookup; querying %s", nodes_to_ask)
+            nodes_asked.update(nodes_to_ask)
+            results = await asyncio.gather(*(
+                _find_node(node_id, n)
+                for n
+                in nodes_to_ask
+                if not self.neighbours_callbacks.locked(n)
+            ))
+            for candidates in results:
+                closest.extend(candidates)
+            closest = kademlia.sort_by_distance(closest, node_id)[:kademlia.k_bucket_size]
+            nodes_to_ask = _exclude_if_asked(closest)
+
+        self.logger.debug("lookup finished for %s: %s", node_id, closest)
+        return tuple(closest)
+
+    async def lookup_random(self) -> Tuple[kademlia.Node, ...]:
+        return await self.lookup(random.randint(0, kademlia.k_max_node_id))
+
+    def get_random_bootnode(self) -> Iterator[kademlia.Node]:
+        if self.bootstrap_nodes:
+            yield random.choice(self.bootstrap_nodes)
+        else:
+            self.logger.warning('No bootnodes available')
+
+    def get_nodes_to_connect(self, count: int) -> Iterator[kademlia.Node]:
+        return self.routing.get_random_nodes(count)
+
+    @property
+    def pubkey(self) -> datatypes.PublicKey:
+        return self.privkey.public_key
+
+    def _get_handler(self, cmd: DiscoveryCommand) -> V4_HANDLER_TYPE:
+        if cmd == CMD_PING:
+            return self.recv_ping_v4
+        elif cmd == CMD_PONG:
+            return self.recv_pong_v4
+        elif cmd == CMD_FIND_NODE:
+            return self.recv_find_node_v4
+        elif cmd == CMD_NEIGHBOURS:
+            return self.recv_neighbours_v4
+        else:
+            raise ValueError(f"Unknown command: {cmd}")
+
+    def _get_max_neighbours_per_packet(self) -> int:
+        if self._max_neighbours_per_packet_cache is not None:
+            return self._max_neighbours_per_packet_cache
+        self._max_neighbours_per_packet_cache = _get_max_neighbours_per_packet()
+        return self._max_neighbours_per_packet_cache
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        # we need to cast here because the signature in the base class dicates BaseTransport
+        # and arguments can only be redefined contravariantly
+        self.transport = cast(asyncio.DatagramTransport, transport)
+
+    async def bootstrap(self) -> None:
+        self.logger.info("boostrapping with %s", self.bootstrap_nodes)
+        try:
+            bonded = await asyncio.gather(*(
+                self.bond(n)
+                for n
+                in self.bootstrap_nodes
+                if (not self.ping_callbacks.locked(n) and not self.pong_callbacks.locked(n))
+            ))
+            if not any(bonded):
+                self.logger.info("Failed to bond with bootstrap nodes %s", self.bootstrap_nodes)
+                return
+            await self.lookup_random()
+        except OperationCancelled as e:
+            self.logger.info("Bootstrapping cancelled: %s", e)
+
+    def datagram_received(self, data: Union[bytes, Text], addr: Tuple[str, int]) -> None:
+        ip_address, udp_port = addr
+        address = kademlia.Address(ip_address, udp_port)
+        # The prefix below is what geth uses to identify discv5 msgs.
+        # https://github.com/ethereum/go-ethereum/blob/c4712bf96bc1bae4a5ad4600e9719e4a74bde7d5/p2p/discv5/udp.go#L149  # noqa: E501
+        if text_if_str(to_bytes, data).startswith(V5_ID_STRING):
+            self.receive_v5(address, cast(bytes, data))
+        else:
+            self.receive(address, cast(bytes, data))
+
+    def error_received(self, exc: Exception) -> None:
+        self.logger.error('error received: %s', exc)
+
+    def send(self, node: kademlia.Node, message: bytes) -> None:
+        self.transport.sendto(message, (node.address.ip, node.address.udp_port))
+
+    async def stop(self) -> None:
+        self.logger.info('stopping discovery')
+        self.cancel_token.trigger()
+        self.transport.close()
+        # We run lots of asyncio tasks so this is to make sure they all get a chance to execute
+        # and exit cleanly when they notice the cancel token has been triggered.
+        await asyncio.sleep(0.1)
+
+    def receive(self, address: kademlia.Address, message: bytes) -> None:
+        try:
+            remote_pubkey, cmd_id, payload, message_hash = _unpack_v4(message)
+        except DefectiveMessage as e:
+            self.logger.error('error unpacking message (%s) from %s: %s', message, address, e)
+            return
+
+        # As of discovery version 4, expiration is the last element for all packets, so
+        # we can validate that here, but if it changes we may have to do so on the
+        # handler methods.
+        expiration = rlp.sedes.big_endian_int.deserialize(payload[-1])
+        if time.time() > expiration:
+            self.logger.debug('received message already expired')
+            return
+
+        cmd = CMD_ID_MAP[cmd_id]
+        if len(payload) != cmd.elem_count:
+            self.logger.error('invalid %s payload: %s', cmd.name, payload)
+            return
+        node = kademlia.Node(remote_pubkey, address)
+        handler = self._get_handler(cmd)
+        handler(node, payload, message_hash)
+
+    def recv_pong_v4(self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32) -> None:
+        # The pong payload should have 3 elements: to, token, expiration
+        _, token, _ = payload
+        self.logger.trace('<<< pong (v4) from %s (token == %s)', node, encode_hex(token))
+        self.process_pong_v4(node, token)
+
+    def recv_neighbours_v4(self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32) -> None:
+        # The neighbours payload should have 2 elements: nodes, expiration
+        nodes, _ = payload
+        neighbours = _extract_nodes_from_payload(node.address, nodes, self.logger)
+        self.logger.trace('<<< neighbours from %s: %s', node, neighbours)
+        self.process_neighbours(node, neighbours)
+
+    def recv_ping_v4(self, node: kademlia.Node, _: Any, message_hash: Hash32) -> None:
+        self.logger.trace('<<< ping(v4) from %s', node)
+        self.process_ping(node, message_hash)
+        self.send_pong_v4(node, message_hash)
+
+    def recv_find_node_v4(self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32) -> None:
+        # The find_node payload should have 2 elements: node_id, expiration
+        self.logger.trace('<<< find_node from %s', node)
+        node_id, _ = payload
+        if node not in self.routing:
+            # FIXME: This is not correct; a node we've bonded before may have become unavailable
+            # and thus removed from self.routing, but once it's back online we should accept
+            # find_nodes from them.
+            self.logger.debug('Ignoring find_node request from unknown node %s', node)
+            return
+        self.update_routing_table(node)
+        found = self.routing.neighbours(big_endian_to_int(node_id))
+        self.send_neighbours_v4(node, found)
+
+    def send_ping_v4(self, node: kademlia.Node) -> Hash32:
+        version = rlp.sedes.big_endian_int.serialize(PROTO_VERSION)
+        payload = (version, self.address.to_endpoint(), node.address.to_endpoint())
+        message = _pack_v4(CMD_PING.id, payload, self.privkey)
+        self.send(node, message)
+        # Return the msg hash, which is used as a token to identify pongs.
+        token = message[:MAC_SIZE]
+        self.logger.trace('>>> ping (v4) %s (token == %s)', node, encode_hex(token))
+        # XXX: This hack is needed because there are lots of parity 1.10 nodes out there that send
+        # the wrong token on pong msgs (https://github.com/paritytech/parity/issues/8038). We
+        # should get rid of this once there are no longer too many parity 1.10 nodes out there.
+        parity_token = keccak(message[HEAD_SIZE + 1:])
+        self.parity_pong_tokens[parity_token] = token
+        return token
+
+    def send_find_node_v4(self, node: kademlia.Node, target_node_id: int) -> None:
+        node_id = int_to_big_endian(
+            target_node_id).rjust(kademlia.k_pubkey_size // 8, b'\0')
+        self.logger.trace('>>> find_node to %s', node)
+        message = _pack_v4(CMD_FIND_NODE.id, tuple([node_id]), self.privkey)
+        self.send(node, message)
+
+    def send_pong_v4(self, node: kademlia.Node, token: Hash32) -> None:
+        self.logger.trace('>>> pong %s', node)
+        payload = (node.address.to_endpoint(), token)
+        message = _pack_v4(CMD_PONG.id, payload, self.privkey)
+        self.send(node, message)
+
+    def send_neighbours_v4(self, node: kademlia.Node, neighbours: List[kademlia.Node]) -> None:
+        nodes = []
+        neighbours = sorted(neighbours)
+        for n in neighbours:
+            nodes.append(n.address.to_endpoint() + [n.pubkey.to_bytes()])
+
+        max_neighbours = self._get_max_neighbours_per_packet()
+        for i in range(0, len(nodes), max_neighbours):
+            message = _pack_v4(
+                CMD_NEIGHBOURS.id, tuple([nodes[i:i + max_neighbours]]), self.privkey)
+            self.logger.trace('>>> neighbours to %s: %s',
+                              node, neighbours[i:i + max_neighbours])
+            self.send(node, message)
+
+    def process_neighbours(self, remote: kademlia.Node, neighbours: List[kademlia.Node]) -> None:
+        """Process a neighbours response.
+
+        Neighbours responses should only be received as a reply to a find_node, and that is only
+        done as part of node lookup, so the actual processing is left to the callback from
+        neighbours_callbacks, which is added (and removed after it's done or timed out) in
+        wait_neighbours().
+        """
+        try:
+            callback = self.neighbours_callbacks.get_callback(remote)
+        except KeyError:
+            self.logger.debug(
+                'unexpected neighbours from %s, probably came too late', remote)
+        else:
+            callback(neighbours)
+
+    def process_pong_v4(self, remote: kademlia.Node, token: Hash32) -> None:
+        """Process a pong packet.
+
+        Pong packets should only be received as a response to a ping, so the actual processing is
+        left to the callback from pong_callbacks, which is added (and removed after it's done
+        or timed out) in wait_pong().
+        """
+        # XXX: This hack is needed because there are lots of parity 1.10 nodes out there that send
+        # the wrong token on pong msgs (https://github.com/paritytech/parity/issues/8038). We
+        # should get rid of this once there are no longer too many parity 1.10 nodes out there.
+        if token in self.parity_pong_tokens:
+            # This is a pong from a buggy parity node, so need to lookup the actual token we're
+            # expecting.
+            token = self.parity_pong_tokens.pop(token)
+        else:
+            # This is a pong from a non-buggy node, so just cleanup self.parity_pong_tokens.
+            self.parity_pong_tokens = cytoolz.valfilter(
+                lambda val: val != token, self.parity_pong_tokens)
+
+        pingid = self._mkpingid(token, remote)
+
+        try:
+            callback = self.pong_callbacks.get_callback(pingid)
+        except KeyError:
+            self.logger.debug('unexpected pong from %s (token == %s)', remote, encode_hex(token))
+        else:
+            callback()
+
+    def process_ping(self, remote: kademlia.Node, hash_: Hash32) -> None:
+        """Process a received ping packet.
+
+        A ping packet may come any time, unrequested, or may be prompted by us bond()ing with a
+        new node. In the former case we'll just update the sender's entry in our routing table and
+        reply with a pong, whereas in the latter we'll also fire a callback from ping_callbacks.
+        """
+        if remote == self.this_node:
+            self.logger.info('Invariant: received ping from this_node: %s', remote)
+            return
+        else:
+            self.update_routing_table(remote)
+        # Sometimes a ping will be sent to us as part of the bonding
+        # performed the first time we see a node, and it is in those cases that
+        # a callback will exist.
+        try:
+            callback = self.ping_callbacks.get_callback(remote)
+        except KeyError:
+            pass
+        else:
+            callback()
+
+    #
+    # Discovery v5 specific methods
+    #
+
+    def send_v5(self, node: kademlia.Node, message: bytes) -> Hash32:
+        msg_hash = keccak(message)
+        self.send(node, V5_ID_STRING + message)
+        return msg_hash
+
+    def _get_handler_v5(self, cmd: DiscoveryCommand) -> V5_HANDLER_TYPE:
+        if cmd == CMD_PING_V5:
+            return self.recv_ping_v5
+        elif cmd == CMD_PONG_V5:
+            return self.recv_pong_v5
+        elif cmd == CMD_FIND_NODE:
+            return self.recv_find_node_v5
+        elif cmd == CMD_NEIGHBOURS:
+            return self.recv_neighbours_v5
+        elif cmd == CMD_FIND_NODEHASH:
+            return self.recv_find_nodehash
+        elif cmd == CMD_TOPIC_REGISTER:
+            return self.recv_topic_register
+        elif cmd == CMD_TOPIC_QUERY:
+            return self.recv_topic_query
+        elif cmd == CMD_TOPIC_NODES:
+            return self.recv_topic_nodes
+        else:
+            raise ValueError(f"Unknown command: {cmd}")
+
+    def receive_v5(self, address: kademlia.Address, message: bytes) -> None:
+        try:
+            remote_pubkey, cmd_id, payload, message_hash = _unpack_v5(message)
+        except DefectiveMessage as e:
+            self.logger.error('error unpacking message (%s) from %s: %s', message, address, e)
+            return
+
+        cmd = CMD_ID_MAP_V5[cmd_id]
+        if len(payload) != cmd.elem_count:
+            self.logger.error('invalid %s payload: %s', cmd.name, payload)
+            return
+        node = kademlia.Node(remote_pubkey, address)
+        handler = self._get_handler_v5(cmd)
+        handler(node, payload, message_hash, message)
+
+    def recv_ping_v5(self, node: kademlia.Node, payload: Tuple[Any, ...],
+                     message_hash: Hash32, _: bytes) -> None:
+        # version, from, to, expiration, topics
+        _, _, _, _, topics = payload
+        self.logger.trace('<<< ping(v5) from %s, topics: %s', node, topics)
+        self.process_ping(node, message_hash)
+        topic_hash = keccak(rlp.encode(topics))
+        ticket_serial = self.topic_table.issue_ticket(node)
+        # TODO: Generate wait_periods list according to spec.
+        wait_periods: List[int] = [60] * len(topics)
+        self.send_pong_v5(node, message_hash, topic_hash, ticket_serial, wait_periods)
+
+    def recv_pong_v5(
+            self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32, raw_msg: bytes) -> None:
+        # to, token, expiration, topic_hash, ticket_serial, wait_periods
+        _, token, _, _, _, wait_periods = payload
+        wait_periods = [big_endian_to_int(wait_period) for wait_period in wait_periods]
+        self.logger.trace('<<< pong (v5) from %s (token == %s)', node, encode_hex(token))
+        self.process_pong_v5(node, token, raw_msg, wait_periods)
+
+    def recv_find_node_v5(self, node: kademlia.Node, payload: Tuple[Any, ...],
+                          msg_hash: Hash32, _: bytes) -> None:
+        # FIND_NODE in v5 is identical to v4, so just call the v4 handler.
+        self.recv_find_node_v4(node, payload, msg_hash)
+
+    def recv_neighbours_v5(self, node: kademlia.Node, payload: Tuple[Any, ...],
+                           msg_hash: Hash32, _: bytes) -> None:
+        # NEIGHBOURS in v5 is identical to v4, so just call the v4 handler.
+        self.recv_neighbours_v4(node, payload, msg_hash)
+
+    def recv_find_nodehash(self, node: kademlia.Node, payload: Tuple[Any, ...],
+                           _: Hash32, _b: bytes) -> None:
+        target_hash, _ = payload
+        self.logger.trace('<<< find_nodehash from %s, target: %s', node, target_hash)
+        # TODO: Reply with a neighbours msg.
+
+    def recv_topic_register(self, node: kademlia.Node, payload: Tuple[Any, ...],
+                            _: Hash32, _m: bytes) -> None:
+        topics, idx, raw_pong = payload
+        topic_idx = big_endian_to_int(idx)
+        self.logger.trace(
+            '<<< topic_register from %s, topics: %s, idx: %d', node, topics, topic_idx)
+        _, _, pong_payload, _ = _unpack_v5(raw_pong)
+        _, _, _, _, ticket_serial, _ = pong_payload
+        self.topic_table.use_ticket(node, big_endian_to_int(ticket_serial), topics[topic_idx])
+
+    def recv_topic_query(self, node: kademlia.Node, payload: Tuple[Any, ...],
+                         message_hash: Hash32, _: bytes) -> None:
+        topic, _ = payload
+        self.logger.trace('<<< topic_query (%s) from %s', topic, node)
+        nodes = self.topic_table.get_nodes(topic)
+        self.send_topic_nodes(node, message_hash, nodes)
+
+    def recv_topic_nodes(self, node: kademlia.Node, payload: Tuple[Any, ...],
+                         _: Hash32, _m: bytes) -> None:
+        echo, raw_nodes = payload
+        nodes = _extract_nodes_from_payload(node.address, raw_nodes, self.logger)
+        self.logger.trace('<<< topic_nodes from %s: %s', node, nodes)
+        try:
+            callback = self.topic_nodes_callbacks.get_callback(node)
+        except KeyError:
+            self.logger.debug(
+                'Unexpected topic_nodes from %s, probably came too late', node)
+        else:
+            callback(echo, nodes)
+
+    def send_ping_v5(self, node: kademlia.Node, topics: List[bytes]) -> Hash32:
+        version = rlp.sedes.big_endian_int.serialize(PROTO_VERSION_V5)
+        payload = (
+            version, self.address.to_endpoint(), node.address.to_endpoint(),
+            _get_msg_expiration(), topics)
+        message = _pack_v5(CMD_PING_V5.id, payload, self.privkey)
+        token = self.send_v5(node, message)
+        self.logger.trace('>>> ping (v5) %s (token == %s)', node, encode_hex(token))
+        # Return the msg hash, which is used as a token to identify pongs.
+        return token
+
+    def send_pong_v5(
+            self, node: kademlia.Node, token: Hash32, topic_hash: Hash32,
+            ticket_serial: int, wait_periods: List[int]) -> None:
+        self.logger.trace('>>> pong (v5) %s', node)
+        payload = (
+            node.address.to_endpoint(), token, _get_msg_expiration(), topic_hash, ticket_serial,
+            wait_periods)
+        message = _pack_v5(CMD_PONG_V5.id, payload, self.privkey)
+        self.send_v5(node, message)
+
+    def send_find_node_v5(self, node: kademlia.Node, target_node_id: int) -> None:
+        node_id = int_to_big_endian(
+            target_node_id).rjust(kademlia.k_pubkey_size // 8, b'\0')
+        self.logger.trace('>>> find_node to %s', node)
+        message = _pack_v5(CMD_FIND_NODE.id, (node_id, _get_msg_expiration()), self.privkey)
+        self.send_v5(node, message)
+
+    def send_topic_query(self, node: kademlia.Node, topic: bytes) -> Hash32:
+        self.logger.trace('>>> topic_query (%s) to %s', topic, node)
+        payload = (topic, _get_msg_expiration())
+        message = _pack_v5(CMD_TOPIC_QUERY.id, payload, self.privkey)
+        return self.send_v5(node, message)
+
+    def send_topic_register(
+            self, node: kademlia.Node, topics: List[bytes], idx: int, pong: bytes) -> None:
+        if idx >= len(topics):
+            raise ValueError(f"Invalid topic idx: {idx}")
+        message = _pack_v5(CMD_TOPIC_REGISTER.id, (topics, idx, pong), self.privkey)
+        self.logger.trace('>>> topic_register to %s: %s', node, topics[idx])
+        self.send_v5(node, message)
+
+    def send_topic_nodes(
+            self, node: kademlia.Node, echo: Hash32, nodes: Tuple[kademlia.Node, ...]) -> None:
+        encoded_nodes = tuple(
+            n.address.to_endpoint() + [n.pubkey.to_bytes()]
+            for n in nodes)
+        max_neighbours = self._get_max_neighbours_per_packet()
+        for batch in cytoolz.partition_all(max_neighbours, encoded_nodes):
+            message = _pack_v5(CMD_TOPIC_NODES.id, (echo, batch), self.privkey)
+            self.logger.trace('>>> topic_nodes to %s: %s', node, batch)
+            self.send_v5(node, message)
+
+    async def wait_topic_nodes(
+            self, remote: kademlia.Node, echo: Hash32) -> Tuple[kademlia.Node, ...]:
+        """Wait for a topic_nodes msg from the given node.
+
+        Returns the list of nodes received.
+        """
+        event = asyncio.Event()
+        nodes: List[kademlia.Node] = []
+
+        def process(received_echo: Hash32, response: List[kademlia.Node]) -> None:
+            if received_echo != echo:
+                self.logger.warning(
+                    "Unexpected topic_nodes from %s, expected echo %s, got %s",
+                    encode_hex(echo), encode_hex(received_echo))
+                return
+
+            nodes.extend(response)
+            # This callback may be called multiple times if the number of nodes returned by the
+            # peer make the msg exceed the 1280 bytes limit, so we only call event.set() once
+            # we've received enough neighbours.
+            if len(nodes) >= MAX_ENTRIES_PER_TOPIC:
+                event.set()
+
+        with self.topic_nodes_callbacks.acquire(remote, process):
+            try:
+                await self.cancel_token.cancellable_wait(
+                    event.wait(), timeout=kademlia.k_request_timeout)
+            except TimeoutError:
+                # A timeout here just means we didn't get at least MAX_ENTRIES_PER_TOPIC nodes,
+                # but we'll still process the ones we get.
+                self.logger.trace(
+                    'timed out waiting for %d neighbours from %s', MAX_ENTRIES_PER_TOPIC, remote)
+            finally:
+                self.logger.trace('got %d topic nodes from %s', len(nodes), remote)
+
+        return tuple(n for n in nodes if n != self.this_node)
+
+    async def get_ticket(self, node: kademlia.Node, topics: List[bytes]) -> 'Ticket':
+        token = self.send_ping_v5(node, topics)
+        try:
+            got_pong, raw_pong, wait_periods = await self.wait_pong_v5(node, token)
+        except AlreadyWaitingDiscoveryResponse:
+            raise UnableToGetDiscV5Ticket(
+                f"Failed to get ticket from {node}, already waiting for pong")
+
+        if not got_pong:
+            raise UnableToGetDiscV5Ticket(f"failed to get ticket from {node}")
+
+        return Ticket(node, raw_pong, topics, wait_periods)
+
+    async def wait_pong_v5(
+            self, remote: kademlia.Node, token: Hash32) -> Tuple[bool, bytes, List[float]]:
+        event = asyncio.Event()
+        wait_periods: List[float] = []
+        pong: bytes = None
+
+        def callback(raw_msg: bytes, wps: List[float]) -> None:
+            nonlocal pong, wait_periods
+            event.set()
+            pong = raw_msg
+            wait_periods = wps
+
+        got_pong = await self._wait_pong(remote, token, event, callback)
+        return got_pong, pong, wait_periods
+
+    def process_pong_v5(self, remote: kademlia.Node, token: Hash32, raw_msg: bytes,
+                        wait_periods: List[float]) -> None:
+        pingid = self._mkpingid(token, remote)
+        try:
+            callback = self.pong_callbacks.get_callback(pingid)
+        except KeyError:
+            self.logger.debug('unexpected pong from %s (token == %s)', remote, encode_hex(token))
+        else:
+            callback(raw_msg, wait_periods)
+
+
+class PreferredNodeDiscoveryProtocol(DiscoveryProtocol):
+    """
+    A DiscoveryProtocol which has a list of preferred nodes which it will prioritize using before
+    trying to find nodes.  Each preferred node can only be used once every
+    preferred_node_recycle_time seconds.
+    """
+    preferred_nodes: Sequence[kademlia.Node] = None
+    preferred_node_recycle_time: int = 300
+    _preferred_node_tracker: Dict[kademlia.Node, float] = None
+
+    def __init__(self,
+                 privkey: datatypes.PrivateKey,
+                 address: kademlia.Address,
+                 bootstrap_nodes: Tuple[kademlia.Node, ...],
+                 preferred_nodes: Sequence[kademlia.Node],
+                 cancel_token: CancelToken) -> None:
+        super().__init__(privkey, address, bootstrap_nodes, cancel_token)
+
+        self.preferred_nodes = preferred_nodes
+        self.logger.info('Preferred peers: %s', self.preferred_nodes)
+        self._preferred_node_tracker = collections.defaultdict(lambda: 0)
+
+    @to_tuple
+    def _get_eligible_preferred_nodes(self) -> Iterator[kademlia.Node]:
+        """
+        Return nodes from the preferred_nodes which have not been used within
+        the last preferred_node_recycle_time
+        """
+        for node in self.preferred_nodes:
+            last_used = self._preferred_node_tracker[node]
+            if time.time() - last_used > self.preferred_node_recycle_time:
+                yield node
+
+    def _get_random_preferred_node(self) -> kademlia.Node:
+        """
+        Return a random node from the preferred list.
+        """
+        eligible_nodes = self._get_eligible_preferred_nodes()
+        if not eligible_nodes:
+            raise NoEligibleNodes("No eligible preferred nodes available")
+        node = random.choice(eligible_nodes)
+        return node
+
+    def get_random_bootnode(self) -> Iterator[kademlia.Node]:
+        """
+        Return a single node to bootstrap, preferring nodes from the preferred list.
+        """
+        try:
+            node = self._get_random_preferred_node()
+            self._preferred_node_tracker[node] = time.time()
+            yield node
+        except NoEligibleNodes:
+            yield from super().get_random_bootnode()
+
+    def get_nodes_to_connect(self, count: int) -> Iterator[kademlia.Node]:
+        """
+        Return up to `count` nodes, preferring nodes from the preferred list.
+        """
+        preferred_nodes = self._get_eligible_preferred_nodes()[:count]
+        for node in preferred_nodes:
+            self._preferred_node_tracker[node] = time.time()
+            yield node
+
+        num_nodes_needed = max(0, count - len(preferred_nodes))
+        yield from super().get_nodes_to_connect(num_nodes_needed)
+
+
+class DiscoveryByTopicProtocol(DiscoveryProtocol):
+    """Experimental discovery implementation that uses topic_query to find compatible nodes"""
+    use_v5 = True
+    _concurrent_topic_nodes_requests = 10
+
+    def __init__(self,
+                 topic: bytes,
+                 privkey: datatypes.PrivateKey,
+                 address: kademlia.Address,
+                 bootstrap_nodes: Tuple[kademlia.Node, ...],
+                 cancel_token: CancelToken) -> None:
+        super().__init__(privkey, address, bootstrap_nodes, cancel_token)
+        self.topic = topic
+
+    def get_nodes_to_connect(self, count: int) -> Iterator[kademlia.Node]:
+        topic_nodes = self.topic_table.get_nodes(self.topic)
+        for node in topic_nodes:
+            yield node
+
+        num_nodes_needed = max(0, count - len(topic_nodes))
+        yield from super().get_nodes_to_connect(num_nodes_needed)
+
+    async def lookup_random(self) -> Tuple[kademlia.Node, ...]:
+        query_nodes = list(self.routing.get_random_nodes(self._concurrent_topic_nodes_requests))
+        expected_echoes = tuple(
+            (n, self.send_topic_query(n, self.topic))
+            for n in query_nodes)
+        replies = await asyncio.gather(
+            *[self.wait_topic_nodes(n, echo) for n, echo in expected_echoes])
+        seen_nodes = set(cytoolz.concat(replies))
+        self.logger.debug(
+            "Got %d nodes for the %s topic: %s", len(seen_nodes), self.topic, seen_nodes)
+        for node in seen_nodes:
+            self.topic_table.add_node(node, self.topic)
+
+        if len(seen_nodes) < kademlia.k_bucket_size:
+            # Not enough nodes were found for our topic, so perform a regular kademlia lookup for
+            # a random node ID.
+            extra_nodes = await super().lookup_random()
+            seen_nodes.update(extra_nodes)
+
+        return tuple(seen_nodes)
+
+
+class DiscoveryService(BaseService):
+    _last_lookup: float = 0
+    _lookup_interval: int = 30
+
+    def __init__(self, proto: DiscoveryProtocol, peer_pool: BasePeerPool,
+                 port: int, token: CancelToken = None) -> None:
+        super().__init__(token)
+        self.proto = proto
+        self.peer_pool = peer_pool
+        self.port = port
+        self._lookup_running = asyncio.Lock()
+
+    async def _run(self) -> None:
+        await self._start_udp_listener()
+        connect_loop_sleep = 2
+        self.run_task(self.proto.bootstrap())
+        while self.is_operational:
+            await self.maybe_connect_to_more_peers()
+            await self.sleep(connect_loop_sleep)
+
+    async def _start_udp_listener(self) -> None:
+        loop = asyncio.get_event_loop()
+        # TODO: Support IPv6 addresses as well.
+        await loop.create_datagram_endpoint(
+            lambda: self.proto,
+            local_addr=('0.0.0.0', self.port),
+            family=socket.AF_INET)
+
+    async def maybe_connect_to_more_peers(self) -> None:
+        """Connect to more peers if we're not yet maxed out to max_peers"""
+        if self.peer_pool.is_full:
+            self.logger.debug("Already connected to %s peers; sleeping", len(self.peer_pool))
+            return
+
+        self.run_task(self.maybe_lookup_random_node())
+
+        await self.peer_pool.connect_to_nodes(
+            self.proto.get_nodes_to_connect(self.peer_pool.max_peers))
+
+        # In some cases (e.g ROPSTEN or private testnets), the discovery table might be full of
+        # bad peers so if we can't connect to any peers we try a random bootstrap node as well.
+        if not len(self.peer_pool):
+            await self.peer_pool.connect_to_nodes(self.proto.get_random_bootnode())
+
+    async def maybe_lookup_random_node(self) -> None:
+        if self._last_lookup + self._lookup_interval > time.time():
+            return
+        elif self._lookup_running.locked():
+            self.logger.debug("Node discovery lookup already in progress, not running another")
+            return
+        async with self._lookup_running:
+            # This method runs in the background, so we must catch OperationCancelled here
+            # otherwise asyncio will warn that its exception was never retrieved.
+            try:
+                await self.proto.lookup_random()
+            except OperationCancelled:
+                pass
+            finally:
+                self._last_lookup = time.time()
+
+    async def _cleanup(self) -> None:
+        await self.proto.stop()
+
+
+class NodeTicketInfo:
+    # The serial number of the last ticket we issued for a given remote node. New tickets are
+    # issued when a node sends a PING msg containing one or more topics.
+    last_issued: int = 0
+    # The serial number of the last ticket used by a given remote node. Tickets are marked as used
+    # when a node sends a REGISTER_TICKET msg using a ticket previously issued.
+    last_used: int = 0
+
+
+class TopicTable:
+    registration_lifetime = 60 * 60
+
+    def __init__(self, logger: TraceLogger) -> None:
+        self.logger = logger
+        # A per-topic FIFO set of nodes.
+        self.topics: Dict[bytes, 'collections.OrderedDict[kademlia.Node, float]'] = (
+            collections.defaultdict(collections.OrderedDict))
+        # The IDs of the last issued/used tickets for any given node.
+        self.node_tickets: Dict[kademlia.Node, NodeTicketInfo] = {}
+
+    def add_node(self, node: kademlia.Node, topic: bytes) -> None:
+        entries = self.topics[topic]
+        if node in entries:
+            entries.pop(node)
+        while len(entries) >= MAX_ENTRIES_PER_TOPIC:
+            entries.popitem(last=False)
+        entries[node] = time.time() + self.registration_lifetime
+
+    def get_nodes(self, topic: bytes) -> Tuple[kademlia.Node, ...]:
+        if topic not in self.topics:
+            return tuple()
+        else:
+            now = time.time()
+            entries = [(node, expiry) for node, expiry in self.topics[topic].items()
+                       if expiry > now]
+            self.topics[topic] = collections.OrderedDict(entries)
+            return tuple(node for node, _ in entries)
+
+    def use_ticket(self, node: kademlia.Node, ticket_serial: int, topic: bytes) -> None:
+        ticket_info = self.node_tickets.get(node)
+        if ticket_info is None:
+            self.logger.debug("No ticket found for %s", node)
+            return
+
+        if ticket_serial != ticket_info.last_issued:
+            self.logger.debug("Wrong ticket for %s, expected %d, got %d", node,
+                              ticket_info.last_issued, ticket_serial)
+            return
+
+        ticket_info.last_used = ticket_serial
+        self.add_node(node, topic)
+
+    def issue_ticket(self, node: kademlia.Node) -> int:
+        node_info = self.node_tickets.setdefault(node, NodeTicketInfo())
+        node_info.last_issued += 1
+        return node_info.last_issued
+
+
+class Ticket:
+
+    def __init__(self, node: kademlia.Node, pong: bytes, topics: List[bytes],
+                 wait_periods: List[float]) -> None:
+        now = time.time()
+        self.issue_time = now
+        self.node = node
+        self.pong = pong
+        self.topics = topics
+        self.registration_times = [now + wait_period for wait_period in wait_periods]
+
+    def __repr__(self) -> str:
+        return 'Ticket(%s:%s)' % (self.node, self.topics)
+
+
+@to_list
+def _extract_nodes_from_payload(
+        sender: kademlia.Address,
+        payload: List[Tuple[str, str, str, str]],
+        logger: TraceLogger) -> Iterator[kademlia.Node]:
+    for item in payload:
+        ip, udp_port, tcp_port, node_id = item
+        address = kademlia.Address.from_endpoint(ip, udp_port, tcp_port)
+        if kademlia.check_relayed_addr(sender, address):
+            yield kademlia.Node(keys.PublicKey(node_id), address)
+        else:
+            logger.debug("Skipping invalid address %s relayed by %s", address, sender)
+
+
+def _get_max_neighbours_per_packet() -> int:
+    # As defined in https://github.com/ethereum/devp2p/blob/master/rlpx.md, the max size of a
+    # datagram must be 1280 bytes, so when sending neighbours packets we must include up to
+    # _max_neighbours_per_packet and if there's more than that split them across multiple
+    # packets.
+    # Use an IPv6 address here as we're interested in the size of the biggest possible node
+    # representation.
+    addr = kademlia.Address('::1', 30303, 30303)
+    node_data = addr.to_endpoint() + [b'\x00' * (kademlia.k_pubkey_size // 8)]
+    neighbours = [node_data]
+    expiration = rlp.sedes.big_endian_int.serialize(_get_msg_expiration())
+    payload = rlp.encode([neighbours] + [expiration])
+    while HEAD_SIZE + len(payload) <= 1280:
+        neighbours.append(node_data)
+        payload = rlp.encode([neighbours] + [expiration])
+    return len(neighbours) - 1
+
+
+def _pack_v4(cmd_id: int, payload: Tuple[Any, ...], privkey: datatypes.PrivateKey) -> bytes:
+    """Create and sign a UDP message to be sent to a remote node.
+
+    See https://github.com/ethereum/devp2p/blob/master/rlpx.md#node-discovery for information on
+    how UDP packets are structured.
+    """
+    cmd_id = to_bytes(cmd_id)
+    expiration = rlp.sedes.big_endian_int.serialize(_get_msg_expiration())
+    encoded_data = cmd_id + rlp.encode(payload + tuple([expiration]))
+    signature = privkey.sign_msg(encoded_data)
+    message_hash = keccak(signature.to_bytes() + encoded_data)
+    return message_hash + signature.to_bytes() + encoded_data
+
+
+def _unpack_v4(message: bytes) -> Tuple[datatypes.PublicKey, int, Tuple[Any, ...], Hash32]:
+    """Unpack a discovery v4 UDP message received from a remote node.
+
+    Returns the public key used to sign the message, the cmd ID, payload and hash.
+    """
+    message_hash = message[:MAC_SIZE]
+    if message_hash != keccak(message[MAC_SIZE:]):
+        raise WrongMAC("Wrong msg mac")
+    signature = keys.Signature(message[MAC_SIZE:HEAD_SIZE])
+    signed_data = message[HEAD_SIZE:]
+    remote_pubkey = signature.recover_public_key_from_msg(signed_data)
+    cmd_id = message[HEAD_SIZE]
+    cmd = CMD_ID_MAP[cmd_id]
+    payload = tuple(rlp.decode(message[HEAD_SIZE + 1:], strict=False))
+    # Ignore excessive list elements as required by EIP-8.
+    payload = payload[:cmd.elem_count]
+    return remote_pubkey, cmd_id, payload, message_hash
+
+
+def _get_msg_expiration() -> int:
+    return int(time.time() + EXPIRATION)
+
+
+def _pack_v5(cmd_id: int, payload: Tuple[Any, ...], privkey: datatypes.PrivateKey) -> bytes:
+    """Create and sign a discovery v5 UDP message to be sent to a remote node."""
+    cmd_id = to_bytes(cmd_id)
+    encoded_data = cmd_id + rlp.encode(payload)
+    signature = privkey.sign_msg(encoded_data)
+    return signature.to_bytes() + encoded_data
+
+
+def _unpack_v5(message: bytes) -> Tuple[datatypes.PublicKey, int, Tuple[Any, ...], Hash32]:
+    """Unpack a discovery v5 UDP message received from a remote node.
+
+    Returns the public key used to sign the message, the cmd ID, payload and msg hash.
+    """
+    if not message.startswith(V5_ID_STRING):
+        raise DefectiveMessage("Missing v5 version prefix")
+    message_hash = keccak(message[len(V5_ID_STRING):])
+    signature = keys.Signature(message[len(V5_ID_STRING):HEAD_SIZE_V5])
+    body = message[HEAD_SIZE_V5:]
+    remote_pubkey = signature.recover_public_key_from_msg(body)
+    cmd_id = body[0]
+    cmd = CMD_ID_MAP_V5[cmd_id]
+    payload = tuple(rlp.decode(body[1:], strict=False))
+    # Ignore excessive list elements as required by EIP-8.
+    payload = payload[:cmd.elem_count]
+    return remote_pubkey, cmd_id, payload, message_hash
+
+
+class CallbackLock:
+    def __init__(self,
+                 callback: Callable[..., Any],
+                 timeout: float=2 * kademlia.k_request_timeout) -> None:
+        self.callback = callback
+        self.timeout = timeout
+        self.created_at = time.time()
+
+    @property
+    def is_expired(self) -> bool:
+        return time.time() - self.created_at > self.timeout
+
+
+class CallbackManager(UserDict):
+    @contextlib.contextmanager
+    def acquire(self,
+                key: Hashable,
+                callback: Callable[..., Any]) -> Iterator[CallbackLock]:
+        if key in self:
+            if not self.locked(key):
+                del self[key]
+            else:
+                raise AlreadyWaitingDiscoveryResponse(f"Already waiting on callback for: {key}")
+
+        lock = CallbackLock(callback)
+        self[key] = lock
+
+        try:
+            yield lock
+        finally:
+            del self[key]
+
+    def get_callback(self, key: Hashable) -> Callable[..., Any]:
+        return self[key].callback
+
+    def locked(self, key: Hashable) -> bool:
+        try:
+            lock = self[key]
+        except KeyError:
+            return False
+        else:
+            if lock.is_expired:
+                return False
+            else:
+                return True
+
+
+def get_v5_topic(proto: Type[protocol.Protocol], genesis_hash: Hash32) -> bytes:
+    proto_id = proto.name.upper()
+    if proto.version != 1:
+        proto_id += str(proto.version)
+    topic = proto_id + '@' + remove_0x_prefix(encode_hex(genesis_hash[:8]))
+    return topic.encode('ascii')
+
+
+def _test() -> None:
+    import argparse
+    import signal
+    from p2p import constants
+    from p2p import ecies
+
+    loop = asyncio.get_event_loop()
+    loop.set_debug(True)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-bootnode', type=str, help="The enode to use as bootnode")
+    parser.add_argument('-v5', action="store_true")
+    parser.add_argument('-trace', action="store_true")
+    args = parser.parse_args()
+
+    log_level = logging.DEBUG
+    if args.trace:
+        log_level = TRACE_LEVEL_NUM
+    logging.basicConfig(level=log_level, format='%(asctime)s %(levelname)s: %(message)s')
+
+    listen_host = '127.0.0.1'
+    # Listen on a port other than 30303 so that we can test against a local geth instance
+    # running on that port.
+    listen_port = 30304
+    privkey = ecies.generate_privkey()
+    addr = kademlia.Address(listen_host, listen_port, listen_port)
+    if args.bootnode:
+        bootstrap_nodes = tuple([kademlia.Node.from_uri(args.bootnode)])
+    elif args.v5:
+        bootstrap_nodes = tuple(
+            kademlia.Node.from_uri(enode) for enode in constants.DISCOVERY_V5_BOOTNODES)
+    else:
+        bootstrap_nodes = tuple(
+            kademlia.Node.from_uri(enode) for enode in constants.ROPSTEN_BOOTNODES)
+
+    cancel_token = CancelToken("discovery")
+    if args.v5:
+        # topic = b'LES2@41941023680923e0'  # LES2/ropsten
+        topic = b'LES2@d4e56740f876aef8'  # LES2/mainnet
+        discovery: DiscoveryProtocol = DiscoveryByTopicProtocol(
+            topic, privkey, addr, bootstrap_nodes, cancel_token)
+    else:
+        discovery = DiscoveryProtocol(privkey, addr, bootstrap_nodes, cancel_token)
+
+    async def run() -> None:
+        await loop.create_datagram_endpoint(lambda: discovery, local_addr=('0.0.0.0', listen_port))
+        try:
+            await discovery.bootstrap()
+            if args.v5:
+                while True:
+                    nodes = discovery.topic_table.get_nodes(topic)
+                    print("******* %d topic nodes found ***************" % len(nodes))
+                    print(nodes)
+                    await discovery.lookup_random()
+                    await cancel_token.cancellable_wait(asyncio.sleep(5))
+        except OperationCancelled:
+            pass
+        finally:
+            await discovery.stop()
+
+    for sig in [signal.SIGINT, signal.SIGTERM]:
+        loop.add_signal_handler(sig, discovery.cancel_token.trigger)
+
+    loop.run_until_complete(run())
+    loop.close()
+
+
+if __name__ == "__main__":
+    _test()

--- a/quarkchain/p2p/discovery.py
+++ b/quarkchain/p2p/discovery.py
@@ -30,7 +30,7 @@ from typing import (
     Union,
 )
 
-import cytoolz
+import toolz
 
 import rlp
 
@@ -563,7 +563,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
             token = self.parity_pong_tokens.pop(token)
         else:
             # This is a pong from a non-buggy node, so just cleanup self.parity_pong_tokens.
-            self.parity_pong_tokens = cytoolz.valfilter(
+            self.parity_pong_tokens = toolz.valfilter(
                 lambda val: val != token, self.parity_pong_tokens)
 
         pingid = self._mkpingid(token, remote)
@@ -755,7 +755,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
             n.address.to_endpoint() + [n.pubkey.to_bytes()]
             for n in nodes)
         max_neighbours = self._get_max_neighbours_per_packet()
-        for batch in cytoolz.partition_all(max_neighbours, encoded_nodes):
+        for batch in toolz.partition_all(max_neighbours, encoded_nodes):
             message = _pack_v5(CMD_TOPIC_NODES.id, (echo, batch), self.privkey)
             self.logger.trace('>>> topic_nodes to %s: %s', node, batch)
             self.send_v5(node, message)
@@ -932,7 +932,7 @@ class DiscoveryByTopicProtocol(DiscoveryProtocol):
             for n in query_nodes)
         replies = await asyncio.gather(
             *[self.wait_topic_nodes(n, echo) for n, echo in expected_echoes])
-        seen_nodes = set(cytoolz.concat(replies))
+        seen_nodes = set(toolz.concat(replies))
         self.logger.debug(
             "Got %d nodes for the %s topic: %s", len(seen_nodes), self.topic, seen_nodes)
         for node in seen_nodes:

--- a/quarkchain/p2p/p2p_proto.py
+++ b/quarkchain/p2p/p2p_proto.py
@@ -2,7 +2,7 @@ import enum
 import sys
 from typing import cast, Dict
 
-from cytoolz import assoc
+from toolz import assoc
 
 import rlp
 from rlp import sedes

--- a/quarkchain/p2p/peer.py
+++ b/quarkchain/p2p/peer.py
@@ -21,7 +21,7 @@ from typing import (
     Type,
 )
 
-from cytoolz import groupby
+from toolz import groupby
 
 import rlp
 

--- a/quarkchain/p2p/tests/test_discovery.py
+++ b/quarkchain/p2p/tests/test_discovery.py
@@ -46,6 +46,10 @@ class LESProtocolV2(LESProtocol):
 def short_timeout(monkeypatch):
     monkeypatch.setattr(kademlia, 'k_request_timeout', 0.01)
 
+# this needs to be done so that test_topic_query can work correctly
+@pytest.fixture
+def short_timeout_undo(monkeypatch):
+    monkeypatch.undo()
 
 def test_ping_pong():
     alice = get_discovery_protocol(b"alice")
@@ -356,7 +360,7 @@ def test_find_node_neighbours_v5():
 
 
 @pytest.mark.asyncio
-async def test_topic_query(event_loop):
+async def test_topic_query(event_loop, short_timeout_undo):
     bob = await get_listening_discovery_protocol(event_loop)
     les_nodes = [random_node() for _ in range(10)]
     topic = b'les'

--- a/quarkchain/p2p/tests/test_discovery.py
+++ b/quarkchain/p2p/tests/test_discovery.py
@@ -1,0 +1,554 @@
+import asyncio
+import logging
+import os
+import random
+import socket
+import string
+import re
+
+import pytest
+
+import rlp
+
+from eth_utils import (
+    decode_hex,
+    to_bytes,
+)
+
+from eth_hash.auto import keccak
+
+from eth_keys import keys
+
+from cancel_token import CancelToken
+
+from eth.chains.ropsten import ROPSTEN_GENESIS_HEADER
+
+from trinity.protocol.les.proto import LESProtocol, LESProtocolV2
+
+from quarkchain.p2p import discovery
+from quarkchain.p2p import kademlia
+
+
+# Force our tests to fail quickly if they accidentally make network requests.
+@pytest.fixture(autouse=True)
+def short_timeout(monkeypatch):
+    monkeypatch.setattr(kademlia, 'k_request_timeout', 0.01)
+
+
+def test_ping_pong():
+    alice = get_discovery_protocol(b"alice")
+    bob = get_discovery_protocol(b"bob")
+
+    # Connect alice's and bob's transports directly so we don't need to deal with the complexities
+    # of going over the wire.
+    link_transports(alice, bob)
+    # Collect all pongs received by alice in a list for later inspection.
+    received_pongs = []
+    alice.recv_pong_v4 = lambda node, payload, hash_: received_pongs.append((node, payload))
+
+    token = alice.send_ping_v4(bob.this_node)
+
+    assert len(received_pongs) == 1
+    node, payload = received_pongs[0]
+    assert node.id == bob.this_node.id
+    assert token == payload[1]
+
+
+def _test_find_node_neighbours(use_v5):
+    alice = get_discovery_protocol(b"alice")
+    bob = get_discovery_protocol(b"bob")
+    # Add some nodes to bob's routing table so that it has something to use when replying to
+    # alice's find_node.
+    for _ in range(kademlia.k_bucket_size * 2):
+        bob.update_routing_table(random_node())
+
+    # Connect alice's and bob's transports directly so we don't need to deal with the complexities
+    # of going over the wire.
+    link_transports(alice, bob)
+    # Collect all neighbours packets received by alice in a list for later inspection.
+    received_neighbours = []
+    alice.recv_neighbours_v4 = lambda node, payload, hash_: received_neighbours.append((node, payload))  # noqa: E501
+    # Pretend that bob and alice have already bonded, otherwise bob will ignore alice's find_node.
+    bob.update_routing_table(alice.this_node)
+
+    if use_v5:
+        alice.send_find_node_v5(bob.this_node, alice.this_node.id)
+    else:
+        alice.send_find_node_v4(bob.this_node, alice.this_node.id)
+
+    # Bob should have sent two neighbours packets in order to keep the total packet size under the
+    # 1280 bytes limit.
+    assert len(received_neighbours) == 2
+    packet1, packet2 = received_neighbours
+    neighbours = []
+    for packet in [packet1, packet2]:
+        node, payload = packet
+        assert node == bob.this_node
+        neighbours.extend(discovery._extract_nodes_from_payload(
+            node.address, payload[0], bob.logger))
+    assert len(neighbours) == kademlia.k_bucket_size
+
+
+def test_find_node_neighbours_v4():
+    _test_find_node_neighbours(use_v5=False)
+
+
+@pytest.mark.asyncio
+async def test_protocol_bootstrap():
+    node1, node2 = [random_node(), random_node()]
+    proto = MockDiscoveryProtocol([node1, node2])
+
+    async def bond(node):
+        assert proto.routing.add_node(node) is None
+        return True
+
+    # Pretend we bonded successfully with our bootstrap nodes.
+    proto.bond = bond
+
+    await proto.bootstrap()
+
+    assert len(proto.messages) == 2
+    # We don't care in which order the bootstrap nodes are contacted, nor which node_id was used
+    # in the find_node request, so we just assert that we sent find_node msgs to both nodes.
+    assert sorted([(node, cmd) for (node, cmd, _) in proto.messages]) == sorted([
+        (node1, 'find_node'),
+        (node2, 'find_node')])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('echo', ['echo', b'echo'])
+async def test_wait_ping(echo):
+    proto = MockDiscoveryProtocol([])
+    node = random_node()
+
+    # Schedule a call to proto.recv_ping() simulating a ping from the node we expect.
+    recv_ping_coroutine = asyncio.coroutine(lambda: proto.recv_ping_v4(node, echo, b''))
+    asyncio.ensure_future(recv_ping_coroutine())
+
+    got_ping = await proto.wait_ping(node)
+
+    assert got_ping
+    # Ensure wait_ping() cleaned up after itself.
+    assert node not in proto.ping_callbacks
+
+    # If we waited for a ping from a different node, wait_ping() would timeout and thus return
+    # false.
+    recv_ping_coroutine = asyncio.coroutine(lambda: proto.recv_ping_v4(node, echo, b''))
+    asyncio.ensure_future(recv_ping_coroutine())
+
+    node2 = random_node()
+    got_ping = await proto.wait_ping(node2)
+
+    assert not got_ping
+    assert node2 not in proto.ping_callbacks
+
+
+@pytest.mark.asyncio
+async def test_wait_pong():
+    proto = MockDiscoveryProtocol([])
+    us = proto.this_node
+    node = random_node()
+
+    token = b'token'
+    # Schedule a call to proto.recv_pong() simulating a pong from the node we expect.
+    pong_msg_payload = [us.address.to_endpoint(), token, discovery._get_msg_expiration()]
+    recv_pong_coroutine = asyncio.coroutine(lambda: proto.recv_pong_v4(node, pong_msg_payload, b''))
+    asyncio.ensure_future(recv_pong_coroutine())
+
+    got_pong = await proto.wait_pong_v4(node, token)
+
+    assert got_pong
+    # Ensure wait_pong() cleaned up after itself.
+    pingid = proto._mkpingid(token, node)
+    assert pingid not in proto.pong_callbacks
+
+    # If the remote node echoed something different than what we expected, wait_pong() would
+    # timeout.
+    wrong_token = b"foo"
+    pong_msg_payload = [us.address.to_endpoint(), wrong_token, discovery._get_msg_expiration()]
+    recv_pong_coroutine = asyncio.coroutine(lambda: proto.recv_pong_v4(node, pong_msg_payload, b''))
+    asyncio.ensure_future(recv_pong_coroutine())
+
+    got_pong = await proto.wait_pong_v4(node, token)
+
+    assert not got_pong
+    assert pingid not in proto.pong_callbacks
+
+
+@pytest.mark.asyncio
+async def test_wait_neighbours():
+    proto = MockDiscoveryProtocol([])
+    node = random_node()
+
+    # Schedule a call to proto.recv_neighbours_v4() simulating a neighbours response from the node
+    # we expect.
+    neighbours = (random_node(), random_node(), random_node())
+    neighbours_msg_payload = [
+        [n.address.to_endpoint() + [n.pubkey.to_bytes()] for n in neighbours],
+        discovery._get_msg_expiration()]
+    recv_neighbours_coroutine = asyncio.coroutine(
+        lambda: proto.recv_neighbours_v4(node, neighbours_msg_payload, b''))
+    asyncio.ensure_future(recv_neighbours_coroutine())
+
+    received_neighbours = await proto.wait_neighbours(node)
+
+    assert neighbours == received_neighbours
+    # Ensure wait_neighbours() cleaned up after itself.
+    assert node not in proto.neighbours_callbacks
+
+    # If wait_neighbours() times out, we get an empty list of neighbours.
+    received_neighbours = await proto.wait_neighbours(node)
+
+    assert received_neighbours == tuple()
+    assert node not in proto.neighbours_callbacks
+
+
+@pytest.mark.asyncio
+async def test_bond():
+    proto = MockDiscoveryProtocol([])
+    node = random_node()
+
+    token = b'token'
+    # Do not send pings, instead simply return the pingid we'd expect back together with the pong.
+    proto.send_ping_v4 = lambda remote: token
+
+    # Pretend we get a pong from the node we are bonding with.
+    proto.wait_pong_v4 = asyncio.coroutine(lambda n, t: t == token and n == node)
+
+    bonded = await proto.bond(node)
+
+    assert bonded
+
+    # If we try to bond with any other nodes we'll timeout and bond() will return False.
+    node2 = random_node()
+    bonded = await proto.bond(node2)
+
+    assert not bonded
+
+
+def test_update_routing_table():
+    proto = MockDiscoveryProtocol([])
+    node = random_node()
+
+    assert proto.update_routing_table(node) is None
+
+    assert node in proto.routing
+
+
+@pytest.mark.asyncio
+async def test_update_routing_table_triggers_bond_if_eviction_candidate():
+    proto = MockDiscoveryProtocol([])
+    old_node, new_node = random_node(), random_node()
+
+    bond_called = False
+
+    def bond(node):
+        nonlocal bond_called
+        bond_called = True
+        assert node == old_node
+
+    proto.bond = asyncio.coroutine(bond)
+    # Pretend our routing table failed to add the new node by returning the least recently seen
+    # node for an eviction check.
+    proto.routing.add_node = lambda n: old_node
+
+    proto.update_routing_table(new_node)
+
+    assert new_node not in proto.routing
+    # The update_routing_table() call above will have scheduled a future call to proto.bond() so
+    # we need to yield here to give it a chance to run.
+    await asyncio.sleep(0.001)
+    assert bond_called
+
+
+def test_get_max_neighbours_per_packet():
+    proto = get_discovery_protocol()
+    # This test is just a safeguard against changes that inadvertently modify the behaviour of
+    # _get_max_neighbours_per_packet().
+    assert proto._get_max_neighbours_per_packet() == 12
+
+
+def test_pack():
+    sender, recipient = random_address(), random_address()
+    version = rlp.sedes.big_endian_int.serialize(discovery.PROTO_VERSION)
+    payload = (version, sender.to_endpoint(), recipient.to_endpoint())
+    privkey = keys.PrivateKey(keccak(b"seed"))
+
+    message = discovery._pack_v4(discovery.CMD_PING.id, payload, privkey)
+
+    pubkey, cmd_id, payload, _ = discovery._unpack_v4(message)
+    assert pubkey == privkey.public_key
+    assert cmd_id == discovery.CMD_PING.id
+    assert len(payload) == discovery.CMD_PING.elem_count
+
+
+def test_unpack_eip8_packets():
+    # Test our _unpack() function against the sample packets specified in
+    # https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8.md
+    for cmd, packets in eip8_packets.items():
+        for _, packet in packets.items():
+            pubkey, cmd_id, payload, _ = discovery._unpack_v4(packet)
+            assert pubkey.to_hex() == '0xca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be00812904767bf5ccd1fc7f'  # noqa: E501
+            assert cmd.id == cmd_id
+            assert cmd.elem_count == len(payload)
+
+
+def test_v5_handlers(monkeypatch):
+    # Ensure we dispatch v5 messages to the appropriate handlers.
+    # These are hex-encoded messages sent by geth over the wire, obtained via wireshark using the
+    # ethereum dissectors (https://github.com/ConsenSys/ethereum-dissectors).
+    v5_handlers = dict(
+        recv_topic_register='74656d706f7261727920646973636f766572792076354b1f9f999e3cf283e42270742eb3b52b1c0b63ede116ea58632517ffccc7516c794f6fc20f199b3a3a887f3e961b453bb9213eebad4581aaf9b2a60da7e5ba7b0106e2da954c455332406434653536373430663837366165663883666f6f8204d283666f6f',  # noqa: E501
+        recv_pong_v5='74656d706f7261727920646973636f766572792076356cb538da9382c022cc6d9b860b7cc7660718c731e1e6331de86a7cabfba8f01c061b5d6c09dd84de1d6c653536bb8ad31fb140d55d317dfaea5225a6907f49450102f855cb84a5a587f2827660827660a0b484b40a3712766dbbe8498f110bab968a543f9d0d57ec4cfa3b38b32ef2f237831f5ca3a0bd1ea218eaf7cddc6b068a414ae08876315f92bd134e214d5f3961d1a3e8e35b4ec13c',  # noqa: E501
+        recv_ping_v5='74656d706f7261727920646973636f76657279207635c26911f1d2a320f17fa683397028e6cc7ebe114623e28e933d870634aa6050f45960679170192ec0f133dbc3f4e627eef468dbdb48bf4a7848412938da21be8a0001f84104d79000000000000000000000000000000000827660827660cb84b0201d9282848b82848b845b7e5593d6954c4553324064346535363734306638373661656638',  # noqa: E501
+        recv_find_nodehash='74656d706f7261727920646973636f7665727920763558dc895847c5d2cc9ab6f722f25b9ff1b9c188af6ff7ed7c716a3cde2e93f3ec1e2b897acb1a33aa1d345c72ea34912287b21480c80ef99241d4bd9fd53711ee0105e6a038f7bb96e94bcd39866baa56038367ad6145de1ee8f4a8b0993ebdf8883a0ad8845b7e5593',  # noqa: E501
+        recv_topic_query='74656d706f7261727920646973636f76657279207635308621f1ed59a67613da52da3f84bac3d927d0dc1650b27552b10a0a823fb2133cebf3680f68bf88457bb0c07787031357430985d03afa1af0574e8ef0eab7fc0007d7954c455332406434653536373430663837366165663880',  # noqa: E501
+        recv_topic_nodes='74656d706f7261727920646973636f76657279207635e33166b59d20f206f0df2502be59186cb971c76ee91dba94ea9b1bbeb1308a5f4efbdf945ead9ba89d7c2c55d5d841dacdef69a455c98e1a5415e489508afa450008f87ea0cff0456ecbf2e6b0a40bc6541bd209c60ced192509470b405c256a17443674b3f85bf8599000000000000000000000ffff904c1f9c82765f82765fb840e7d624c642b86d3d48cea3e395305345c3a0226fc4c2dfdfbeb94cb6891e5e72b4467c69684ac14b072d2e4fa9c7a731cc1fdf0283abe41186d00b4c879f80ed',  # noqa: E501
+        recv_neighbours_v5='74656d706f7261727920646973636f766572792076358f6671ae9611c82c9cb04538aeed13a8b4e8eb8ad0d0dbba4b161ded52b195846c6086a0d42eef44cfcc0b793a0b9420613727958a8956139c127810b94d4e830004f90174f9016cf8599000000000000000000000ffff59401a22826597826597b840d723e264da67820fb0cedb0d03d5d975cc82bffdadd2879f3e5fa58b5525de5fdd0b90002bba44ac9232247dfbccb2a730e5ea98201bab1f1fe72422aa58143ff8599000000000000000000000ffffae6c601a82765f82765fb840779f19056e0a0486c3f6838896a931bf920cd8f551f664022a50690d4cca4730b50a97058aac11a5aa0cc55db6f9207e12a9cd389269f414a98e5b6a2f6c9f89f8599000000000000000000000ffff287603df827663827663b84085c85d7143ae8bb96924f2b54f1b3e70d8c4d367af305325d30a61385a432f247d2c75c45c6b4a60335060d072d7f5b35dd1d4c45f76941f62a4f83b6e75daaff8599000000000000000000000ffff0d4231b0820419820419b8407b46cc366b6cbaec088a7d15688a2c12bb8ba4cf7ee8e01b22ab534829f9ff13f7cc4130f10a4021f7d77e9b9c80a9777f5ddc035efb130fe3b6786434367973845b7e5569',  # noqa: E501
+    )
+
+    proto = get_discovery_protocol()
+    addr = random_address()
+    for handler, msg in v5_handlers.items():
+        mock_handler = MockHandler()
+        monkeypatch.setattr(proto, handler, mock_handler)
+        proto.datagram_received(decode_hex(msg), (addr.ip, addr.udp_port))
+        assert mock_handler.called
+
+
+def test_ping_pong_v5():
+    alice = get_discovery_protocol(b"alice")
+    bob = get_discovery_protocol(b"bob")
+
+    # Connect alice's and bob's transports directly so we don't need to deal with the complexities
+    # of going over the wire.
+    link_transports(alice, bob)
+
+    # Collect all pongs received by alice in a list for later inspection.
+    received_pongs = []
+    alice.recv_pong_v5 = lambda node, payload, hash_, _: received_pongs.append((node, payload))
+
+    topics = [b'foo', b'bar']
+    token = alice.send_ping_v5(bob.this_node, topics)
+
+    assert len(received_pongs) == 1
+    node, payload = received_pongs[0]
+    _, reply_token, _, topic_hash, _, _ = payload
+    assert node.id == bob.this_node.id
+    assert token == reply_token
+    assert topic_hash == keccak(rlp.encode(topics))
+
+
+def test_find_node_neighbours_v5():
+    _test_find_node_neighbours(use_v5=True)
+
+
+@pytest.mark.asyncio
+async def test_topic_query(event_loop):
+    bob = await get_listening_discovery_protocol(event_loop)
+    les_nodes = [random_node() for _ in range(10)]
+    topic = b'les'
+    for n in les_nodes:
+        bob.topic_table.add_node(n, topic)
+    alice = await get_listening_discovery_protocol(event_loop)
+
+    echo = alice.send_topic_query(bob.this_node, topic)
+    received_nodes = await alice.wait_topic_nodes(bob.this_node, echo)
+
+    assert len(received_nodes) == 10
+    assert sorted(received_nodes) == sorted(les_nodes)
+
+
+@pytest.mark.asyncio
+async def test_topic_register(event_loop):
+    bob = await get_listening_discovery_protocol(event_loop)
+    alice = await get_listening_discovery_protocol(event_loop)
+    topics = [b'les', b'les2']
+
+    # In order to register ourselves under a given topic we need to first get a ticket.
+    ticket = await bob.get_ticket(alice.this_node, topics)
+
+    assert ticket is not None
+    assert ticket.topics == topics
+    assert ticket.node == alice.this_node
+    assert len(ticket.registration_times) == 2
+
+    # Now we register ourselves under one of the topics for which we have a ticket.
+    topic_idx = 0
+    bob.send_topic_register(alice.this_node, ticket.topics, topic_idx, ticket.pong)
+    await asyncio.sleep(0.2)
+
+    topic_nodes = alice.topic_table.get_nodes(topics[topic_idx])
+    assert len(topic_nodes) == 1
+    assert topic_nodes[0] == bob.this_node
+
+
+def test_topic_table():
+    table = discovery.TopicTable(logging.getLogger("test"))
+    topic = b'topic'
+    node = random_node()
+
+    table.add_node(node, topic)
+    assert len(table.get_nodes(topic)) == 1
+    assert table.get_nodes(topic)[0] == node
+
+    node2 = random_node()
+    table.add_node(node2, topic)
+    assert len(table.get_nodes(topic)) == 2
+    assert table.get_nodes(topic)[1] == node2
+
+    # Adding the same node again won't cause a duplicate entry to be added.
+    table.add_node(node, topic)
+    assert len(table.get_nodes(topic)) == 2
+
+    # When we reach the max number of entries for a given topic, the first added items are evicted
+    # to make room for the new ones.
+    for _ in range(discovery.MAX_ENTRIES_PER_TOPIC + 2):
+        table.add_node(random_node(), topic)
+
+    assert node not in table.get_nodes(topic)
+    assert node2 not in table.get_nodes(topic)
+
+
+def test_get_v5_topic():
+    les_topic = discovery.get_v5_topic(LESProtocol, ROPSTEN_GENESIS_HEADER.hash)
+    assert les_topic == b'LES@41941023680923e0'
+    les2_topic = discovery.get_v5_topic(LESProtocolV2, ROPSTEN_GENESIS_HEADER.hash)
+    assert les2_topic == b'LES2@41941023680923e0'
+
+
+def remove_whitespace(s):
+    return re.sub(r"\s+", "", s)
+
+
+eip8_packets = {
+    discovery.CMD_PING: dict(
+        # ping packet with version 4, additional list elements
+        ping1=decode_hex(remove_whitespace('''
+        e9614ccfd9fc3e74360018522d30e1419a143407ffcce748de3e22116b7e8dc92ff74788c0b6663a
+        aa3d67d641936511c8f8d6ad8698b820a7cf9e1be7155e9a241f556658c55428ec0563514365799a
+        4be2be5a685a80971ddcfa80cb422cdd0101ec04cb847f000001820cfa8215a8d790000000000000
+        000000000000000000018208ae820d058443b9a3550102''')),
+
+        # ping packet with version 555, additional list elements and additional random data
+        ping2=decode_hex(remove_whitespace('''
+        577be4349c4dd26768081f58de4c6f375a7a22f3f7adda654d1428637412c3d7fe917cadc56d4e5e
+        7ffae1dbe3efffb9849feb71b262de37977e7c7a44e677295680e9e38ab26bee2fcbae207fba3ff3
+        d74069a50b902a82c9903ed37cc993c50001f83e82022bd79020010db83c4d001500000000abcdef
+        12820cfa8215a8d79020010db885a308d313198a2e037073488208ae82823a8443b9a355c5010203
+        040531b9019afde696e582a78fa8d95ea13ce3297d4afb8ba6433e4154caa5ac6431af1b80ba7602
+        3fa4090c408f6b4bc3701562c031041d4702971d102c9ab7fa5eed4cd6bab8f7af956f7d565ee191
+        7084a95398b6a21eac920fe3dd1345ec0a7ef39367ee69ddf092cbfe5b93e5e568ebc491983c09c7
+        6d922dc3''')),
+    ),
+
+    discovery.CMD_PONG: dict(
+        # pong packet with additional list elements and additional random data
+        pong=decode_hex(remove_whitespace('''
+        09b2428d83348d27cdf7064ad9024f526cebc19e4958f0fdad87c15eb598dd61d08423e0bf66b206
+        9869e1724125f820d851c136684082774f870e614d95a2855d000f05d1648b2d5945470bc187c2d2
+        216fbe870f43ed0909009882e176a46b0102f846d79020010db885a308d313198a2e037073488208
+        ae82823aa0fbc914b16819237dcd8801d7e53f69e9719adecb3cc0e790c57e91ca4461c9548443b9
+        a355c6010203c2040506a0c969a58f6f9095004c0177a6b47f451530cab38966a25cca5cb58f0555
+        42124e''')),
+    ),
+
+    discovery.CMD_FIND_NODE: dict(
+        # findnode packet with additional list elements and additional random data
+        findnode=decode_hex(remove_whitespace('''
+        c7c44041b9f7c7e41934417ebac9a8e1a4c6298f74553f2fcfdcae6ed6fe53163eb3d2b52e39fe91
+        831b8a927bf4fc222c3902202027e5e9eb812195f95d20061ef5cd31d502e47ecb61183f74a504fe
+        04c51e73df81f25c4d506b26db4517490103f84eb840ca634cae0d49acb401d8a4c6b6fe8c55b70d
+        115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be0081290476
+        7bf5ccd1fc7f8443b9a35582999983999999280dc62cc8255c73471e0a61da0c89acdc0e035e260a
+        dd7fc0c04ad9ebf3919644c91cb247affc82b69bd2ca235c71eab8e49737c937a2c396''')),
+    ),
+
+    discovery.CMD_NEIGHBOURS: dict(
+        # neighbours packet with additional list elements and additional random data
+        neighbours=decode_hex(remove_whitespace('''
+        c679fc8fe0b8b12f06577f2e802d34f6fa257e6137a995f6f4cbfc9ee50ed3710faf6e66f932c4c8
+        d81d64343f429651328758b47d3dbc02c4042f0fff6946a50f4a49037a72bb550f3a7872363a83e1
+        b9ee6469856c24eb4ef80b7535bcf99c0004f9015bf90150f84d846321163782115c82115db84031
+        55e1427f85f10a5c9a7755877748041af1bcd8d474ec065eb33df57a97babf54bfd2103575fa8291
+        15d224c523596b401065a97f74010610fce76382c0bf32f84984010203040101b840312c55512422
+        cf9b8a4097e9a6ad79402e87a15ae909a4bfefa22398f03d20951933beea1e4dfa6f968212385e82
+        9f04c2d314fc2d4e255e0d3bc08792b069dbf8599020010db83c4d001500000000abcdef12820d05
+        820d05b84038643200b172dcfef857492156971f0e6aa2c538d8b74010f8e140811d53b98c765dd2
+        d96126051913f44582e8c199ad7c6d6819e9a56483f637feaac9448aacf8599020010db885a308d3
+        13198a2e037073488203e78203e8b8408dcab8618c3253b558d459da53bd8fa68935a719aff8b811
+        197101a4b2b47dd2d47295286fc00cc081bb542d760717d1bdd6bec2c37cd72eca367d6dd3b9df73
+        8443b9a355010203b525a138aa34383fec3d2719a0''')),
+    ),
+}
+
+
+def get_discovery_protocol(seed=b"seed", address=None):
+    privkey = keys.PrivateKey(keccak(seed))
+    if address is None:
+        address = random_address()
+    return discovery.DiscoveryProtocol(privkey, address, [], CancelToken("discovery-test"))
+
+
+async def get_listening_discovery_protocol(event_loop):
+    addr = kademlia.Address('127.0.0.1', random.randint(1024, 9999))
+    proto = get_discovery_protocol(os.urandom(4), addr)
+    await event_loop.create_datagram_endpoint(
+        lambda: proto, local_addr=(addr.ip, addr.udp_port), family=socket.AF_INET)
+    return proto
+
+
+def link_transports(proto1, proto2):
+    # Link both protocol's transports directly by having one's sendto() call the other's
+    # datagram_received().
+    proto1.transport = type(
+        "mock-transport",
+        (object,),
+        {"sendto": lambda msg, addr: proto2.datagram_received(msg, addr)},
+    )
+    proto2.transport = type(
+        "mock-transport",
+        (object,),
+        {"sendto": lambda msg, addr: proto1.datagram_received(msg, addr)},
+    )
+
+
+def random_address():
+    return kademlia.Address(
+        '10.0.0.{}'.format(random.randint(0, 255)), random.randint(0, 9999))
+
+
+def random_node():
+    seed = to_bytes(text="".join(random.sample(string.ascii_lowercase, 10)))
+    priv_key = keys.PrivateKey(keccak(seed))
+    return kademlia.Node(priv_key.public_key, random_address())
+
+
+class MockHandler:
+    called = False
+
+    def __call__(self, node, payload, msg_hash, raw_msg):
+        self.called = True
+
+
+class MockDiscoveryProtocol(discovery.DiscoveryProtocol):
+
+    messages = []
+
+    def __init__(self, bootnodes):
+        privkey = keys.PrivateKey(keccak(b"seed"))
+        super().__init__(privkey, random_address(), bootnodes, CancelToken("discovery-test"))
+
+    def send_ping_v4(self, node):
+        echo = hex(random.randint(0, 2**256))[-32:]
+        self.messages.append((node, 'ping', echo))
+        return echo
+
+    def send_pong_v4(self, node, echo):
+        self.messages.append((node, 'pong', echo))
+
+    def send_find_node_v4(self, node, nodeid):
+        self.messages.append((node, 'find_node', nodeid))
+
+    def send_neighbours_v4(self, node, neighbours):
+        self.messages.append((node, 'neighbours', neighbours))

--- a/quarkchain/p2p/tests/test_discovery.py
+++ b/quarkchain/p2p/tests/test_discovery.py
@@ -19,14 +19,26 @@ from eth_hash.auto import keccak
 
 from eth_keys import keys
 
-from cancel_token import CancelToken
+from quarkchain.p2p.cancel_token.token import CancelToken
 
-from eth.chains.ropsten import ROPSTEN_GENESIS_HEADER
-
-from trinity.protocol.les.proto import LESProtocol, LESProtocolV2
 
 from quarkchain.p2p import discovery
 from quarkchain.p2p import kademlia
+
+from quarkchain.core import MinorBlockHeader
+
+from quarkchain.p2p.protocol import (
+    Protocol,
+)
+
+
+class LESProtocol(Protocol):
+    name = 'les'
+    version = 1
+
+
+class LESProtocolV2(LESProtocol):
+    version = 2
 
 
 # Force our tests to fail quickly if they accidentally make network requests.
@@ -411,9 +423,9 @@ def test_topic_table():
 
 
 def test_get_v5_topic():
-    les_topic = discovery.get_v5_topic(LESProtocol, ROPSTEN_GENESIS_HEADER.hash)
+    les_topic = discovery.get_v5_topic(LESProtocol, MinorBlockHeader().get_hash())
     assert les_topic == b'LES@41941023680923e0'
-    les2_topic = discovery.get_v5_topic(LESProtocolV2, ROPSTEN_GENESIS_HEADER.hash)
+    les2_topic = discovery.get_v5_topic(LESProtocolV2, MinorBlockHeader().get_hash())
     assert les2_topic == b'LES2@41941023680923e0'
 
 

--- a/quarkchain/p2p/tests/test_discovery.py
+++ b/quarkchain/p2p/tests/test_discovery.py
@@ -424,9 +424,9 @@ def test_topic_table():
 
 def test_get_v5_topic():
     les_topic = discovery.get_v5_topic(LESProtocol, MinorBlockHeader().get_hash())
-    assert les_topic == b'LES@41941023680923e0'
+    assert les_topic == b'LES@4252b62def95fdd0'
     les2_topic = discovery.get_v5_topic(LESProtocolV2, MinorBlockHeader().get_hash())
-    assert les2_topic == b'LES2@41941023680923e0'
+    assert les2_topic == b'LES2@4252b62def95fdd0'
 
 
 def remove_whitespace(s):


### PR DESCRIPTION
this is the final part of the port of py-evm p2p module
adds discovery service that uses udp to form a Kademlia-like network and find peers
to learn more: https://github.com/fjl/p2p-drafts