### PR TITLE
fix keccak image memory leak

### DIFF
--- a/quarkchain/p2p/auth.py
+++ b/quarkchain/p2p/auth.py
@@ -7,14 +7,15 @@ from typing import Tuple
 
 from quarkchain.utils import Logger
 from eth_hash.auto import keccak
+from Crypto.Hash import (
+    keccak as keccaklib,
+)  # keccak from pycryptodome, py-evm uses pysha3, seems the same
 from eth_hash.preimage import BasePreImage
 
 import rlp
 from rlp import sedes
 
 from eth_keys import datatypes, keys
-
-from eth_hash.auto import keccak
 
 from quarkchain.p2p.cancel_token.token import CancelToken
 
@@ -152,9 +153,17 @@ class HandshakeBase:
 
         # setup keccak instances for the MACs
         # egress-mac = sha3.keccak_256(mac-secret ^ recipient-nonce || auth-sent-init)
-        mac1 = keccak.new(sxor(mac_secret, responder_nonce) + auth_init_ciphertext)
+        mac1 = keccaklib.new(
+            data=sxor(mac_secret, responder_nonce) + auth_init_ciphertext,
+            digest_bits=256,
+            update_after_digest=True,
+        )
         # ingress-mac = sha3.keccak_256(mac-secret ^ initiator-nonce || auth-recvd-ack)
-        mac2 = keccak.new(sxor(mac_secret, initiator_nonce) + auth_ack_ciphertext)
+        mac2 = keccaklib.new(
+            data=sxor(mac_secret, initiator_nonce) + auth_ack_ciphertext,
+            digest_bits=256,
+            update_after_digest=True,
+        )
 
         if self._is_initiator:
             egress_mac, ingress_mac = mac1, mac2

--- a/quarkchain/p2p/auth.py
+++ b/quarkchain/p2p/auth.py
@@ -9,7 +9,7 @@ from quarkchain.utils import Logger
 from eth_hash.auto import keccak
 from Crypto.Hash import (
     keccak as keccaklib,
-)  # keccak from pycryptodome, py-evm uses pysha3, seems the same
+)  # keccak from pycryptodome; unlike eth_hash, its update() method does not leak memory
 from eth_hash.preimage import BasePreImage
 
 import rlp

--- a/quarkchain/p2p/tests/test_auth.py
+++ b/quarkchain/p2p/tests/test_auth.py
@@ -224,7 +224,17 @@ async def test_handshake_eip8():
 
     # Also according to https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8.md, running B's
     # ingress-mac keccak state on the string "foo" yields the following hash:
-    ingress_mac_copy = ingress_mac.copy()
+    # ingress_mac_copy = ingress_mac.copy()
+    # QKC NOTE: see eth_hash/backends/pycryptodome.py
+    # pycryptodome doesn't expose a `copy` mechanism for it's hash objects
+    # and we don't want to use eth_hash's preimage because it LEAKS MEMORY
+    _, _, _, ingress_mac_copy = responder.derive_secrets(
+        initiator_nonce,
+        responder_nonce,
+        initiator_ephemeral_pubkey,
+        auth_init_ciphertext,
+        auth_ack_ciphertext,
+    )
     ingress_mac_copy.update(b"foo")
     assert ingress_mac_copy.digest().hex() == (
         "0c7ec6340062cc46f5e9f1e3cf86f8c8c403c5a0964f5df0ebd34a75ddc86db5"


### PR DESCRIPTION
#252 
this causes tests to break now, because of the `copy()` call in tests, will fix later