### PR TITLE
add qkchash llrb version

### DIFF
--- a/qkchash/Makefile
+++ b/qkchash/Makefile
@@ -1,13 +1,16 @@
 CC=g++
 CFLAGS=-Wall -O3 -std=c++17
 
-all: qkchash libqkchash.so
+all: qkchash libqkchash.so qkchash_llrb
 
-qkchash: qkchash.cpp
+qkchash: qkchash.cpp util.h
 	$(CC) $(CFLAGS) -o qkchash qkchash.cpp
 
-libqkchash.so: qkchash.cpp
+libqkchash.so: qkchash.cpp util.h
 	$(CC) $(CFLAGS) -o libqkchash.so -shared -fPIC qkchash.cpp
 
+qkchash_llrb: qkchash_llrb.cpp qkchash_llrb.h util.h
+	$(CC) $(CFLAGS) -o qkchash_llrb qkchash_llrb.cpp
+
 clean:
-	rm -f qkchash libqkchash.so
+	rm -f qkchash libqkchash.so qkchash_llrb

--- a/qkchash/qkchash.cpp
+++ b/qkchash/qkchash.cpp
@@ -11,6 +11,10 @@
 #include <ext/pb_ds/assoc_container.hpp>
 #include <ext/pb_ds/tree_policy.hpp>
 
+#include "util.h"
+
+#include "qkchash_llrb.h"
+
 using namespace std;
 using namespace __gnu_pbds;
 
@@ -32,19 +36,6 @@ const uint64_t FNV_PRIME_64 = 0x100000001b3ULL;
 const uint32_t ACCESS_ROUND = 64;
 const uint32_t INIT_SET_ENTRIES = 1024 * 64;
 
-/*
- * 32-bit FNV function
- */
-uint32_t fnv32(uint32_t v1, uint32_t v2) {
-    return (v1 * FNV_PRIME_32) ^ v2;
-}
-
-/*
- * 64-bit FNV function
- */
-uint64_t fnv64(uint64_t v1, uint64_t v2) {
-    return (v1 * FNV_PRIME_64) ^ v2;
-}
 
 /*
  * A simplified version of generating initial set.
@@ -147,6 +138,46 @@ void qkc_hash_sorted_list(
     }
 }
 
+void qkc_hash_llrb(
+        org::quarkchain::LLRB<uint64_t>& cache,
+        std::array<uint64_t, 8>& seed,
+        std::array<uint64_t, 4>& result) {
+    std::array<uint64_t, 16> mix;
+    for (uint32_t i = 0; i < mix.size(); i++) {
+        mix[i] = seed[i % seed.size()];
+    }
+
+    for (uint32_t i = 0; i < ACCESS_ROUND; i ++) {
+        std::array<uint64_t, 16> new_data;
+        uint64_t p = fnv64(i ^ seed[0], mix[i % mix.size()]);
+        for (uint32_t j = 0; j < mix.size(); j++) {
+            // Find the pth element and remove it
+            uint32_t idx = p % cache.size();
+            new_data[j] = cache.eraseByOrder(idx);
+
+            // Generate random data and insert it
+            // if the vector doesn't contain it.
+            p = fnv64(p, new_data[j]);
+            cache.insert(p);
+
+            // Find the next element index (ordered)
+            p = fnv64(p, new_data[j]);
+        }
+
+        for (uint32_t j = 0; j < mix.size(); j++) {
+            mix[j] = fnv64(mix[j], new_data[j]);
+        }
+    }
+
+    /*
+     * Compress
+     */
+    for (uint32_t i = 0; i < result.size(); i++) {
+        uint32_t j = i * 4;
+        result[i] = fnv64(fnv64(fnv64(mix[j], mix[j + 1]), mix[j + 2]), mix[j + 3]);
+    }
+}
+
 
 } // quarkchain
 } // org
@@ -217,6 +248,52 @@ void test_sorted_list() {
     std::cout << "Test passed" << std::endl;
 }
 
