### PR TITLE
prevent double peer connection with contextlib

### DIFF
--- a/quarkchain/p2p/poc/trinity_server.py
+++ b/quarkchain/p2p/poc/trinity_server.py
@@ -225,6 +225,14 @@ class BaseServer(BaseService):
             remote=initiator_remote, connection=connection, inbound=True
         )
 
+        if (
+            peer.remote in self.peer_pool.connected_nodes
+            or peer.remote.pubkey in self.peer_pool.dialedout_pubkeys
+        ):
+            self.logger.debug("already connected or dialed, disconnecting...")
+            await peer.disconnect(DisconnectReason.already_connected)
+            return
+
         if self.peer_pool.is_full:
             await peer.disconnect(DisconnectReason.too_many_peers)
             return


### PR DESCRIPTION
test plan to run 2 nodes:
```
python trinity_node.py --logging_level=debug
python trinity_node.py --privkey="" --listen_port=29001 --logging_level=debug
```
there are other ways to prevent this (eg using a lock), and it looks geth or py-evm does not handle this at all (due to the larger scale and less likelihood that 2 peers try to connect each other at the same time)

all approaches are susceptible to the case where two nodes simultaneously discover each other and start sending handshake to the other node. If we use locks, this will cause dead lock (each node's dial out method holding the lock and thus preventing the other to come in, think of a case where both you and your friend is trying to call each other) in a network environment, and it would be quite tricky to get rid of (perhaps timeout will help).

The approach here can fail fast in the case where two nodes are trying to connect to each other at once. In worst case scenario they both refuse the incoming connection from the other party because of the ongoing dial out, but this is acceptable as they will just try again