### PR TITLE
Use threads for external mining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ celerybeat-schedule
 env/
 venv/
 pypy-env/
+py3-env/
 ENV/
 env.bak/
 venv.bak/

--- a/quarkchain/tools/external_miner.py
+++ b/quarkchain/tools/external_miner.py
@@ -2,12 +2,14 @@ import argparse
 import json
 import logging
 import random
+import signal
 import threading
 import time
+from itertools import cycle
 from typing import Dict, Optional, List, Tuple
 
 import jsonrpcclient
-from aioprocessing import AioProcess, AioQueue
+from queue import Queue
 
 from quarkchain.cluster.miner import Miner, MiningWork, MiningResult
 from quarkchain.config import ConsensusType
@@ -16,16 +18,15 @@ from quarkchain.config import ConsensusType
 logging.getLogger("jsonrpcclient.client.request").setLevel(logging.WARNING)
 logging.getLogger("jsonrpcclient.client.response").setLevel(logging.WARNING)
 
-logger = logging.getLogger("quarkchain.tools.external_miner")
-logger.setLevel(logging.INFO)
-
 
 def get_work_rpc(
-    shard: Optional[int], host: str = "localhost", jrpc_port: int = 38391
+    shard: Optional[int], host: str = "localhost", jrpc_port: int = 38391, timeout=3
 ) -> MiningWork:
     json_rpc_url = "http://{}:{}".format(host, jrpc_port)
