### PR TITLE
Finalize docker-related changes

### DIFF
--- a/quarkchain/db.py
+++ b/quarkchain/db.py
@@ -69,9 +69,14 @@ class PersistentDb(Db):
         options.write_buffer_size = 128 * 1024 * 1024  # 128 MiB
         options.max_write_buffer_number = 3
         options.target_file_size_base = 67108864
-        options.compression = rocksdb.CompressionType.lz4_compression
 
-        self._db = rocksdb.DB(db_path, options)
+        try:
+            options.compression = rocksdb.CompressionType.lz4_compression
+            self._db = rocksdb.DB(db_path, options)
+        except:
+            # in some cases lz4 is not linked to the binary
+            options.compression = rocksdb.CompressionType.snappy_compression
+            self._db = rocksdb.DB(db_path, options)
 
     def _destroy(self):
         shutil.rmtree(self.db_path, ignore_errors=True)

--- a/quarkchain/tools/external_miner.py
+++ b/quarkchain/tools/external_miner.py
@@ -3,6 +3,7 @@ import copy
 import functools
 import json
 import logging
+import os
 import random
 import signal
 import threading
@@ -115,6 +116,7 @@ class ExternalMiner(threading.Thread):
                         "consensus_type": config["consensus_type"],
                         "shard": shard_id,
                         "rounds": 100,
+                        "native_lib_path": os.environ.get("QKCHASHLIB"),
                     }
                     if mining_thread:
                         input_q.put((work, mining_params))

--- a/quarkchain/tools/external_miner_manager.sh
+++ b/quarkchain/tools/external_miner_manager.sh
@@ -44,12 +44,19 @@ shards_by_process=()
 i=0
 for shard in "${shards[@]}"; do
 	shards_by_process[$(( i % $process ))]+=" $shard"
-	i=$(( $i + 1))
+	i=$(( $i + 1 ))
 done
 
 miner_py_path="$( cd "$(dirname "$0")" ; pwd -P )/external_miner.py"
 for shards_per_process in "${shards_by_process[@]}"; do
-	python $miner_py_path \
+	# shard 6, 7 running python+qkchash native to prevent mem leak
+	# others running pypy3
+	if [ "$j" -ge 6 ]; then
+                py=python3.6
+        else
+                py=pypy3
+	fi
+	$py $miner_py_path \
 		--host   $host \
 		--config $config \
 		--worker $thread \

--- a/quarkchain/tools/external_miner_manager.sh
+++ b/quarkchain/tools/external_miner_manager.sh
@@ -48,6 +48,7 @@ for shard in "${shards[@]}"; do
 done
 
 miner_py_path="$( cd "$(dirname "$0")" ; pwd -P )/external_miner.py"
+j=0
 for shards_per_process in "${shards_by_process[@]}"; do
 	# shard 6, 7 running python+qkchash native to prevent mem leak
 	# others running pypy3
@@ -61,6 +62,7 @@ for shards_per_process in "${shards_by_process[@]}"; do
 		--config $config \
 		--worker $thread \
 		--shards $shards_per_process &
+	j=$(( $j + 1 ))
 done
 
 wait

--- a/testnet/2/Dockerfile
+++ b/testnet/2/Dockerfile
@@ -1,0 +1,64 @@
+FROM ubuntu:bionic
+
+MAINTAINER quarkchain
+
+### set up basic system packages
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y libpq-dev libxml2-dev libxslt1-dev nginx openssh-client openssh-server openssl rsyslog rsyslog-gnutls liblcms2-dev libwebp-dev python-tk libfreetype6-dev vim-nox imagemagick libffi-dev libgmp-dev build-essential libssl-dev software-properties-common pkg-config libtool python3-dev && \
+    apt-get clean
+
+# install git
+RUN apt-get update && apt-get install -y git-core && apt-get clean
+
+# install rocksdb
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev libgflags-dev liblz4-dev libzstd-dev librocksdb-dev
+# WORKDIR /opt
+# RUN git clone https://github.com/facebook/rocksdb.git
+# RUN cd rocksdb && DEBUG_LEVEL=0 make shared_lib install-shared
+# RUN mkdir /data
+
+# install python development tools, setuptools and pip
+# pypy3
+WORKDIR /opt
+RUN wget https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-linux64.tar.bz2
+RUN tar fxv pypy3-v6.0.0-linux64.tar.bz2
+RUN ln -s /opt/pypy3-v6.0.0-linux64/bin/pypy3 /usr/bin/pypy3
+RUN pypy3 -m ensurepip
+RUN pypy3 -m pip install -U pip wheel
+# cpython
+RUN apt-get install -y curl
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN python3 get-pip.py
+
+# configure locale
+RUN apt-get update && apt-get install -y locales
+RUN locale-gen en_US.UTF-8 && dpkg-reconfigure --frontend noninteractive locales
+ENV LC_ALL="en_US.UTF-8" LANG="en_US.UTF-8"
+
+EXPOSE 22 80 443 38291 38391 38491 8000 29000
+
+### set up code
+RUN mkdir /code
+WORKDIR /code
+RUN git clone https://github.com/QuarkChain/pyquarkchain.git
+
+# pypy3 dep
+RUN pypy3 -m pip install -r pyquarkchain/requirements.txt
+# crypto lib issue
+# https://github.com/ethereum/pyethapp/issues/274#issuecomment-385268798
+RUN pypy3 -m pip uninstall -y pyelliptic
+RUN pypy3 -m pip install https://github.com/mfranciszkiewicz/pyelliptic/archive/1.5.10.tar.gz#egg=pyelliptic
+# cpython dep, used for mining qkchash
+RUN python3 -m pip install -r pyquarkchain/requirements.txt
+
+# build qkchash c++ lib
+WORKDIR /code/pyquarkchain/qkchash
+RUN make
+
+ENV PYTHONPATH /code/pyquarkchain
+ENV QKCHASHLIB /code/pyquarkchain/qkchash/libqkchash.so
+
+WORKDIR /code/pyquarkchain
+
+# one mining related dep
+RUN apt-get install -y jq


### PR DESCRIPTION
1. qkchashlib path in external miner is read from env (easier to configure in docker)
1. auto switch to snappy if lz4 not linked. this happens in ubuntu while installing rocksdb from package manager. may consider a better way to force using lz4 in the future
1. pypy3 mining qkchash has memory leak issues, so switch to python3 for shard 6 and shard 7
1. add the example Dockerfile