### PR TITLE
Fixing bugs that causes missing minor blocks in root block

### DIFF
--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -601,7 +601,7 @@ class Shard:
 
             block_hash = block.header.get_hash()
             try:
-                xshard_list = self.state.add_block(block)
+                xshard_list = self.state.add_block(block, skip_if_too_old=False)
             except Exception as e:
                 Logger.error_exception()
                 return False

--- a/quarkchain/cluster/slave.py
+++ b/quarkchain/cluster/slave.py
@@ -408,10 +408,15 @@ class MasterConnection(ClusterConnection):
                 )
                 check(len(block_chain) == len(blocks_to_download))
 
-                await self.slave_server.add_block_list_for_sync(block_chain)
+                add_block_success = await self.slave_server.add_block_list_for_sync(
+                    block_chain
+                )
+                if not add_block_success:
+                    raise RuntimeError(
+                        "Failed to add minor blocks for syncing root block"
+                    )
                 block_hash_list = block_hash_list[BLOCK_BATCH_SIZE:]
-
-        except Exception as e:
+        except Exception:
             Logger.error_exception()
             return SyncMinorBlockListResponse(error_code=1)
 


### PR DESCRIPTION
There were two issues:
1. shard_state.add_block returns False on failure but
slave.handle_sync_minor_block_list_request expected Exception.
Failing to add minor block (minor block was too old) didn't cause adding
root block to fail and thus we saw some minor blocks are missing from
the cluster.

2. Adding minor blocks for syncing root blocks should skip the age
check. Because root block mining is falling behind in testnet this case
happens quite often.