### PR TITLE
Improve root chain synchronizer

### DIFF
--- a/quarkchain/cluster/jsonrpc.py
+++ b/quarkchain/cluster/jsonrpc.py
@@ -1013,6 +1013,10 @@ class JSONRPCServer:
         return {"peers": peer_list}
 
     @private_methods.add
+    async def getSyncStats(self):
+        return self.master.synchronizer.get_stats()
+
+    @private_methods.add
     async def getStats(self):
         # This JRPC doesn't follow the standard encoding
         return await self.master.get_stats()


### PR DESCRIPTION
Instead of using a FIFO queue use a dict to record the latest root
header from each peer. Always pick the heighest root header to sync.

Added a "getSyncStats" private JRPC.

```
{'queuedTasks': [{'peerId': 'a66afe1eb473a4dd294096f95da0446459cbfb01e71651a5c98426ec48e12dc0',
   'peerIp': '52.11.34.67',
   'peerPort': 38291,
   'rootHash': '12f4c5b91f19447be7a795e6a1ff2e4b5a982ba1cde5870f48e2b64f364b0db2',
   'rootHeight': 8814},
  {'peerId': 'b543b2022ff6cc8e2145393b763fc017baef6e0ff950348c773f2f6af5e527d1',
   'peerIp': '107.150.60.146',
   'peerPort': 38291,
   'rootHash': '1a8ce1b44327251777186947f8baf4706cfbd7f4ecf4d983c7b6493a9d002703',
   'rootHeight': 8299},
  {'peerId': '9b849f10f701bcac43d8f06b385eb11c93aa2fe2e615d7dfecd475a2382a5403',
   'peerIp': '198.204.235.122',
   'peerPort': 38291,
   'rootHash': '12f4c5b91f19447be7a795e6a1ff2e4b5a982ba1cde5870f48e2b64f364b0db2',
   'rootHeight': 8814}],
 'runningTask': {'peerId': 'a66afe1eb473a4dd294096f95da0446459cbfb01e71651a5c98426ec48e12dc0',
  'peerIp': '52.11.34.67',
  'peerPort': 38291,
  'rootHash': '6338c540267b3fc1eb09a337f308f7dfc656c01c60ce4042b80150a3c5242002',
  'rootHeight': 8811}}
```

