### PR TITLE
fix test_monitoring.py; py.test can handle whole quarkchain dir

### DIFF
--- a/quarkchain/evm/tests/conftest.py
+++ b/quarkchain/evm/tests/conftest.py
@@ -1,0 +1,1 @@
+collect_ignore = ["test_state.py"]

--- a/quarkchain/experimental/test_heap.py
+++ b/quarkchain/experimental/test_heap.py
@@ -5,7 +5,7 @@ import random
 import unittest
 
 
-class TestItem:
+class HeapTestItem:
     def __init__(self, value):
         self.value = value
         self.heap_index = 0
@@ -20,7 +20,7 @@ class TestItem:
 class TestHeap(unittest.TestCase):
     def test_heap_sort(self):
         N = 100
-        data = [TestItem(i) for i in range(N)]
+        data = [HeapTestItem(i) for i in range(N)]
         random.shuffle(data)
         h = heap.Heap(lambda x, y: x.value - y.value)
         for d in data:
@@ -33,7 +33,7 @@ class TestHeap(unittest.TestCase):
 
     def test_heap_random_pop(self):
         N = 100
-        data = [TestItem(i) for i in range(N)]
+        data = [HeapTestItem(i) for i in range(N)]
         random.shuffle(data)
         h = heap.Heap(lambda x, y: x.value - y.value)
         for d in data:

--- a/quarkchain/tools/tests/test_monitoring.py
+++ b/quarkchain/tools/tests/test_monitoring.py
@@ -1,5 +1,5 @@
 import unittest
-from tools.monitoring import crawl_recursive, crawl_bfs
+from quarkchain.tools.monitoring import crawl_recursive, crawl_bfs
 
 
 class TestCrawl(unittest.TestCase):


### PR DESCRIPTION
now run tests with:
```
python -m pytest quarkchain
```
get coverage data with:
```
python -m pytest --cov quarkchain quarkchain
```
pytest is so much better than -m unittest
