### PR TITLE
Pass miner and difficulty to getStats JRPC

### DIFF
--- a/quarkchain/cluster/jsonrpc.py
+++ b/quarkchain/cluster/jsonrpc.py
@@ -144,6 +144,7 @@ def root_block_encoder(block):
         "nonce": quantity_encoder(header.nonce),
         "hashMerkleRoot": data_encoder(header.hash_merkle_root),
         "miner": address_encoder(header.coinbase_address.serialize()),
+        "coinbase": quantity_encoder(header.coinbase_amount),
         "difficulty": quantity_encoder(header.difficulty),
         "timestamp": quantity_encoder(header.create_time),
         "size": quantity_encoder(len(block.serialize())),
@@ -164,6 +165,8 @@ def root_block_encoder(block):
             "hashPrevRootBlock": data_encoder(header.hash_prev_root_block),
             "nonce": quantity_encoder(header.nonce),
             "difficulty": quantity_encoder(header.difficulty),
+            "miner": address_encoder(header.coinbase_address.serialize()),
+            "coinbase": quantity_encoder(header.coinbase_amount),
             "timestamp": quantity_encoder(header.create_time),
         }
         d["minorBlockHeaders"].append(h)
@@ -196,6 +199,7 @@ def minor_block_encoder(block, include_transactions=False):
         "hashMerkleRoot": data_encoder(meta.hash_merkle_root),
         "hashEvmStateRoot": data_encoder(meta.hash_evm_state_root),
         "miner": address_encoder(header.coinbase_address.serialize()),
+        "coinbase": quantity_encoder(header.coinbase_amount),
         "difficulty": quantity_encoder(header.difficulty),
         "extraData": data_encoder(header.extra_data),
         "gasLimit": quantity_encoder(header.evm_gas_limit),

--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -265,6 +265,8 @@ class SyncTask:
             _, result, _ = result
             if result.error_code != 0:
                 raise RuntimeError("Unable to download minor blocks from root block")
+            if result.shard_stats:
+                self.master_server.update_shard_stats(result.shard_stats)
 
         for m_header in minor_block_header_list:
             self.root_state.add_validated_minor_block_hash(m_header.get_hash())
@@ -1256,6 +1258,10 @@ class MasterServer:
         for shard_stats in self.branch_to_shard_stats.values():
             shard_id = shard_stats.branch.get_shard_id()
             shards[shard_id]["height"] = shard_stats.height
+            shards[shard_id]["difficulty"] = shard_stats.difficulty
+            shards[shard_id]["coinbaseAddress"] = (
+                "0x" + shard_stats.coinbase_address.to_hex()
+            )
             shards[shard_id]["timestamp"] = shard_stats.timestamp
             shards[shard_id]["txCount60s"] = shard_stats.tx_count60s
             shards[shard_id]["pendingTxCount"] = shard_stats.pending_tx_count
@@ -1315,6 +1321,8 @@ class MasterServer:
             "shardServerCount": len(self.slave_pool),
             "shardSize": self.__get_shard_size(),
             "rootHeight": self.root_state.tip.height,
+            "rootDifficulty": self.root_state.tip.difficulty,
+            "rootCoinbaseAddress": "0x" + self.root_state.tip.coinbase_address.to_hex(),
             "rootTimestamp": self.root_state.tip.create_time,
             "rootLastBlockTime": root_last_block_time,
             "txCount60s": tx_count60s,

--- a/quarkchain/cluster/rpc.py
+++ b/quarkchain/cluster/rpc.py
@@ -496,6 +496,48 @@ class AddTransactionResponse(Serializable):
         self.error_code = error_code
 
 
+class ShardStats(Serializable):
+    FIELDS = [
+        ("branch", Branch),
+        ("height", uint64),
+        ("difficulty", biguint),
+        ("coinbase_address", Address),
+        ("timestamp", uint64),
+        ("tx_count60s", uint32),
+        ("pending_tx_count", uint32),
+        ("total_tx_count", uint32),
+        ("block_count60s", uint32),
+        ("stale_block_count60s", uint32),
+        ("last_block_time", uint32),
+    ]
+
+    def __init__(
+        self,
+        branch: Branch,
+        height: int,
+        difficulty: int,
+        coinbase_address: Address,
+        timestamp: int,
+        tx_count60s: int,
+        pending_tx_count: int,
+        total_tx_count: int,
+        block_count60s: int,
+        stale_block_count60s: int,
+        last_block_time: int,
+    ):
+        self.branch = branch
+        self.height = height
+        self.difficulty = difficulty
+        self.coinbase_address = coinbase_address
+        self.timestamp = timestamp
+        self.tx_count60s = tx_count60s
+        self.pending_tx_count = pending_tx_count
+        self.total_tx_count = total_tx_count
+        self.block_count60s = block_count60s
+        self.stale_block_count60s = stale_block_count60s
+        self.last_block_time = last_block_time
+
+
 class SyncMinorBlockListRequest(Serializable):
     FIELDS = [
         ("minor_block_hash_list", PrependedSizeListSerializer(4, hash256)),
@@ -510,49 +552,14 @@ class SyncMinorBlockListRequest(Serializable):
 
 
 class SyncMinorBlockListResponse(Serializable):
-    FIELDS = [("error_code", uint32)]
+    FIELDS = [("error_code", uint32), ("shard_stats", Optional(ShardStats))]
 
-    def __init__(self, error_code):
+    def __init__(self, error_code, shard_stats=None):
         self.error_code = error_code
+        self.shard_stats = shard_stats
 
 
 # slave -> master
-
-
-class ShardStats(Serializable):
-    FIELDS = [
-        ("branch", Branch),
-        ("height", uint64),
-        ("timestamp", uint64),
-        ("tx_count60s", uint32),
-        ("pending_tx_count", uint32),
-        ("total_tx_count", uint32),
-        ("block_count60s", uint32),
-        ("stale_block_count60s", uint32),
-        ("last_block_time", uint32),
-    ]
-
-    def __init__(
-        self,
-        branch: Branch,
-        height: int,
-        timestamp: int,
-        tx_count60s: int,
-        pending_tx_count: int,
-        total_tx_count: int,
-        block_count60s: int,
-        stale_block_count60s: int,
-        last_block_time: int,
-    ):
-        self.branch = branch
-        self.height = height
-        self.timestamp = timestamp
-        self.tx_count60s = tx_count60s
-        self.pending_tx_count = pending_tx_count
-        self.total_tx_count = total_tx_count
-        self.block_count60s = block_count60s
-        self.stale_block_count60s = stale_block_count60s
-        self.last_block_time = last_block_time
 
 
 class AddMinorBlockHeaderRequest(Serializable):

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -1382,6 +1382,8 @@ class ShardState:
         return ShardStats(
             branch=self.branch,
             height=self.header_tip.height,
+            difficulty=self.header_tip.difficulty,
+            coinbase_address=self.header_tip.coinbase_address,
             timestamp=self.header_tip.create_time,
             tx_count60s=tx_count,
             pending_tx_count=len(self.tx_queue),


### PR DESCRIPTION
Also in sync minor blocks response pass back ShardStats so that
during initial root block sync the ShardStats won't be empty.