-    header_hash, height, diff = jsonrpcclient.request(
-        json_rpc_url, "getWork", hex(shard) if shard is not None else None
+    cli = jsonrpcclient.HTTPClient(json_rpc_url)
+    header_hash, height, diff = cli.send(
+        jsonrpcclient.Request("getWork", hex(shard) if shard is not None else None),
+        timeout=timeout,
     )
     return MiningWork(bytes.fromhex(header_hash[2:]), int(height, 16), int(diff, 16))
 
@@ -35,15 +36,19 @@ def submit_work_rpc(
     res: MiningResult,
     host: str = "localhost",
     jrpc_port: int = 38391,
+    timeout=3,
 ) -> bool:
     json_rpc_url = "http://{}:{}".format(host, jrpc_port)
-    success = jsonrpcclient.request(
-        json_rpc_url,
-        "submitWork",
-        hex(shard) if shard is not None else None,
-        "0x" + res.header_hash.hex(),
-        hex(res.nonce),
-        "0x" + res.mixhash.hex(),
+    cli = jsonrpcclient.HTTPClient(json_rpc_url)
+    success = cli.send(
+        jsonrpcclient.Request(
+            "submitWork",
+            hex(shard) if shard is not None else None,
+            "0x" + res.header_hash.hex(),
+            hex(res.nonce),
+            "0x" + res.mixhash.hex(),
+        ),
+        timeout=timeout,
     )
     return success
 
@@ -55,30 +60,31 @@ def repr_shard(shard_id):
 class ExternalMiner(threading.Thread):
     """One external miner could handles multiple shards."""
 
-    def __init__(self, configs):
+    def __init__(self, configs, stopper: threading.Event):
         super().__init__()
         self.configs = configs
-        self.input_q = AioQueue()
-        self.output_q = AioQueue()
-        self.process = None
+        self.stopper = stopper
+        self.input_q = Queue()
+        self.output_q = Queue()
 
     def run(self):
-        work_map = {}  # type: Dict[bytes, Tuple[MiningWork, int]]
+        # header hash -> (work, shard)
+        work_map = {}  # type: Dict[bytes, Tuple[MiningWork, Optional[int]]]
 
         # start the thread to get work
-        def get_work():
-            # hash -> shard
-            nonlocal work_map, self
+        def get_work(configs, stopper, input_q, output_q):
+            nonlocal work_map
             # shard -> work
             existing_work = {}  # type: Dict[int, MiningWork]
-            while True:
-                for config in self.configs:
+            mining_thread = None
+            while not stopper.is_set():
+                for config in configs:
                     shard_id = config["shard_id"]
                     try:
                         work = get_work_rpc(shard_id)
-                    except Exception:
+                    except Exception as e:
                         # ignore network errors and try next one
-                        logger.error("Failed to get work")
+                        print("Failed to get work", e)
                         continue
                     # skip duplicate work
                     if (
@@ -86,48 +92,63 @@ class ExternalMiner(threading.Thread):
                         and existing_work[shard_id].hash == work.hash
                     ):
                         continue
+                    # bookkeeping
+                    existing_work[shard_id] = work
+                    work_map[work.hash] = (work, shard_id)
+
                     mining_params = {
                         "consensus_type": config["consensus_type"],
                         "shard": shard_id,
                     }
-                    if self.process:
-                        self.input_q.put((work, mining_params))
-                        logger.info(
-                            "Pushed work to %s height %d"
+                    if mining_thread:
+                        input_q.put((work, mining_params), timeout=10)
+                        print(
+                            "Added work to queue of %s height %d"
                             % (repr_shard(shard_id), work.height)
                         )
                     else:
-                        # start the process to mine
-                        self.process = AioProcess(
+                        # start the thread to mine
+                        mining_thread = threading.Thread(
                             target=Miner.mine_loop,
-                            args=(work, mining_params, self.input_q, self.output_q),
+                            # target=loop,
+                            args=(work, mining_params, input_q, output_q),
                         )
-                        self.process.start()
-                        logger.info(
-                            "Started mining process for %s" % repr_shard(shard_id)
-                        )
-                    # bookkeeping
-                    existing_work[shard_id] = work
-                    work_map[work.hash] = (work, shard_id)
-                # random sleep 1~2 secs
-                time.sleep(random.uniform(1.0, 2.0))
+                        mining_thread.start()
+                        print("Started mining thread on %s" % repr_shard(shard_id))
 
-        get_work_thread = threading.Thread(target=get_work)
+                # random sleep
+                time.sleep(random.uniform(2.0, 3.0))
+            # loop stopped, notify the mining thread
+            if mining_thread:
+                input_q.put((None, {}))
+                mining_thread.join()
+
+            # END OF `get_work` FUNCTION
+
+        get_work_thread = threading.Thread(
+            target=get_work,
+            args=(self.configs, self.stopper, self.input_q, self.output_q),
+        )
         get_work_thread.start()
 
         # the current thread handles the work submission
         while True:
-            res = self.output_q.get(block=True)  # type: MiningResult
-            work, shard_id = work_map[res.header_hash]
+            res = self.output_q.get(block=True)  # type: Optional[MiningResult]
+            if not res:
+                # get_work terminated -> mining terminated
+                # join and terminate itself too
+                get_work_thread.join()
+                return
+            work, shard_id = work_map.pop(res.header_hash)
             while True:
                 try:
                     success = submit_work_rpc(shard_id, res)
                     break
-                except Exception:
-                    logger.error("Failed to submit work, backing off...")
+                except Exception as e:
+                    print("Failed to submit work, backing off...", e)
                     time.sleep(0.5)
 
-            logger.info(
+            print(
                 "Mining result submission result: %s for %s height %d"
                 % (
                     "success" if success else "failure",
@@ -135,44 +156,69 @@ class ExternalMiner(threading.Thread):
                     work.height,
                 )
             )
-            del work_map[res.header_hash]  # clear bookkeeping
 
 
-if __name__ == "__main__":
+class SigHandler:
+    """Graceful exit for mining threads."""
+
+    def __init__(self, stopper: threading.Event, threads: List[threading.Thread]):
+        self.stopper = stopper
+        self.threads = threads
+
+    def __call__(self, signum, frame):
+        self.stopper.set()
+        for thread in self.threads:
+            thread.join()
+        print("Stop mining")
+
+
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--config",
         required=True,
         type=str,
-        help="path to config json file, same as the config running cluster",
+        help="<Required> path to config json file, same as the config running cluster",
     )
-    parser.add_argument("--worker", type=int, help="number of workers", default=8)
+    parser.add_argument(
+        "-s",
+        "--shards",
+        required=True,
+        nargs="+",
+        help='<Required> specify shards to mine, use "R" to indicate root chain',
+    )
+    parser.add_argument(
+        "--worker", type=int, help="number of worker threads", default=1
+    )
     args = parser.parse_args()
 
     with open(args.config) as f:
         config_json = json.load(f)
 
+    # 1 worker config <-> 1 mining thread <-> 1 or more shards
     worker_configs = [[] for _ in range(args.worker)]  # type: List[List[Dict]]
 
-    for i, shard_config in enumerate(config_json["QUARKCHAIN"]["SHARD_LIST"]):
-        config = {
-            "shard_id": i,
-            "consensus_type": ConsensusType[shard_config["CONSENSUS_TYPE"]],
-        }
-        worker_configs[i % args.worker].append(config)
+    for worker_i, shard_str in zip(cycle(range(args.worker)), args.shards):
+        if shard_str.isnumeric():
+            shard_i = int(shard_str)
+            c = config_json["QUARKCHAIN"]["SHARD_LIST"][shard_i]
+        else:
+            shard_i = None
+            c = config_json["QUARKCHAIN"]["ROOT"]
+        worker_configs[worker_i].append(
+            {"shard_id": shard_i, "consensus_type": ConsensusType[c["CONSENSUS_TYPE"]]}
+        )
 
-    # FIXME: manually add another worker dedicated for root chain
-    worker_configs.append(
-        [
-            {
-                "shard_id": None,
-                "consensus_type": ConsensusType[
-                    config_json["QUARKCHAIN"]["ROOT"]["CONSENSUS_TYPE"]
-                ],
-            }
-        ]
-    )
-
-    for config_list in worker_configs:
-        ext_miner = ExternalMiner(config_list)
+    miners = []
+    stopper = threading.Event()
+    for i, config_list in enumerate(worker_configs):
+        ext_miner = ExternalMiner(config_list, stopper)
         ext_miner.start()
+        miners.append(ext_miner)
+
+    sig_handler = SigHandler(stopper, miners)
+    signal.signal(signal.SIGINT, sig_handler)
+
+
+if __name__ == "__main__":
+    main()

--- a/quarkchain/tools/external_miner.py
+++ b/quarkchain/tools/external_miner.py
@@ -101,7 +101,7 @@ class ExternalMiner(threading.Thread):
                         "shard": shard_id,
                     }
                     if mining_thread:
-                        input_q.put((work, mining_params), timeout=10)
+                        input_q.put((work, mining_params))
                         print(
                             "Added work to queue of %s height %d"
                             % (repr_shard(shard_id), work.height)
@@ -196,7 +196,9 @@ def main():
         config_json = json.load(f)
 
     # 1 worker config <-> 1 mining thread <-> 1 or more shards
-    worker_configs = [[] for _ in range(args.worker)]  # type: List[List[Dict]]
+    worker_configs = [
+        [] for _ in range(min(args.worker, len(args.shards)))
+    ]  # type: List[List[Dict]]
 
     for worker_i, shard_str in zip(cycle(range(args.worker)), args.shards):
         if shard_str.isnumeric():
@@ -211,7 +213,7 @@ def main():
 
     miners = []
     stopper = threading.Event()
-    for i, config_list in enumerate(worker_configs):
+    for config_list in worker_configs:
         ext_miner = ExternalMiner(config_list, stopper)
         ext_miner.start()
         miners.append(ext_miner)

--- a/quarkchain/tools/external_miner.py
+++ b/quarkchain/tools/external_miner.py
@@ -1,4 +1,5 @@
 import argparse
+import copy
 import json
 import logging
 import random
@@ -74,11 +75,16 @@ class ExternalMiner(threading.Thread):
         # start the thread to get work
         def get_work(configs, stopper, input_q, output_q):
             nonlocal work_map
+            configs = copy.copy(configs)
             # shard -> work
             existing_work = {}  # type: Dict[int, MiningWork]
             mining_thread = None
             while not stopper.is_set():
+                total_wait_time = random.uniform(2.0, 3.0)
+                random.shuffle(configs)
                 for config in configs:
+                    # random sleep between each shard
+                    time.sleep(total_wait_time / len(configs))
                     shard_id = config["shard_id"]
                     try:
                         work = get_work_rpc(shard_id)
@@ -116,8 +122,6 @@ class ExternalMiner(threading.Thread):
                         mining_thread.start()
                         print("Started mining thread on %s" % repr_shard(shard_id))
 
-                # random sleep
-                time.sleep(random.uniform(2.0, 3.0))
             # loop stopped, notify the mining thread
             if mining_thread:
                 input_q.put((None, {}))

--- a/quarkchain/tools/external_miner_manager.sh
+++ b/quarkchain/tools/external_miner_manager.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -u; set -e
+
+type jq >/dev/null 2>&1 || { echo >&2 "Please install jq."; exit 1; }
+
+# c -> config, p -> process, t -> thread
+# eg: external_miner_manager.sh -c ~/Documents/config.json -p 9 -t 1
+while getopts ":c:p:t:" opt; do
+	case ${opt} in
+		c )
+			config=$OPTARG
+			;;
+		p )
+			process=$OPTARG
+			;;
+		t )
+			thread=$OPTARG
+			;;
+		\? )
+			echo "Invalid option: $OPTARG" 1>&2
+			exit 1
+			;;
+		: )
+			echo "Invalid option: $OPTARG requires an argument" 1>&2
+			exit 1
+			;;
+	esac
+done
+shift $((OPTIND -1))
+
+shards=()
+shard_cnt=$(jq '.QUARKCHAIN.SHARD_LIST | length' < $config)
+end_shard=$(( $shard_cnt - 1))
+for i in $(seq 0 $end_shard); do
+	shards+=("$i")
+done
+shards+=("R")  # root chain
+
+shards_by_process=()
+i=0
+for shard in "${shards[@]}"; do
+	shards_by_process[$(( i % $process ))]+=" $shard"
+	i=$(( $i + 1))
+done
+
+miner_py_path="$( cd "$(dirname "$0")" ; pwd -P )/external_miner.py"
+for shards_per_process in "${shards_by_process[@]}"; do
+	python $miner_py_path \
+		--config $config \
+		--worker $thread \
+		--shards $shards_per_process &
+done
+
+wait

--- a/quarkchain/tools/external_miner_manager.sh
+++ b/quarkchain/tools/external_miner_manager.sh
@@ -4,7 +4,7 @@ set -u; set -e
 
 type jq >/dev/null 2>&1 || { echo >&2 "Please install jq."; exit 1; }
 
-# c -> config, p -> process, t -> thread
+# c -> config, p -> process number, t -> threads per miner process
 # eg: external_miner_manager.sh -c ~/Documents/config.json -p 9 -t 1
 while getopts ":c:p:t:" opt; do
 	case ${opt} in


### PR DESCRIPTION
saw some mysterious problems with previous method using `multiprocessing.Process`
and `multiprocessing.Queue` for managing mining.

turned to threads, while GIL may add performance cost, it can be
alleviated by a separate shell script to run multiple external miners in
parallel.