+void test_qkc_hash_llrb() {
+    std::cout << "Testing llrb implementation" << std::endl;
+    ordered_set_t oset;
+
+    org::quarkchain::generate_init_set(
+        oset, 431, org::quarkchain::INIT_SET_ENTRIES);
+
+    void *arena0 = malloc(org::quarkchain::INIT_SET_ENTRIES *
+                          org::quarkchain::LLRB<uint64_t>::getNodeSize());
+    void *arena1 = malloc(org::quarkchain::INIT_SET_ENTRIES *
+                          org::quarkchain::LLRB<uint64_t>::getNodeSize());
+    org::quarkchain::LLRB<uint64_t> tree0(
+        (uintptr_t)arena0,
+        org::quarkchain::INIT_SET_ENTRIES *
+            org::quarkchain::LLRB<uint64_t>::getNodeSize());
+    for (auto v : oset) {
+        tree0.insert(v);
+    }
+
+    uint32_t trials = 100;
+
+    std::array<uint64_t, 4> result0;
+    std::array<uint64_t, 4> result1;
+    for (uint32_t i = 0; i < trials; i ++) {
+        std::uniform_int_distribution<uint64_t> dist(0, ULLONG_MAX);
+        std::default_random_engine generator(475);
+        std::array<uint64_t, 8> seed;
+        for (uint32_t j = 0; j < 8; j++) {
+            seed[j] = dist(generator);
+        }
+
+        auto nset = oset;
+        org::quarkchain::LLRB<uint64_t> tree1 = tree0.copy((uintptr_t)arena1);
+        org::quarkchain::qkc_hash(nset, seed, result0);
+        org::quarkchain::qkc_hash_llrb(tree1, seed, result1);
+
+        for (uint32_t j = 0; j < result0.size(); j++) {
+            if (result0[j] != result1[j]) {
+                std::cout << "Test failed at " << i << " trial" << std::endl;
+                return;
+            }
+        }
+    }
+    std::cout << "Test passed" << std::endl;
+}
+
 void test_qkc_hash_perf() {
     ordered_set_t oset;
 
@@ -239,21 +316,89 @@ void test_qkc_hash_perf() {
     std::default_random_engine generator(475);
 
     t_start = std::chrono::steady_clock::now();
-    uint32_t count = 1000;
+    uint32_t count = 1000, total_count = 0;
     std::array<uint64_t, 8> seed;
     std::array<uint64_t, 4> result;
-    for (uint32_t i = 0; i < count; i++) {
-        for (uint32_t j = 0; j < 8; j++) {
-            seed[j] = dist(generator);
-        }
 
-        ordered_set_t new_oset(oset);
-        org::quarkchain::qkc_hash(new_oset, seed, result);
+    while (1) {
+        for (uint32_t i = 0; i < count; i++) {
+            for (uint32_t j = 0; j < 8; j++) {
+                seed[j] = dist(generator);
+            }
+
+            ordered_set_t new_oset(oset);
+            org::quarkchain::qkc_hash(new_oset, seed, result);
+        }
+        total_count += count;
+
+        used_time = std::chrono::steady_clock::now() - t_start;
+        auto used_time_ms = (uint64_t)std::chrono::duration<double, std::milli>(used_time).count();
+        std::cout << total_count * 1000 / used_time_ms
+                  << std::endl;
+
+        std::cout << "Hash:" << std::endl;
+        for (uint64_t v : result) {
+            std::cout << v << " ";
+        }
+        std::cout << std::endl;
     }
-    used_time = std::chrono::steady_clock::now() - t_start;
-    std::cout << "Duration: "
+}
+
+void test_qkc_hash_llrb_perf() {
+    ordered_set_t oset;
+    org::quarkchain::generate_init_set(
+        oset, 1, org::quarkchain::INIT_SET_ENTRIES);
+
+    void *arena0 = malloc(org::quarkchain::INIT_SET_ENTRIES *
+                          org::quarkchain::LLRB<uint64_t>::getNodeSize());
+    void *arena1 = malloc(org::quarkchain::INIT_SET_ENTRIES *
+                          org::quarkchain::LLRB<uint64_t>::getNodeSize());
+    org::quarkchain::LLRB<uint64_t> tree0(
+        (uintptr_t)arena0,
+        org::quarkchain::INIT_SET_ENTRIES *
+            org::quarkchain::LLRB<uint64_t>::getNodeSize());
+
+    for (auto v : oset) {
+        tree0.insert(v);
+    }
+
+    auto t_start = std::chrono::steady_clock::now();
+    org::quarkchain::LLRB<uint64_t> tree1 = tree0.copy((uintptr_t)arena1);
+    auto used_time = std::chrono::steady_clock::now() - t_start;
+    std::cout << "Copy time: "
               << std::chrono::duration<double, std::milli>(used_time).count()
               << std::endl;
+
+    std::uniform_int_distribution<uint64_t> dist(0, ULLONG_MAX);
+    std::default_random_engine generator(475);
+
+    t_start = std::chrono::steady_clock::now();
+    uint32_t count = 1000, total_count = 0;
+    std::array<uint64_t, 8> seed;
+    std::array<uint64_t, 4> result;
+
+    while (1) {
+        for (uint32_t i = 0; i < count; i++) {
+            for (uint32_t j = 0; j < 8; j++) {
+                seed[j] = dist(generator);
+            }
+
+            tree1 = tree0.copy((uintptr_t)arena1);
+            org::quarkchain::qkc_hash_llrb(tree1, seed, result);
+        }
+        total_count += count;
+
+        used_time = std::chrono::steady_clock::now() - t_start;
+        auto used_time_ms = (uint64_t)std::chrono::duration<double, std::milli>(used_time).count();
+        std::cout << total_count * 1000 / used_time_ms
+                  << std::endl;
+
+        std::cout << "Hash:" << std::endl;
+        for (uint64_t v : result) {
+            std::cout << v << " ";
+        }
+        std::cout << std::endl;
+    }
 }
 
 void test_qkc_hash_slist_perf() {
@@ -302,7 +447,7 @@ void test_qkc_hash_slist_perf() {
 int main(int argc, char** argv) {
     if (argc <= 1) {
         std::cout << "Must specify command in "
-                     "qkc_perf, slist_test, slist_perf"
+                     "qkc_perf, llrb_perf, slist_test, slist_perf"
                   << std::endl;
         return -1;
     }
@@ -313,6 +458,10 @@ int main(int argc, char** argv) {
         test_qkc_hash_slist_perf();
     } else if (strcmp(argv[1], "slist_test") == 0) {
         test_sorted_list();
+    } else if (strcmp(argv[1], "llrb_perf") == 0) {
+        test_qkc_hash_llrb_perf();
+    } else if (strcmp(argv[1], "llrb_test") == 0) {
+        test_qkc_hash_llrb();
     } else {
         std::cout << "Unrecognized command: " << argv[1] << std::endl;
         return -1;

--- a/qkchash/qkchash_llrb.cpp
+++ b/qkchash/qkchash_llrb.cpp
@@ -1,0 +1,356 @@
+#include <climits>
+#include <cstdlib>
+
+#include <chrono>
+#include <random>
+#include <set>
+
+#include <ext/pb_ds/assoc_container.hpp>
+#include <ext/pb_ds/tree_policy.hpp>
+
+#include "qkchash_llrb.h"
+
+using namespace __gnu_pbds;
+
+typedef
+tree<
+    uint64_t,
+    null_type,
+    std::less<uint64_t>,
+    rb_tree_tag,
+    tree_order_statistics_node_update>
+ordered_set_t;
+
+class ClockPrinter {
+public:
+    ClockPrinter(std::string prefix)
+    : prefix_(prefix),
+      startTime_(std::chrono::steady_clock::now()) {}
+
+    ~ClockPrinter() {
+        auto usedTime = std::chrono::steady_clock::now() - startTime_;
+        std::cout << prefix_
+                  << " used_time: "
+                  << std::chrono::duration<double, std::milli>(usedTime).count()
+                  << std::endl;
+    }
+
+private:
+    std::string prefix_;
+    std::chrono::time_point<std::chrono::steady_clock> startTime_;
+};
+
+void comp_perf() {
+    std::cout << std::endl;
+    std::cout << "================" << std::endl;
+    std::cout << "Performance test" << std::endl;
+
+    uint32_t key_size = 64 * 1024;
+
+    std::uniform_int_distribution<uint64_t>
+        dist64(0, std::numeric_limits<uint64_t>::max());
+    std::default_random_engine generator(
+        std::chrono::steady_clock::now().time_since_epoch().count());
+    std::vector<uint64_t> data_to_insert;
+    for (uint32_t i = 0; i < key_size; i++) {
+        data_to_insert.push_back(dist64(generator));
+    }
+
+    ordered_set_t set0;
+    {
+        ClockPrinter printer("insert");
+        for (uint64_t v : data_to_insert) {
+            set0.insert(v);
+        }
+    }
+
+    ordered_set_t set1;
+    {
+        ClockPrinter printer("copy");
+        set1 = set0;
+    }
+
+    {
+        ClockPrinter printer("erase/insert");
+        for (uint32_t i = 0; i < key_size; i++) {
+            uint64_t p = dist64(generator) % set1.size();
+            set1.erase(data_to_insert[p]);
+            data_to_insert[p] = dist64(generator);
+            set1.insert(data_to_insert[p]);
+        }
+    }
+
+    void *arena0 = malloc(key_size * org::quarkchain::LLRB<uint64_t>::getNodeSize());
+    void *arena1 = malloc(key_size * org::quarkchain::LLRB<uint64_t>::getNodeSize());
+    org::quarkchain::LLRB<uint64_t> tree0(
+        (uintptr_t)arena0, key_size * org::quarkchain::LLRB<uint64_t>::getNodeSize());
+
+    std::cout << "Node size " << org::quarkchain::LLRB<uint64_t>::getNodeSize() << std::endl;
+    {
+        ClockPrinter printer("insert");
+        for (uint64_t v : data_to_insert) {
+            tree0.insert(v);
+        }
+    }
+
+    {
+        ClockPrinter printer("copy");
+        org::quarkchain::LLRB<uint64_t> tree1 = tree0.copy((uintptr_t)arena1);
+    }
+
+    {
+        ClockPrinter printer("erase/insert");
+        for (uint32_t i = 0; i < key_size; i++) {
+            uint64_t p = dist64(generator) % tree0.size();
+            tree0.erase(data_to_insert[p]);
+            data_to_insert[p] = dist64(generator);
+            tree0.insert(data_to_insert[p]);
+        }
+    }
+
+    {
+        ClockPrinter printer("hash");
+        std::cout << tree0.hash() << std::endl;
+    }
+
+    std::cout << "Passed" << std::endl;
+}
+
+void comp_perf_order() {
+    std::cout << std::endl;
+    std::cout << "======================" << std::endl;
+    std::cout << "Order performance test" << std::endl;
+    uint32_t key_size = 64 * 1024;
+
+    std::uniform_int_distribution<uint64_t>
+        dist64(0, std::numeric_limits<uint64_t>::max());
+    std::default_random_engine generator(
+        std::chrono::steady_clock::now().time_since_epoch().count());
+    std::vector<uint64_t> data_to_insert;
+    for (uint32_t i = 0; i < key_size; i++) {
+        data_to_insert.push_back(dist64(generator));
+    }
+
+    ordered_set_t set0;
+    {
+        ClockPrinter printer("insert");
+        for (uint64_t v : data_to_insert) {
+            set0.insert(v);
+        }
+    }
+
+    {
+        ClockPrinter printer("copy and destroy");
+        ordered_set_t copy_set1 = set0;
+    }
+
+
+    ordered_set_t set1(set0);
+    {
+        ClockPrinter printer("erase/insert");
+        for (uint32_t i = 0; i < key_size; i++) {
+            uint64_t p = dist64(generator) % set1.size();
+            auto it = set1.find_by_order(p);
+            set1.erase(it);
+            uint64_t nd = dist64(generator);
+            set1.insert(nd);
+        }
+    }
+
+    void *arena0 = malloc(key_size * org::quarkchain::LLRB<uint64_t>::getNodeSize());
+    void *arena1 = malloc(key_size * org::quarkchain::LLRB<uint64_t>::getNodeSize());
+    org::quarkchain::LLRB<uint64_t> tree0(
+        (uintptr_t)arena0, key_size * org::quarkchain::LLRB<uint64_t>::getNodeSize());
+
+    std::cout << "Node size " << org::quarkchain::LLRB<uint64_t>::getNodeSize() << std::endl;
+    {
+        ClockPrinter printer("insert");
+        for (uint64_t v : data_to_insert) {
+            tree0.insert(v);
+        }
+    }
+
+    {
+        ClockPrinter printer("copy");
+        org::quarkchain::LLRB<uint64_t> tree1 = tree0.copy((uintptr_t)arena1);
+    }
+
+    {
+        ClockPrinter printer("erase/insert");
+        for (uint32_t i = 0; i < key_size; i++) {
+            uint64_t p = dist64(generator) % tree0.size();
+            tree0.eraseByOrder(p);
+            uint64_t nd = dist64(generator);
+            tree0.insert(nd);
+        }
+
+        CHECK(tree0.check());
+    }
+
+    {
+        ClockPrinter printer("hash");
+        std::cout << tree0.hash() << std::endl;
+    }
+
+    std::cout << "Passed" << std::endl;
+}
+
+
+void simple_test() {
+    void *arena = malloc(1024 * 1024);
+    org::quarkchain::LLRB<uint64_t> tree(
+        (uintptr_t)arena, 1024 * 1024);
+
+    assert(!tree.contain(10));
+
+    tree.insert(10);
+    assert(tree.contain(10));
+    tree.print();
+
+    tree.insert(20);
+    assert(tree.contain(20));
+    tree.print();
+
+    tree.insert(30);
+    assert(tree.contain(30));
+    tree.print();
+    CHECK(tree.check());
+
+    void *arena1 = malloc(1024 * 1024);
+    org::quarkchain::LLRB<uint64_t> ntree = tree.copy((uintptr_t)arena1);
+    ntree.print();
+
+    ntree.erase(30);
+    CHECK(ntree.check());
+    ntree.print();
+
+    ntree.erase(20);
+    ntree.print();
+    CHECK(ntree.check());
+
+    ntree.erase(10);
+    ntree.print();
+    CHECK(ntree.check());
+
+    ntree.insert(30);
+    ntree.insert(20);
+    ntree.insert(10);
+    ntree.print();
+    CHECK(ntree.check());
+
+    ntree = tree.copy((uintptr_t)arena1);
+    CHECK(ntree.eraseByOrder(0) == 10);
+    CHECK(ntree.check());
+
+    ntree = tree.copy((uintptr_t)arena1);
+    CHECK(ntree.eraseByOrder(1) == 20);
+    CHECK(ntree.check());
+
+    ntree = tree.copy((uintptr_t)arena1);
+    CHECK(ntree.eraseByOrder(2) == 30);
+    CHECK(ntree.check());
+
+    CHECK(ntree.eraseByOrder(0) == 10);
+    CHECK(ntree.check());
+
+    CHECK(ntree.eraseByOrder(0) == 20);
+    CHECK(ntree.check());
+}
+
+void simple_test1() {
+    void *arena = malloc(1024 * 1024);
+    void *arena1 = malloc(1024 * 1024);
+    org::quarkchain::LLRB<uint64_t> tree(
+        (uintptr_t)arena, 1024 * 1024);
+
+    for (uint64_t i = 0; i < 100; i++) {
+        tree.insert(i);
+    }
+
+    for (uint64_t i = 0; i < 100; i++) {
+        org::quarkchain::LLRB<uint64_t> ntree = tree.copy((uintptr_t)arena1);
+        ntree.erase(i);
+    }
+
+    org::quarkchain::LLRB<uint64_t> ntree = tree.copy((uintptr_t)arena1);
+    for (uint64_t i = 0; i < 100; i ++) {
+        ntree.erase(i);
+    }
+}
+
+void random_test() {
+    uint32_t entries = 1024;
+
+    std::uniform_int_distribution<uint64_t> dist(0, ULLONG_MAX);
+    std::default_random_engine generator(51235);
+    uint64_t arenaSize = entries * org::quarkchain::LLRB<uint64_t>::getNodeSize();
+
+    void *arena = malloc(arenaSize);
+    org::quarkchain::LLRB<uint64_t> tree(
+        (uintptr_t)arena, arenaSize);
+
+    std::vector<uint64_t> elements;
+    for (uint32_t i = 0; i < entries; i++) {
+        uint64_t e = dist(generator);
+        tree.insert(e);
+        elements.push_back(e);
+        CHECK(tree.check());
+    }
+
+    for (uint32_t i = 0; i < entries; i ++) {
+        uint64_t p = dist(generator) % tree.size();
+        tree.erase(elements[p]);
+        elements[p] = dist(generator);
+        tree.insert(elements[p]);
+        CHECK(tree.check());
+    }
+}
+
+void random_order_test() {
+    std::cout << std::endl;
+    std::cout << "==================================" << std::endl;
+    std::cout << "Random insert/delete by order test" << std::endl;
+    uint32_t entries = 1024;
+
+    std::uniform_int_distribution<uint64_t> dist(0, ULLONG_MAX);
+    std::default_random_engine generator(51235);
+
+    void *arena = malloc(1024 * 1024);
+    org::quarkchain::LLRB<uint64_t> tree(
+        (uintptr_t)arena, 1024 * 1024);
+    ordered_set_t oset;
+
+    for (uint32_t i = 0; i < entries; i++) {
+        uint64_t e = dist(generator);
+        tree.insert(e);
+        oset.insert(e);
+        CHECK(tree.check());
+    }
+
+    for (uint32_t i = 0; i < entries; i ++) {
+        uint64_t p = dist(generator) % tree.size();
+        uint64_t v = tree.eraseByOrder(p);
+        auto it = oset.find_by_order(p);
+        CHECK(v == *it);
+        oset.erase(it);
+
+        uint64_t nv = dist(generator);
+        tree.insert(nv);
+        CHECK(tree.check());
+        oset.insert(nv);
+    }
+
+    std::cout << "Passed" << std::endl;
+}
+
+int main(int argc, char const *argv[])
+{
+    simple_test();
+    simple_test1();
+    random_test();
+    random_order_test();
+    comp_perf();
+    comp_perf_order();
+
+    return 0;
+}

--- a/qkchash/qkchash_llrb.h
+++ b/qkchash/qkchash_llrb.h
@@ -1,0 +1,492 @@
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+
+#include <iostream>
+#include <vector>
+
+#include "util.h"
+
+namespace org {
+namespace quarkchain {
+
+template <typename T>
+class LLRB {
+
+private:
+    const uint32_t NULL_IDX = 0xFFFFFFFF;
+    struct Node {
+        T value;
+        uint32_t left;
+        uint32_t right;
+        bool color;
+        uint32_t size;      // number of elements on left
+    };
+
+public:
+    static uint32_t getNodeSize() {
+        return sizeof (Node);
+    }
+
+public:
+    LLRB(uintptr_t arenaBase,
+         uint64_t arenaSize)
+         : arenaBase_(arenaBase),
+           arenaSize_(arenaSize),
+           capacity_(arenaSize_ / sizeof (Node)),
+           root_(NULL_IDX) {
+        for (int32_t i = arenaSize_ / sizeof (Node) - 1; i >= 0; i--) {
+            freeList_.push_back(i);
+        }
+    }
+
+    LLRB<T>& operator=(LLRB<T>&& other) {
+        arenaBase_ = other.arenaBase_;
+        arenaSize_ = other.arenaSize_;
+        capacity_ = other.capacity_;
+        root_ = other.root_;
+        freeList_ = std::move(other.freeList_);
+        return *this;
+    };
+    LLRB<T>& operator=(const LLRB<T>& other) = delete;
+    LLRB<T>(const LLRB<T>& o) = delete;
+    LLRB<T>(LLRB<T>&& o) = default;
+
+    void insert(T value) {
+        Node* n = insert(getNode(root_), value);
+        root_ = getIndex(n);
+    }
+
+    bool contain(T value) {
+        Node* n = getNode(root_);
+        while (n != nullptr) {
+            if (n->value == value) {
+                return true;
+            } else if (value < n->value) {
+                n = getNode(n->left);
+            } else {
+                n = getNode(n->right);
+            }
+        }
+        return false;
+    }
+
+    void erase(T value) {
+        CHECK(root_ != NULL_IDX);
+
+        Node* root = getNode(root_);
+        if (!isRed(root->left) && !isRed(root->right)) {
+            root->color = RED;
+        }
+
+        Node* n = erase(root, value);
+        root_ = getIndex(n);
+
+        if (n != nullptr) {
+            n->color = BLACK;
+        }
+    }
+
+    T eraseByOrder(uint32_t p) {
+        CHECK(p < size());
+
+        Node* root = getNode(root_);
+        if (!isRed(root->left) && !isRed(root->right)) {
+            root->color = RED;
+        }
+
+        T value;
+        Node* n = eraseAt(root, p, value);
+        root_ = getIndex(n);
+
+        if (n != nullptr) {
+            n->color = BLACK;
+        }
+        return value;
+    }
+
+    void print() {
+        print(root_);
+    }
+
+    LLRB<T> copy(uintptr_t arenaBase) {
+        memcpy((void *)arenaBase, (void *)arenaBase_, arenaSize_);
+        return LLRB<T>(arenaBase, arenaSize_, root_, freeList_);
+    }
+
+    uint32_t size() {
+        return capacity_ - freeList_.size();
+    }
+
+    /*
+     * Obtain a quick hash of the tree.
+     */
+    uint64_t hash() {
+        return hash(getNode(root_), FNV_OFFSET_BASE_64, 0);
+    }
+
+    /*
+     * Sanity check.
+     */
+    bool check() {
+        uint32_t sum;
+        return isBST(getNode(root_), nullptr, nullptr) &&
+               isSizeConsistent(getNode(root_), sum) &&
+               sum == size() &&
+               is23(getNode(root_));
+    }
+
+private:
+    LLRB(uintptr_t arenaBase,
+         uint64_t arenaSize,
+         uint32_t root,
+         std::vector<uint32_t> freeList)
+         : arenaBase_(arenaBase),
+           arenaSize_(arenaSize),
+           capacity_(arenaSize_ / sizeof (Node)),
+           root_(root),
+           freeList_(std::move(freeList)) { }
+
+    uintptr_t arenaBase_;
+    uint64_t arenaSize_;
+    uint32_t capacity_;
+    uint32_t root_;
+    std::vector<uint32_t> freeList_;
+
+    const bool RED = true;
+    const bool BLACK = false;
+
+    void print(uint32_t idx) {
+        Node* n = getNode(idx);
+        if (n == nullptr) {
+            return;
+        }
+
+        print(n->left);
+        std::cout << n->value << " " << std::endl;
+        print(n->right);
+    }
+
+    uint64_t hash(Node* h, uint64_t hv, uint64_t idx) {
+        if (h == nullptr) {
+            return hv;
+        }
+        hv = fnv64(hv, idx);
+        hv = fnv64(hv, h->value ^ (h->color ? 0 : 1));
+        hv = hash(getNode(h->left), hv, (idx << 1) + 1);
+        hv = hash(getNode(h->right), hv, (idx << 1) + 2);
+        return hv;
+    }
+
+    Node* rotateLeft(Node* h) {
+        Node* x = getNode(h->right);
+        h->right = x->left;
+        x->left = getIndex(h);
+        x->color = h->color;
+        h->color = RED;
+        x->size += (h->size + 1);
+        return x;
+    }
+
+    uint32_t getNodeSize(Node *n) {
+        if (n == nullptr) {
+            return 0;
+        }
+
+        return n->size;
+    }
+
+    Node* rotateRight(Node* h) {
+        Node* x = getNode(h->left);
+        h->left = x->right;
+        x->right = getIndex(h);
+        x->color = h->color;
+        h->color = RED;
+        h->size -= (x->size + 1);
+        return x;
+    }
+
+    void flipColor(Node* h) {
+        h->color = !h->color;
+        Node* left = getNode(h->left);
+        left->color = !left->color;
+        Node* right = getNode(h->right);
+        right->color = !right->color;
+    }
+
+    Node* getNode(uint32_t idx) {
+        if (idx == NULL_IDX) {
+            return nullptr;
+        }
+        return (Node *)(arenaBase_ + sizeof (Node) * idx);
+    }
+
+    uint32_t getIndex(Node *n) {
+        if (n == nullptr) {
+            return NULL_IDX;
+        }
+
+        return ((uintptr_t)n - arenaBase_) / sizeof (Node);
+    }
+
+    Node* newNode(uint64_t value) {
+        CHECK(!freeList_.empty());
+
+        uint32_t idx = freeList_.back();
+        freeList_.pop_back();
+        Node* node = getNode(idx);
+        node->left = NULL_IDX;
+        node->right = NULL_IDX;
+        node->value = value;
+        node->color = RED;
+        node->size = 0;
+        return node;
+    }
+
+    bool isRed(uint32_t idx) {
+        if (idx == NULL_IDX) {
+            return false;
+        }
+
+        return getNode(idx)->color;
+    }
+
+    Node* insert(Node* h, T value) {
+        if (h == nullptr) {
+            return newNode(value);
+        }
+
+        if (value == h->value) {
+            return nullptr;
+        } else if (value < h->value) {
+            Node* left = insert(getNode(h->left), value);
+            if (left == nullptr) {
+                return nullptr;
+            }
+            h->left = getIndex(left);
+            h->size++;
+        } else {
+            Node* right = insert(getNode(h->right), value);
+            if (right == nullptr) {
+                return nullptr;
+            }
+            h->right = getIndex(right);
+        }
+
+        if (isRed(h->right) && !isRed(h->left)) {
+            h = rotateLeft(h);
+        }
+
+        if (isRed(h->left) && isRed(getNode(h->left)->left)) {
+            h = rotateRight(h);
+        }
+
+        if (isRed(h->left) && isRed(h->right)) {
+            flipColor(h);
+        }
+        return h;
+    }
+
+    Node* fixUp(Node* h) {
+        if (isRed(h->right)) {
+            h = rotateLeft(h);
+        }
+        if (isRed(h->left) && isRed(getNode(h->left)->left)) {
+            h = rotateRight(h);
+        }
+        if (isRed(h->left) && isRed(h->right)) {
+            flipColor(h);
+        }
+        return h;
+    }
+
+    Node* moveRedLeft(Node* h) {
+        flipColor(h);
+        Node* right = getNode(h->right);
+        if (isRed(right->left)) {
+            h->right = getIndex(rotateRight(right));
+            h = rotateLeft(h);
+            flipColor(h);
+        }
+        return h;
+    }
+
+    Node* moveRedRight(Node* h) {
+        flipColor(h);
+        if (isRed(getNode(h->left)->left)) {
+            h = rotateRight(h);
+            flipColor(h);
+        }
+        return h;
+    }
+
+    Node* getMinNode(Node* h) {
+        while (h->left != NULL_IDX) {
+            h = getNode(h->left);
+        }
+        return h;
+    }
+
+    Node* removeMin(Node* h) {
+        if (h->left == NULL_IDX) {
+            freeList_.push_back(getIndex(h));
+            return nullptr;
+        }
+
+        if (!isRed(h->left) && !isRed(getNode(h->left)->left)) {
+            h = moveRedLeft(h);
+        }
+
+        h->left = getIndex(removeMin(getNode(h->left)));
+        h->size--;
+        return fixUp(h);
+    }
+
+    Node* erase(Node* h, T value) {
+        CHECK(h != nullptr);
+
+        if (value < h->value) {
+            if (!isRed(h->left) && !isRed(getNode(h->left)->left)) {
+                h = moveRedLeft(h);
+            }
+            h->left = getIndex(erase(getNode(h->left), value));
+            h->size--;
+        } else {
+            if (isRed(h->left)) {
+                h = rotateRight(h);
+            }
+            if (h->value == value && h->right == NULL_IDX) {
+                freeList_.push_back(getIndex(h));
+                return nullptr;
+            }
+            if (!isRed(h->right) && !isRed(getNode(h->right)->left)) {
+                h = moveRedRight(h);
+            }
+            if (h->value == value) {
+                Node* minNode = getMinNode(getNode(h->right));
+                h->value = minNode->value;
+                h->right = getIndex(removeMin(getNode(h->right)));
+            } else {
+                h->right = getIndex(erase(getNode(h->right), value));
+            }
+        }
+
+        return fixUp(h);
+    }
+
+    Node* eraseAt(Node* h, uint32_t p, T& value) {
+        CHECK(h != nullptr);
+
+        if (p < h->size) {
+            if (!isRed(h->left) && !isRed(getNode(h->left)->left)) {
+                h = moveRedLeft(h);
+            }
+            h->left = getIndex(eraseAt(getNode(h->left), p, value));
+            h->size--;
+        } else {
+            if (isRed(h->left)) {
+                h = rotateRight(h);
+            }
+            if (p == h->size && h->right == NULL_IDX) {
+                value = h->value;
+                freeList_.push_back(getIndex(h));
+                return nullptr;
+            }
+            if (!isRed(h->right) && !isRed(getNode(h->right)->left)) {
+                h = moveRedRight(h);
+            }
+            if (h->size == p) {
+                value = h->value;
+                Node* minNode = getMinNode(getNode(h->right));
+                h->value = minNode->value;
+                h->right = getIndex(removeMin(getNode(h->right)));
+            } else {
+                h->right = getIndex(eraseAt(getNode(h->right), p - h->size - 1, value));
+            }
+        }
+
+        return fixUp(h);
+    }
+
+    bool isBST(Node* x, T* min, T* max) {
+        if (x == nullptr) {
+            return true;
+        }
+
+        if (min != nullptr && x->value <= *min) {
+            return false;
+        }
+
+        if (max != nullptr && x->value >= *max) {
+            return false;
+        }
+
+        return isBST(getNode(x->left), min, &x->value) &&
+               isBST(getNode(x->right), &x->value, max);
+    }
+
+    bool isSizeConsistent(Node* x, uint32_t& sum) {
+        if (x == nullptr) {
+            sum = 0;
+            return true;
+        }
+
+        uint32_t left_sum, right_sum;
+        if (!isSizeConsistent(getNode(x->left), left_sum)) {
+            return false;
+        }
+
+        if (x->size != left_sum) {
+            return false;
+        }
+
+        if (!isSizeConsistent(getNode(x->right), right_sum)) {
+            return false;
+        }
+
+        sum = left_sum + right_sum + 1;
+        return true;
+    }
+
+    bool is23(Node* x) {
+        if (x == nullptr) {
+            return true;
+        }
+
+        if (isRed(x->right)) {
+            return false;
+        }
+
+        if (x != getNode(root_) && x->color == RED && isRed(x->left)) {
+            return false;
+        }
+
+        return is23(getNode(x->left)) && is23(getNode(x->right));
+    }
+
+    bool isBalanced() {
+        uint32_t black = 0;
+        Node* x = root_;
+        while (x != nullptr) {
+            if (!isRed(x)) black++;
+            x = x.left;
+        }
+
+        return isBalanced(root_, black);
+    }
+
+    bool isBalanced(Node* x, int black) {
+        if (x == nullptr) {
+            return black == 0;
+        }
+
+        if (!isRed(x)) {
+            black--;
+        }
+
+        return isBalanced(x->left, black) && isBalanced(x->right, black);
+    }
+};
+
+} // quarkchain
+} // org

--- a/qkchash/util.h
+++ b/qkchash/util.h
@@ -1,0 +1,36 @@
+#ifndef __QKC_UTIL
+#define __QKC_UTIL
+
+const uint32_t FNV_PRIME_32 = 0x01000193;
+const uint64_t FNV_PRIME_64 = 0x100000001b3ULL;
+const uint64_t FNV_OFFSET_BASE_64 = 0xcbf29ce484222325ULL;
+
+/*
+ * 32-bit FNV function
+ */
+uint32_t fnv32(uint32_t v1, uint32_t v2) {
+    return (v1 * FNV_PRIME_32) ^ v2;
+}
+
+/*
+ * 64-bit FNV function
+ */
+uint64_t fnv64(uint64_t v1, uint64_t v2) {
+    return (v1 * FNV_PRIME_64) ^ v2;
+}
+
+/*
+ * 64-bit FNV-1a function
+ */
+uint64_t fnv64_1a(uint64_t v1, uint64_t v2) {
+    return (v1 ^ v2) * FNV_PRIME_64;
+}
+
+/*
+ * Abort the code if cond is false.
+ * Unlike assert(), which can be disabled by NDEBUG macro,
+ * check() will always abort the code if cond is false.
+ */
+#define CHECK(COND) ((COND) ? (void)0 : abort())
+
+#endif


### PR DESCRIPTION
Implemented a customized version of left-leaning red-black tree for qkchash with the following improvements:
- The nodes are allocated/freed in a contiguous memory space with freelist.  This makes node allocation/free and tree copy to be very efficient.  E.g., a 64K entries of GNU order-statistics tree copy takes about 6ms, while the code takes about <1ms

- Pointers are replaced by node index, which saves the tree size and may be more friendly to cache

Performance comparison:
ACCESS_ROUND = 64
- Before: 110 H/s
- After: 1200 H/s

ACCESS_ROUND = 128
- Before: 92 H/s
- After: 640 H/s