### PR TITLE
add qkchash native call from python

### DIFF
--- a/qkchash/make.sh
+++ b/qkchash/make.sh
@@ -1,1 +1,1 @@
-g++ qkchash.cpp -std=gnu++17 -O3
+g++ qkchash.cpp -std=gnu++17 -O3 -Wall

--- a/qkchash/qkchash.cpp
+++ b/qkchash/qkchash.cpp
@@ -150,6 +150,38 @@ void qkc_hash_sorted_list(
 } // org
 
 
+extern "C" void *cache_create(uint64_t *cache_ptr,
+                              uint32_t cache_size) {
+    ordered_set_t *oset = new ordered_set_t();
+    for (uint32_t i = 0; i < cache_size; i++) {
+        oset->insert(cache_ptr[i]);
+    }
+    return oset;
+}
+
+extern "C" void *cache_copy(void *ptr) {
+    return new ordered_set_t(*(ordered_set_t *)ptr);
+}
+
+extern "C" void cache_destroy(void *ptr) {
+    auto cache = (ordered_set_t *)ptr;
+    delete cache;
+}
+
+extern "C" void qkc_hash(void *cache_ptr,
+                         uint64_t* seed_ptr,
+                         uint64_t* result_ptr) {
+    ordered_set_t *oset = (ordered_set_t *)cache_ptr;
+
+    std::array<uint64_t, 8> seed;
+    std::array<uint64_t, 8> result;
+    std::copy(seed_ptr, seed_ptr + seed.size(), seed.begin());
+
+    org::quarkchain::qkc_hash(*oset, seed, result);
+
+    std::copy(result.begin(), result.end(), result_ptr);
+}
+
 void test_sorted_list() {
     std::cout << "Testing sorted list implementation" << std::endl;
     ordered_set_t oset;


### PR DESCRIPTION
Add python wrapper code to call native code to evaluate qkchash

To compile the library on Linux, need to run:
g++ -shared -o libqkchash.so -fPIC qkchash.cpp -O3 -std=gnu++17

And run:
LD_LIBRARY_PATH=. python3  qkchash.py

The output is:
make_cache time: 0.09
Python version, time used: 0.46, hashes per sec: 21.54
Native version, time used: 6.16, hashes per sec: 162.23
Equal:  True

The performance gain is about 8x.
