### PR TITLE
[rewards p2] Use tax rate when applying tx

### DIFF
--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -777,7 +777,7 @@ class MasterServer:
         for response in responses:
             _, response, _ = response
             if response.error_code != 0:
-                return (None, None)
+                return None, None
             for headers_info in response.headers_info_list:
                 if headers_info.branch.get_shard_size() != self.__get_shard_size():
                     Logger.error(

--- a/quarkchain/cluster/root_state.py
+++ b/quarkchain/cluster/root_state.py
@@ -210,7 +210,7 @@ class RootState:
 
         tracking_data["creation_ms"] = time_ms() - tracking_data["inception"]
         block.tracking_data = json.dumps(tracking_data).encode("utf-8")
-        return block.finalize(quarkash=coinbase_amount, coinbase_address=address)
+        return block.finalize(coinbase_amount=coinbase_amount, coinbase_address=address)
 
     def validate_block_header(self, block_header: RootBlockHeader, block_hash=None):
         """ Validate the block header.

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import time
 from collections import defaultdict
+from fractions import Fraction
 from typing import Optional, Tuple, List, Union, Dict
 
 from quarkchain.cluster.filter import Filter
@@ -9,7 +10,6 @@ from quarkchain.cluster.miner import validate_seal
 from quarkchain.cluster.neighbor import is_neighbor
 from quarkchain.cluster.rpc import ShardStats, TransactionDetail
 from quarkchain.cluster.shard_db_operator import ShardDbOperator
-from quarkchain.config import NetworkId
 from quarkchain.core import (
     calculate_merkle_root,
     Address,
@@ -696,16 +696,12 @@ class ShardState:
                     evm_state.xshard_receive_gas_used,
                 )
             )
-
-        # The rest fee goes to root block
-        if evm_state.block_fee // 2 != block.header.coinbase_amount:
+        coinbase_amount = self.get_coinbase_amount() + evm_state.block_fee
+        if coinbase_amount != block.header.coinbase_amount:
             raise ValueError("Coinbase reward incorrect")
 
         if evm_state.bloom != block.header.bloom:
             raise ValueError("Bloom mismatch")
-
-        # TODO: Add block reward to coinbase
-        self.reward_calc.get_block_reward()
 
         self.db.put_minor_block(block, x_shard_receive_tx_list)
 
@@ -777,11 +773,24 @@ class ShardState:
             )
         return evm_state.xshard_list
 
+    def get_coinbase_amount(self) -> int:
+        local_fee_rate = (
+            1 - self.env.quark_chain_config.reward_tax_rate
+        )  # type: Fraction
+        coinbase_amount = (
+            self.env.quark_chain_config.SHARD_LIST[self.shard_id].COINBASE_AMOUNT
+            * local_fee_rate.numerator
+            // local_fee_rate.denominator
+        )
+        return coinbase_amount
+
     def get_tip(self) -> MinorBlock:
         return self.db.get_minor_block_by_hash(self.header_tip.get_hash())
 
     def finalize_and_add_block(self, block):
-        block.finalize(evm_state=self.run_block(block))
+        evm_state = self.run_block(block)
+        coinbase_amount = self.get_coinbase_amount() + evm_state.block_fee
+        block.finalize(evm_state=evm_state, coinbase_amount=coinbase_amount)
         self.add_block(block)
 
     def get_balance(self, recipient: bytes, height: Optional[int] = None) -> int:
@@ -1003,7 +1012,8 @@ class ShardState:
         # Update actual root hash
         evm_state.commit()
 
-        block.finalize(evm_state=evm_state)
+        coinbase_amount = self.get_coinbase_amount() + evm_state.block_fee
+        block.finalize(evm_state=evm_state, coinbase_amount=coinbase_amount)
 
         tracking_data["creation_ms"] = time_ms() - tracking_data["inception"]
         block.tracking_data = json.dumps(tracking_data).encode("utf-8")
@@ -1199,7 +1209,9 @@ class ShardState:
 
     def __run_one_cross_shard_tx_list_by_root_block_hash(self, r_hash, evm_state):
         tx_list = self.__get_cross_shard_tx_list_by_root_block_hash(r_hash)
-        local_fee_rate = 1.0 - self.env.quark_chain_config.REWARD_TAX_RATE
+        local_fee_rate = (
+            1 - self.env.quark_chain_config.reward_tax_rate
+        )  # type: Fraction
 
         for tx in tx_list:
             evm_state.delta_balance(tx.to_address.recipient, tx.value)
@@ -1208,7 +1220,12 @@ class ShardState:
                 + (opcodes.GTXXSHARDCOST if tx.gas_price != 0 else 0),
                 evm_state.gas_limit,
             )
-            xshard_fee = int(opcodes.GTXXSHARDCOST * tx.gas_price * local_fee_rate)
+            xshard_fee = (
+                opcodes.GTXXSHARDCOST
+                * tx.gas_price
+                * local_fee_rate.numerator
+                // local_fee_rate.denominator
+            )
             evm_state.block_fee += xshard_fee
             evm_state.delta_balance(evm_state.block_coinbase, xshard_fee)
 

--- a/quarkchain/cluster/tests/test_cluster.py
+++ b/quarkchain/cluster/tests/test_cluster.py
@@ -90,10 +90,10 @@ class TestCluster(unittest.TestCase):
             self.assertEqual(block1.header.branch.value, 0b10)
             self.assertEqual(len(block1.tx_list), 1)
 
-            originalBalanceAcc1 = call_async(
+            original_balance_acc1 = call_async(
                 master.get_primary_account_data(acc1)
             ).balance
-            gasPaid = (opcodes.GTXXSHARDCOST + opcodes.GTXCOST) * 3
+            gas_paid = (opcodes.GTXXSHARDCOST + opcodes.GTXCOST) * 3
             self.assertTrue(
                 call_async(
                     master.add_raw_minor_block(block1.header.branch, block1.serialize())
@@ -101,7 +101,7 @@ class TestCluster(unittest.TestCase):
             )
             self.assertEqual(
                 call_async(master.get_primary_account_data(acc1)).balance,
-                originalBalanceAcc1 - 54321 - gasPaid,
+                original_balance_acc1 - 54321 - gas_paid,
             )
             self.assertEqual(
                 slaves[1].shards[Branch(3)].state.get_balance(acc3.recipient), 0
@@ -236,10 +236,10 @@ class TestCluster(unittest.TestCase):
             shard_state = clusters[0].slave_list[0].shards[Branch(0b10)].state
             b1 = shard_state.get_tip().create_block_to_append()
             b1.finalize(evm_state=shard_state.run_block(b1))
-            addResult = call_async(
+            add_result = call_async(
                 clusters[0].master.add_raw_minor_block(b1.header.branch, b1.serialize())
             )
-            self.assertTrue(addResult)
+            self.assertTrue(add_result)
 
             # Make sure the xshard list is not broadcasted to the other shard
             self.assertFalse(
@@ -278,35 +278,35 @@ class TestCluster(unittest.TestCase):
             # add blocks in cluster 0
             block_header_list = [clusters[0].get_shard_state(0).header_tip]
             for i in range(7):
-                shardState0 = clusters[0].slave_list[0].shards[Branch(0b10)].state
-                b1 = shardState0.get_tip().create_block_to_append()
-                b1.finalize(evm_state=shardState0.run_block(b1))
-                addResult = call_async(
+                shard_state0 = clusters[0].slave_list[0].shards[Branch(0b10)].state
+                b1 = shard_state0.get_tip().create_block_to_append()
+                b1.finalize(evm_state=shard_state0.run_block(b1))
+                add_result = call_async(
                     clusters[0].master.add_raw_minor_block(
                         b1.header.branch, b1.serialize()
                     )
                 )
-                self.assertTrue(addResult)
+                self.assertTrue(add_result)
                 block_header_list.append(b1.header)
 
             block_header_list.append(clusters[0].get_shard_state(1).header_tip)
-            shardState0 = clusters[0].slave_list[1].shards[Branch(0b11)].state
-            b2 = shardState0.get_tip().create_block_to_append()
-            b2.finalize(evm_state=shardState0.run_block(b2))
-            addResult = call_async(
+            shard_state0 = clusters[0].slave_list[1].shards[Branch(0b11)].state
+            b2 = shard_state0.get_tip().create_block_to_append()
+            b2.finalize(evm_state=shard_state0.run_block(b2))
+            add_result = call_async(
                 clusters[0].master.add_raw_minor_block(b2.header.branch, b2.serialize())
             )
-            self.assertTrue(addResult)
+            self.assertTrue(add_result)
             block_header_list.append(b2.header)
 
             # add 1 block in cluster 1
-            shardState1 = clusters[1].slave_list[1].shards[Branch(0b11)].state
-            b3 = shardState1.get_tip().create_block_to_append()
-            b3.finalize(evm_state=shardState1.run_block(b3))
-            addResult = call_async(
+            shard_state1 = clusters[1].slave_list[1].shards[Branch(0b11)].state
+            b3 = shard_state1.get_tip().create_block_to_append()
+            b3.finalize(evm_state=shard_state1.run_block(b3))
+            add_result = call_async(
                 clusters[1].master.add_raw_minor_block(b3.header.branch, b3.serialize())
             )
-            self.assertTrue(addResult)
+            self.assertTrue(add_result)
 
             self.assertEqual(
                 clusters[1].slave_list[1].shards[Branch(0b11)].state.header_tip,
@@ -358,15 +358,15 @@ class TestCluster(unittest.TestCase):
             blockList = []
             # cluster 0 has 13 blocks added
             for i in range(13):
-                shardState0 = clusters[0].slave_list[0].shards[Branch(0b10)].state
-                block = shardState0.get_tip().create_block_to_append()
-                block.finalize(evm_state=shardState0.run_block(block))
-                addResult = call_async(
+                shard_state0 = clusters[0].slave_list[0].shards[Branch(0b10)].state
+                block = shard_state0.get_tip().create_block_to_append()
+                block.finalize(evm_state=shard_state0.run_block(block))
+                add_result = call_async(
                     clusters[0].master.add_raw_minor_block(
                         block.header.branch, block.serialize()
                     )
                 )
-                self.assertTrue(addResult)
+                self.assertTrue(add_result)
                 blockList.append(block)
             self.assertEqual(
                 clusters[0].slave_list[0].shards[Branch(0b10)].state.header_tip.height,
@@ -375,15 +375,15 @@ class TestCluster(unittest.TestCase):
 
             # cluster 1 has 12 blocks added
             for i in range(12):
-                shardState0 = clusters[1].slave_list[0].shards[Branch(0b10)].state
-                block = shardState0.get_tip().create_block_to_append()
-                block.finalize(evm_state=shardState0.run_block(block))
-                addResult = call_async(
+                shard_state0 = clusters[1].slave_list[0].shards[Branch(0b10)].state
+                block = shard_state0.get_tip().create_block_to_append()
+                block.finalize(evm_state=shard_state0.run_block(block))
+                add_result = call_async(
                     clusters[1].master.add_raw_minor_block(
                         block.header.branch, block.serialize()
                     )
                 )
-                self.assertTrue(addResult)
+                self.assertTrue(add_result)
             self.assertEqual(
                 clusters[1].slave_list[0].shards[Branch(0b10)].state.header_tip.height,
                 12,
@@ -398,15 +398,15 @@ class TestCluster(unittest.TestCase):
             )
 
             # a new block from cluster 0 will trigger sync in cluster 1
-            shardState0 = clusters[0].slave_list[0].shards[Branch(0b10)].state
-            block = shardState0.get_tip().create_block_to_append()
-            block.finalize(evm_state=shardState0.run_block(block))
-            addResult = call_async(
+            shard_state0 = clusters[0].slave_list[0].shards[Branch(0b10)].state
+            block = shard_state0.get_tip().create_block_to_append()
+            block.finalize(evm_state=shard_state0.run_block(block))
+            add_result = call_async(
                 clusters[0].master.add_raw_minor_block(
                     block.header.branch, block.serialize()
                 )
             )
-            self.assertTrue(addResult)
+            self.assertTrue(add_result)
             blockList.append(block)
 
             # expect cluster 1 has all the blocks from cluter 0 and
@@ -527,32 +527,32 @@ class TestCluster(unittest.TestCase):
             call_async(clusters[0].get_shard(0).add_block(b1))
 
             # expect shard 1 got the CrossShardTransactionList of b1
-            xshardTxList = (
+            xshard_tx_list = (
                 clusters[0]
                 .get_shard_state(1)
                 .db.get_minor_block_xshard_tx_list(b1.header.get_hash())
             )
-            self.assertEqual(len(xshardTxList.tx_list), 1)
-            self.assertEqual(xshardTxList.tx_list[0].tx_hash, tx1.get_hash())
-            self.assertEqual(xshardTxList.tx_list[0].from_address, acc1)
-            self.assertEqual(xshardTxList.tx_list[0].to_address, acc3)
-            self.assertEqual(xshardTxList.tx_list[0].value, 54321)
+            self.assertEqual(len(xshard_tx_list.tx_list), 1)
+            self.assertEqual(xshard_tx_list.tx_list[0].tx_hash, tx1.get_hash())
+            self.assertEqual(xshard_tx_list.tx_list[0].from_address, acc1)
+            self.assertEqual(xshard_tx_list.tx_list[0].to_address, acc3)
+            self.assertEqual(xshard_tx_list.tx_list[0].value, 54321)
 
             call_async(clusters[0].get_shard(0).add_block(b2))
             # b2 doesn't update tip
             self.assertEqual(clusters[0].get_shard_state(0).header_tip, b1.header)
 
             # expect shard 1 got the CrossShardTransactionList of b2
-            xshardTxList = (
+            xshard_tx_list = (
                 clusters[0]
                 .get_shard_state(1)
                 .db.get_minor_block_xshard_tx_list(b2.header.get_hash())
             )
-            self.assertEqual(len(xshardTxList.tx_list), 1)
-            self.assertEqual(xshardTxList.tx_list[0].tx_hash, tx1.get_hash())
-            self.assertEqual(xshardTxList.tx_list[0].from_address, acc1)
-            self.assertEqual(xshardTxList.tx_list[0].to_address, acc3)
-            self.assertEqual(xshardTxList.tx_list[0].value, 54321)
+            self.assertEqual(len(xshard_tx_list.tx_list), 1)
+            self.assertEqual(xshard_tx_list.tx_list[0].tx_hash, tx1.get_hash())
+            self.assertEqual(xshard_tx_list.tx_list[0].from_address, acc1)
+            self.assertEqual(xshard_tx_list.tx_list[0].to_address, acc3)
+            self.assertEqual(xshard_tx_list.tx_list[0].value, 54321)
 
             b3 = (
                 slaves[1]
@@ -623,13 +623,13 @@ class TestCluster(unittest.TestCase):
 
             neighbor_shards = [2 ** i for i in range(6)]
             for shard_id in range(64):
-                xshardTxList = (
+                xshard_tx_list = (
                     clusters[0]
                     .get_shard_state(shard_id)
                     .db.get_minor_block_xshard_tx_list(b1.header.get_hash())
                 )
                 # Only neighbor should have it
                 if shard_id in neighbor_shards:
-                    self.assertIsNotNone(xshardTxList)
+                    self.assertIsNotNone(xshard_tx_list)
                 else:
-                    self.assertIsNone(xshardTxList)
+                    self.assertIsNone(xshard_tx_list)

--- a/quarkchain/cluster/tests/test_cluster.py
+++ b/quarkchain/cluster/tests/test_cluster.py
@@ -234,8 +234,18 @@ class TestCluster(unittest.TestCase):
 
         with ClusterContext(2, acc1) as clusters:
             shard_state = clusters[0].slave_list[0].shards[Branch(0b10)].state
+            coinbase_amount = (
+                shard_state.env.quark_chain_config.SHARD_LIST[
+                    shard_state.shard_id
+                ].COINBASE_AMOUNT
+                // 2
+            )
             b1 = shard_state.get_tip().create_block_to_append()
-            b1.finalize(evm_state=shard_state.run_block(b1))
+            evm_state = shard_state.run_block(b1)
+            b1.finalize(
+                evm_state=evm_state,
+                coinbase_amount=evm_state.block_fee + coinbase_amount,
+            )
             add_result = call_async(
                 clusters[0].master.add_raw_minor_block(b1.header.branch, b1.serialize())
             )
@@ -277,10 +287,20 @@ class TestCluster(unittest.TestCase):
 
             # add blocks in cluster 0
             block_header_list = [clusters[0].get_shard_state(0).header_tip]
+            shard_state0 = clusters[0].slave_list[0].shards[Branch(0b10)].state
+            coinbase_amount = (
+                shard_state0.env.quark_chain_config.SHARD_LIST[
+                    shard_state0.shard_id
+                ].COINBASE_AMOUNT
+                // 2
+            )
             for i in range(7):
-                shard_state0 = clusters[0].slave_list[0].shards[Branch(0b10)].state
                 b1 = shard_state0.get_tip().create_block_to_append()
-                b1.finalize(evm_state=shard_state0.run_block(b1))
+                evm_state = shard_state0.run_block(b1)
+                b1.finalize(
+                    evm_state=evm_state,
+                    coinbase_amount=evm_state.block_fee + coinbase_amount,
+                )
                 add_result = call_async(
                     clusters[0].master.add_raw_minor_block(
                         b1.header.branch, b1.serialize()
@@ -291,8 +311,18 @@ class TestCluster(unittest.TestCase):
 
             block_header_list.append(clusters[0].get_shard_state(1).header_tip)
             shard_state0 = clusters[0].slave_list[1].shards[Branch(0b11)].state
+            coinbase_amount = (
+                shard_state0.env.quark_chain_config.SHARD_LIST[
+                    shard_state0.shard_id
+                ].COINBASE_AMOUNT
+                // 2
+            )
             b2 = shard_state0.get_tip().create_block_to_append()
-            b2.finalize(evm_state=shard_state0.run_block(b2))
+            evm_state = shard_state0.run_block(b2)
+            b2.finalize(
+                evm_state=evm_state,
+                coinbase_amount=evm_state.block_fee + coinbase_amount,
+            )
             add_result = call_async(
                 clusters[0].master.add_raw_minor_block(b2.header.branch, b2.serialize())
             )
@@ -301,8 +331,18 @@ class TestCluster(unittest.TestCase):
 
             # add 1 block in cluster 1
             shard_state1 = clusters[1].slave_list[1].shards[Branch(0b11)].state
+            coinbase_amount = (
+                shard_state1.env.quark_chain_config.SHARD_LIST[
+                    shard_state1.shard_id
+                ].COINBASE_AMOUNT
+                // 2
+            )
             b3 = shard_state1.get_tip().create_block_to_append()
-            b3.finalize(evm_state=shard_state1.run_block(b3))
+            evm_state = shard_state1.run_block(b3)
+            b3.finalize(
+                evm_state=evm_state,
+                coinbase_amount=evm_state.block_fee + coinbase_amount,
+            )
             add_result = call_async(
                 clusters[1].master.add_raw_minor_block(b3.header.branch, b3.serialize())
             )
@@ -355,29 +395,49 @@ class TestCluster(unittest.TestCase):
             # shutdown cluster connection
             clusters[1].peer.close()
 
-            blockList = []
+            block_list = []
             # cluster 0 has 13 blocks added
+            shard_state0 = clusters[0].slave_list[0].shards[Branch(0b10)].state
+            coinbase_amount = (
+                shard_state0.env.quark_chain_config.SHARD_LIST[
+                    shard_state0.shard_id
+                ].COINBASE_AMOUNT
+                // 2
+            )
             for i in range(13):
-                shard_state0 = clusters[0].slave_list[0].shards[Branch(0b10)].state
                 block = shard_state0.get_tip().create_block_to_append()
-                block.finalize(evm_state=shard_state0.run_block(block))
+                evm_state = shard_state0.run_block(block)
+                block.finalize(
+                    evm_state=evm_state,
+                    coinbase_amount=evm_state.block_fee + coinbase_amount,
+                )
                 add_result = call_async(
                     clusters[0].master.add_raw_minor_block(
                         block.header.branch, block.serialize()
                     )
                 )
                 self.assertTrue(add_result)
-                blockList.append(block)
+                block_list.append(block)
             self.assertEqual(
                 clusters[0].slave_list[0].shards[Branch(0b10)].state.header_tip.height,
                 13,
             )
 
             # cluster 1 has 12 blocks added
+            shard_state0 = clusters[1].slave_list[0].shards[Branch(0b10)].state
+            coinbase_amount = (
+                shard_state0.env.quark_chain_config.SHARD_LIST[
+                    shard_state0.shard_id
+                ].COINBASE_AMOUNT
+                // 2
+            )
             for i in range(12):
-                shard_state0 = clusters[1].slave_list[0].shards[Branch(0b10)].state
                 block = shard_state0.get_tip().create_block_to_append()
-                block.finalize(evm_state=shard_state0.run_block(block))
+                evm_state = shard_state0.run_block(block)
+                block.finalize(
+                    evm_state=evm_state,
+                    coinbase_amount=evm_state.block_fee + coinbase_amount,
+                )
                 add_result = call_async(
                     clusters[1].master.add_raw_minor_block(
                         block.header.branch, block.serialize()
@@ -399,19 +459,29 @@ class TestCluster(unittest.TestCase):
 
             # a new block from cluster 0 will trigger sync in cluster 1
             shard_state0 = clusters[0].slave_list[0].shards[Branch(0b10)].state
+            coinbase_amount = (
+                shard_state0.env.quark_chain_config.SHARD_LIST[
+                    shard_state0.shard_id
+                ].COINBASE_AMOUNT
+                // 2
+            )
             block = shard_state0.get_tip().create_block_to_append()
-            block.finalize(evm_state=shard_state0.run_block(block))
+            evm_state = shard_state0.run_block(block)
+            block.finalize(
+                evm_state=evm_state,
+                coinbase_amount=evm_state.block_fee + coinbase_amount,
+            )
             add_result = call_async(
                 clusters[0].master.add_raw_minor_block(
                     block.header.branch, block.serialize()
                 )
             )
             self.assertTrue(add_result)
-            blockList.append(block)
+            block_list.append(block)
 
             # expect cluster 1 has all the blocks from cluter 0 and
             # has the same tip as cluster 0
-            for block in blockList:
+            for block in block_list:
                 assert_true_with_timeout(
                     lambda: clusters[1]
                     .slave_list[0]

--- a/quarkchain/cluster/tests/test_jsonrpc.py
+++ b/quarkchain/cluster/tests/test_jsonrpc.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import time
 import unittest
 from contextlib import contextmanager
 

--- a/quarkchain/cluster/tests/test_jsonrpc.py
+++ b/quarkchain/cluster/tests/test_jsonrpc.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import time
 import unittest
 from contextlib import contextmanager
 

--- a/quarkchain/cluster/tests/test_root_state.py
+++ b/quarkchain/cluster/tests/test_root_state.py
@@ -7,7 +7,6 @@ from quarkchain.cluster.tests.test_utils import get_test_env
 from quarkchain.core import Address
 from quarkchain.core import CrossShardTransactionList
 from quarkchain.diff import EthDifficultyCalculator
-from quarkchain.genesis import GenesisManager
 
 
 def create_default_state(env, diff_calc=None):

--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -6,6 +6,7 @@ from quarkchain.cluster.tests.test_utils import (
     get_test_env,
     create_transfer_transaction,
 )
+from quarkchain.config import QUARKSH_TO_JIAOZI
 from quarkchain.core import CrossShardTransactionDeposit, CrossShardTransactionList
 from quarkchain.core import Identity, Address
 from quarkchain.diff import EthDifficultyCalculator
@@ -572,7 +573,7 @@ class TestShardState(unittest.TestCase):
         )
         self.assertEqual(
             state.get_balance(id1.recipient),
-            10000000 - 888888 - opcodes.GTXCOST - opcodes.GTXXSHARDCOST,
+            10000000 - 888888 - (opcodes.GTXCOST + opcodes.GTXXSHARDCOST),
         )
         # Make sure the xshard gas is not used by local block
         self.assertEqual(
@@ -752,8 +753,8 @@ class TestShardState(unittest.TestCase):
         self.assertEqual(state0.get_balance(acc3.recipient), 0)
 
         # X-shard gas used
-        evmState0 = state0.evm_state
-        self.assertEqual(evmState0.xshard_receive_gas_used, 0)
+        evm_state0 = state0.evm_state
+        self.assertEqual(evm_state0.xshard_receive_gas_used, 0)
 
     def test_xshard_for_two_root_blocks(self):
         id1 = Identity.create_random_identity()
@@ -854,7 +855,7 @@ class TestShardState(unittest.TestCase):
         self.assertEqual(b5.header.hash_prev_root_block, root_block0.header.get_hash())
         b6 = state0.create_block_to_mine(address=acc3, gas_limit=opcodes.GTXXSHARDCOST)
         self.assertEqual(b6.header.hash_prev_root_block, root_block0.header.get_hash())
-        # There are two x-shard txs: one is root block coinbase with zero gas, and anonther is from shard 1
+        # There are two x-shard txs: one is root block coinbase with zero gas, and another is from shard 1
         b7 = state0.create_block_to_mine(
             address=acc3, gas_limit=2 * opcodes.GTXXSHARDCOST
         )
@@ -1181,8 +1182,11 @@ class TestShardState(unittest.TestCase):
         # Should succeed
         state.finalize_and_add_block(b1)
         b1.finalize(evm_state=state.run_block(b1))
-        b1.meta.hash_evm_receipt_root = b"00" * 32
-        self.assertRaises(ValueError, state.add_block(b1))
+        b1.meta.hash_evm_receipt_root = bytes(32)
+        # low-level db operation to clear existing records
+        del state.db.m_header_pool[b1.header.get_hash()]
+        with self.assertRaises(ValueError):
+            state.add_block(b1)
 
     def test_not_update_tip_on_root_fork(self):
         """ block's hash_prev_root_block must be on the same chain with root_tip to update tip.

--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -6,7 +6,6 @@ from quarkchain.cluster.tests.test_utils import (
     get_test_env,
     create_transfer_transaction,
 )
-from quarkchain.config import QUARKSH_TO_JIAOZI
 from quarkchain.core import CrossShardTransactionDeposit, CrossShardTransactionList
 from quarkchain.core import Identity, Address
 from quarkchain.diff import EthDifficultyCalculator
@@ -921,7 +920,8 @@ class TestShardState(unittest.TestCase):
         state0.finalize_and_add_block(b2)
 
         b1 = state1.get_tip().create_block_to_append()
-        b1.finalize(evm_state=state1.run_block(b1))
+        evm_state = state1.run_block(b1)
+        b1.finalize(evm_state=evm_state, coinbase_amount=evm_state.block_fee)
 
         # Create a root block containing the block with the x-shard tx
         state0.add_cross_shard_tx_list_by_minor_block_hash(
@@ -966,7 +966,8 @@ class TestShardState(unittest.TestCase):
         state0.finalize_and_add_block(b2)
 
         b1 = state1.get_tip().create_block_to_append()
-        b1.finalize(evm_state=state1.run_block(b1))
+        evm_state = state1.run_block(b1)
+        b1.finalize(evm_state=evm_state, coinbase_amount=evm_state.block_fee)
 
         # Create a root block containing the block with the x-shard tx
         state0.add_cross_shard_tx_list_by_minor_block_hash(
@@ -1181,7 +1182,8 @@ class TestShardState(unittest.TestCase):
 
         # Should succeed
         state.finalize_and_add_block(b1)
-        b1.finalize(evm_state=state.run_block(b1))
+        evm_state = state.run_block(b1)
+        b1.finalize(evm_state=evm_state, coinbase_amount=b1.header.coinbase_amount)
         b1.meta.hash_evm_receipt_root = bytes(32)
         # low-level db operation to clear existing records
         del state.db.m_header_pool[b1.header.get_hash()]

--- a/quarkchain/cluster/tests/test_utils.py
+++ b/quarkchain/cluster/tests/test_utils.py
@@ -61,7 +61,7 @@ def get_test_env(
     env.quark_chain_config.SKIP_ROOT_DIFFICULTY_CHECK = True
     env.cluster_config.ENABLE_TRANSACTION_HISTORY = True
     env.cluster_config.DB_PATH_ROOT = ""
-    # prent breaking previous tests after tweaking default rewards
+    # prevent breaking previous tests after tweaking default rewards
     env.quark_chain_config.ROOT.COINBASE_AMOUNT = 5
     for c in env.quark_chain_config.SHARD_LIST:
         c.COINBASE_AMOUNT = 5

--- a/quarkchain/cluster/tests/test_utils.py
+++ b/quarkchain/cluster/tests/test_utils.py
@@ -61,6 +61,11 @@ def get_test_env(
     env.quark_chain_config.SKIP_ROOT_DIFFICULTY_CHECK = True
     env.cluster_config.ENABLE_TRANSACTION_HISTORY = True
     env.cluster_config.DB_PATH_ROOT = ""
+    # prent breaking previous tests after tweaking default rewards
+    env.quark_chain_config.ROOT.COINBASE_AMOUNT = 5
+    for c in env.quark_chain_config.SHARD_LIST:
+        c.COINBASE_AMOUNT = 5
+
     check(env.cluster_config.use_mem_db())
 
     return env

--- a/quarkchain/config.py
+++ b/quarkchain/config.py
@@ -1,5 +1,6 @@
 import json
 from enum import Enum
+from fractions import Fraction
 from typing import List
 from eth_keys import KeyAPI
 import quarkchain.db
@@ -266,6 +267,13 @@ class QuarkChainConfig(BaseConfig):
             s.CONSENSUS_CONFIG = POWConfig()
             s.CONSENSUS_CONFIG.TARGET_BLOCK_TIME = 3
             self.SHARD_LIST.append(s)
+
+    @property
+    def reward_tax_rate(self) -> Fraction:
+        ret = Fraction(self.REWARD_TAX_RATE).limit_denominator()
+        # a simple heuristic to make sure it's at least a percent number
+        assert ret.denominator <= 100
+        return ret
 
     def get_genesis_root_height(self, shard_id) -> int:
         """ Return the root block height at which the shard shall be created"""

--- a/quarkchain/config.py
+++ b/quarkchain/config.py
@@ -111,7 +111,7 @@ class ShardConfig(BaseConfig):
     GENESIS = None  # type: ShardGenesis
 
     COINBASE_ADDRESS = bytes(24).hex()
-    COINBASE_AMOUNT = 5
+    COINBASE_AMOUNT = 5 * QUARKSH_TO_JIAOZI
 
     # Gas Limit
     GAS_LIMIT_EMA_DENOMINATOR = 1024
@@ -191,7 +191,7 @@ class RootConfig(BaseConfig):
     GENESIS = None  # type: RootGenesis
 
     COINBASE_ADDRESS = bytes(24).hex()
-    COINBASE_AMOUNT = 5
+    COINBASE_AMOUNT = 120 * QUARKSH_TO_JIAOZI
 
     def __init__(self):
         self.GENESIS = RootGenesis()
@@ -225,9 +225,6 @@ class QuarkChainConfig(BaseConfig):
     SHARD_SIZE = 8
 
     MAX_NEIGHBORS = 32
-
-    # Block reward
-    MINOR_BLOCK_DEFAULT_REWARD = 100 * QUARKSH_TO_JIAOZI
 
     NETWORK_ID = NetworkId.TESTNET_PORSCHE
     TRANSACTION_QUEUE_SIZE_LIMIT_PER_SHARD = 10000

--- a/quarkchain/core.py
+++ b/quarkchain/core.py
@@ -752,13 +752,13 @@ class MinorBlock(Serializable):
         self.meta.hash_merkle_root = self.calculate_merkle_root()
         return self
 
-    def finalize(self, evm_state, hash_prev_root_block=None):
+    def finalize(self, evm_state, coinbase_amount, hash_prev_root_block=None):
         if hash_prev_root_block is not None:
             self.header.hash_prev_root_block = hash_prev_root_block
         self.meta.hash_evm_state_root = evm_state.trie.root_hash
         self.meta.evm_gas_used = evm_state.gas_used
         self.meta.evm_cross_shard_receive_gas_used = evm_state.xshard_receive_gas_used
-        self.header.coinbase_amount = evm_state.block_fee // 2
+        self.header.coinbase_amount = coinbase_amount
         self.finalize_merkle_root()
         self.meta.hash_evm_receipt_root = mk_receipt_sha(
             evm_state.receipts, evm_state.db

--- a/quarkchain/core.py
+++ b/quarkchain/core.py
@@ -809,7 +809,7 @@ class MinorBlock(Serializable):
         self,
         create_time=None,
         address=None,
-        quarkash=0,
+        coinbase_amount=0,
         difficulty=None,
         extra_data=b"",
         nonce=0,
@@ -829,7 +829,7 @@ class MinorBlock(Serializable):
             height=self.header.height + 1,
             branch=self.header.branch,
             coinbase_address=address,
-            coinbase_amount=quarkash,
+            coinbase_amount=coinbase_amount,
             hash_prev_minor_block=self.header.get_hash(),
             hash_prev_root_block=self.header.hash_prev_root_block,
             evm_gas_limit=self.header.evm_gas_limit,
@@ -949,15 +949,17 @@ class RootBlock(Serializable):
         self.header = header
         self.minor_block_header_list = (
             [] if minor_block_header_list is None else minor_block_header_list
-        )
+        )  # type: List[MinorBlockHeader]
         self.tracking_data = tracking_data
 
-    def finalize(self, quarkash=0, coinbase_address=Address.create_empty_account()):
+    def finalize(
+        self, coinbase_amount=0, coinbase_address=Address.create_empty_account()
+    ):
         self.header.hash_merkle_root = calculate_merkle_root(
             self.minor_block_header_list
         )
 
-        self.header.coinbase_amount = quarkash
+        self.header.coinbase_amount = coinbase_amount
         self.header.coinbase_address = coinbase_address
         return self
 

--- a/quarkchain/env.py
+++ b/quarkchain/env.py
@@ -1,5 +1,5 @@
 import copy
-from quarkchain.config import get_default_evm_config
+from quarkchain.config import get_default_evm_config, QuarkChainConfig
 from quarkchain.evm.config import Env as EvmEnv
 from quarkchain.db import InMemoryDb
 from quarkchain.cluster.cluster_config import ClusterConfig

--- a/quarkchain/evm/state.py
+++ b/quarkchain/evm/state.py
@@ -172,7 +172,13 @@ class Account(rlp.Serializable):
 # from ethereum.state import State
 class State:
     def __init__(
-        self, root=BLANK_ROOT, env=Env(), executing_on_head=False, db=None, **kwargs
+        self,
+        root=BLANK_ROOT,
+        env=Env(),
+        qkc_config=None,
+        executing_on_head=False,
+        db=None,
+        **kwargs
     ):
         if db is None:
             db = env.db
@@ -187,6 +193,7 @@ class State:
         self.deletes = []
         self.changed = {}
         self.executing_on_head = executing_on_head
+        self.qkc_config = qkc_config
 
     @property
     def db(self):
@@ -593,6 +600,7 @@ class State:
             assert not acct.touched or not acct.deleted
         s.journal = copy.copy(self.journal)
         s.cache = {}
+        s.qkc_config = self.qkc_config
         return s
 
 

--- a/quarkchain/reward.py
+++ b/quarkchain/reward.py
@@ -3,4 +3,4 @@ class ConstMinorBlockRewardCalcultor:
         self.env = env
 
     def get_block_reward(self):
-        return self.env.quark_chain_config.MINOR_BLOCK_DEFAULT_REWARD
+        return 100000000000000000000

--- a/quarkchain/tests/test_config.py
+++ b/quarkchain/tests/test_config.py
@@ -38,7 +38,6 @@ class TestShardConfig(unittest.TestCase):
         expected_json = """{
     "SHARD_SIZE": 8,
     "MAX_NEIGHBORS": 32,
-    "MINOR_BLOCK_DEFAULT_REWARD": 100000000000000000000,
     "NETWORK_ID": 3,
     "TRANSACTION_QUEUE_SIZE_LIMIT_PER_SHARD": 10000,
     "BLOCK_EXTRA_DATA_SIZE_LIMIT": 1024,
@@ -66,7 +65,7 @@ class TestShardConfig(unittest.TestCase):
             "NONCE": 0
         },
         "COINBASE_ADDRESS": "000000000000000000000000000000000000000000000000",
-        "COINBASE_AMOUNT": 5
+        "COINBASE_AMOUNT": 120000000000000000000
     },
     "SHARD_LIST": [
         {
@@ -89,7 +88,7 @@ class TestShardConfig(unittest.TestCase):
                 "ALLOC": {}
             },
             "COINBASE_ADDRESS": "000000000000000000000000000000000000000000000000",
-            "COINBASE_AMOUNT": 5,
+            "COINBASE_AMOUNT": 5000000000000000000,
             "GAS_LIMIT_EMA_DENOMINATOR": 1024,
             "GAS_LIMIT_ADJUSTMENT_FACTOR": 1024,
             "GAS_LIMIT_MINIMUM": 5000,
@@ -117,7 +116,7 @@ class TestShardConfig(unittest.TestCase):
                 "ALLOC": {}
             },
             "COINBASE_ADDRESS": "000000000000000000000000000000000000000000000000",
-            "COINBASE_AMOUNT": 5,
+            "COINBASE_AMOUNT": 5000000000000000000,
             "GAS_LIMIT_EMA_DENOMINATOR": 1024,
             "GAS_LIMIT_ADJUSTMENT_FACTOR": 1024,
             "GAS_LIMIT_MINIMUM": 5000,
@@ -145,7 +144,7 @@ class TestShardConfig(unittest.TestCase):
                 "ALLOC": {}
             },
             "COINBASE_ADDRESS": "000000000000000000000000000000000000000000000000",
-            "COINBASE_AMOUNT": 5,
+            "COINBASE_AMOUNT": 5000000000000000000,
             "GAS_LIMIT_EMA_DENOMINATOR": 1024,
             "GAS_LIMIT_ADJUSTMENT_FACTOR": 1024,
             "GAS_LIMIT_MINIMUM": 5000,
@@ -173,7 +172,7 @@ class TestShardConfig(unittest.TestCase):
                 "ALLOC": {}
             },
             "COINBASE_ADDRESS": "000000000000000000000000000000000000000000000000",
-            "COINBASE_AMOUNT": 5,
+            "COINBASE_AMOUNT": 5000000000000000000,
             "GAS_LIMIT_EMA_DENOMINATOR": 1024,
             "GAS_LIMIT_ADJUSTMENT_FACTOR": 1024,
             "GAS_LIMIT_MINIMUM": 5000,
@@ -184,7 +183,7 @@ class TestShardConfig(unittest.TestCase):
         {
             "CONSENSUS_TYPE": "NONE",
             "COINBASE_ADDRESS": "000000000000000000000000000000000000000000000000",
-            "COINBASE_AMOUNT": 5,
+            "COINBASE_AMOUNT": 5000000000000000000,
             "GAS_LIMIT_EMA_DENOMINATOR": 1024,
             "GAS_LIMIT_ADJUSTMENT_FACTOR": 1024,
             "GAS_LIMIT_MINIMUM": 5000,

--- a/quarkchain/tests/test_config.py
+++ b/quarkchain/tests/test_config.py
@@ -1,4 +1,5 @@
 import unittest
+from fractions import Fraction
 
 from quarkchain.config import (
     ConsensusType,
@@ -10,7 +11,7 @@ from quarkchain.config import (
 
 
 class TestShardConfig(unittest.TestCase):
-    def testBasic(self):
+    def test_basic(self):
         config = QuarkChainConfig()
         config.ROOT = RootConfig()
         config.ROOT.CONSENSUS_TYPE = ConsensusType.POW_SIMULATE
@@ -199,3 +200,16 @@ class TestShardConfig(unittest.TestCase):
         self.assertEqual(config.to_json(), expected_json)
         deserialized_config = QuarkChainConfig.from_json(expected_json)
         self.assertEqual(deserialized_config.to_json(), expected_json)
+
+
+class TestQuarkChainConfig(unittest.TestCase):
+    def test_reward_tax_rate(self):
+        config = QuarkChainConfig()
+        self.assertEqual(config.reward_tax_rate, Fraction(1, 2))
+        config.REWARD_TAX_RATE = 0.33
+        self.assertEqual(config.reward_tax_rate, Fraction(33, 100))
+        config.REWARD_TAX_RATE = 0.8
+        self.assertEqual(config.reward_tax_rate, Fraction(4, 5))
+        config.REWARD_TAX_RATE = 0.123
+        with self.assertRaises(AssertionError):
+            _ = config.reward_tax_rate


### PR DESCRIPTION
plus some naming / coding style changes

two relevant parts:

1. when applying transactions, fees are multiplied with the reward tax rate (e.g. 0.5)
2. when collecting x-shard tx fees, multiply with the same tax rate

comparing with previous approach (processing fee as usual, then deduct half from coinbase address when finalizing the block), this should reflect gas dynamics more accurately
