### PR TITLE
Cache the cache to speed up ethash

### DIFF
--- a/ethereum/pow/ethpow.py
+++ b/ethereum/pow/ethpow.py
@@ -5,7 +5,7 @@ from typing import Tuple, Optional, List, Union
 from eth_utils import big_endian_to_int
 
 from ethereum.pow import ethash
-from ethereum.pow.ethash_utils import get_full_size, get_cache_size
+from ethereum.pow.ethash_utils import get_full_size, get_cache_size, EPOCH_LENGTH
 
 try:
     import pyethash
@@ -36,8 +36,12 @@ if ETHASH_LIB == "ethash":
     hashimoto = hashimoto_slow
 elif ETHASH_LIB == "pyethash":
 
+    @lru_cache(10)
+    def calculate_cache(n):
+        return pyethash.mkcache_bytes(n * EPOCH_LENGTH)
+
     def get_cache(cache_size: int, block_number: int):
-        return pyethash.mkcache_bytes(block_number)
+        return calculate_cache(block_number // EPOCH_LENGTH)
 
     def hashimoto(
         block_number: int,


### PR DESCRIPTION
```
BEFORE:
In [1]: from ethereum.pow.ethpow import get_cache

In [2]: %timeit get_cache(1,1)
624 ms ± 15.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

AFTER:
In [2]: from ethereum.pow.ethpow import get_cache

In [3]: %timeit get_cache(1,1)
The slowest run took 4.25 times longer than the fastest. This could mean that an intermediate result is being cached.
6.82 µs ± 4.68 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [4]: %%timeit
   ...: try:
   ...:     validate_seal(RootBlockHeader(), ConsensusType.POW_ETHASH)
   ...: except Exception:
   ...:     pass
   ...: 
2.63 ms ± 326 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```