### PR TITLE
add back simulated mining flag

### DIFF
--- a/quarkchain/cluster/cluster_config.py
+++ b/quarkchain/cluster/cluster_config.py
@@ -123,6 +123,7 @@ class ClusterConfig(BaseConfig):
     DB_PATH_ROOT = "./db"
     LOG_LEVEL = "info"
 
+    START_SIMULATED_MINING = False
     CLEAN = False
     GENESIS_DIR = None
 
@@ -186,6 +187,12 @@ class ClusterConfig(BaseConfig):
         parser.add_argument("--log_level", default=ClusterConfig.LOG_LEVEL, type=str)
         parser.add_argument(
             "--clean", action="store_true", default=ClusterConfig.CLEAN, dest="clean"
+        )
+        parser.add_argument(
+            "--start_simulated_mining",
+            action="store_true",
+            default=ClusterConfig.START_SIMULATED_MINING,
+            dest="start_simulated_mining",
         )
         pwd = os.path.dirname(os.path.abspath(__file__))
         default_genesis_dir = os.path.join(pwd, "../genesis_data")
@@ -283,6 +290,7 @@ class ClusterConfig(BaseConfig):
             config.PRIVATE_JSON_RPC_PORT = args.json_rpc_private_port
 
             config.CLEAN = args.clean
+            config.START_SIMULATED_MINING = args.start_simulated_mining
             config.ENABLE_TRANSACTION_HISTORY = args.enable_transaction_history
 
             config.QUARKCHAIN.update(

--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -1502,6 +1502,10 @@ def main():
     master.start()
     master.wait_until_cluster_active()
 
+    # kick off simulated mining if enabled
+    if env.cluster_config.START_SIMULATED_MINING:
+        asyncio.ensure_future(master.start_mining())
+
     loop = asyncio.get_event_loop()
 
     if env.cluster_config.use_p2p():


### PR DESCRIPTION
was removed in #221 
it turns out that we still need the flag as a convenience when doing quick tests
to avoid confusion, I changed the name to START_SIMULATED_MINING