### PR TITLE
Quick miner tools for non-technical miners

### DIFF
--- a/quarkchain/tools/check_syncing_state.py
+++ b/quarkchain/tools/check_syncing_state.py
@@ -27,8 +27,8 @@ def checkHeight(private_client, public_client, timeout=TIMEOUT):
         jsonrpcclient.Request("getRootBlockByHeight"),
         timeout=timeout,)
     return {
-        "height": str(result_private["height"]),
-        "currentHeight": str(result_public["height"]),
+        "height": int(result_private["height"], 16),
+        "currentHeight": int(result_public["height"], 16),
     }
 
 
@@ -52,11 +52,11 @@ def query_height(private_client, public_client, args):
                 print("Failed to get the current root height", e)
                 time.sleep(2)
 
-        syncing_state = ("False" if data["height"] >= data["currentHeight"] else "True")
+        syncing_state = (False if data["height"] >= data["currentHeight"] else True)
         
-        print(format.format(time=now(), syncing=syncing_state, height=int(data["height"], 16), currentHeight=int(data["currentHeight"], 16)))
+        print(format.format(time=now(), syncing=str(syncing_state), height=data["height"], currentHeight=data["currentHeight"]))
 
-        if data["height"] >= data["currentHeight"]:
+        if syncing_state is False:
             break
         time.sleep(args.interval)
 

--- a/quarkchain/tools/check_syncing_state.py
+++ b/quarkchain/tools/check_syncing_state.py
@@ -1,0 +1,79 @@
+#! /usr/bin/env python3
+
+import argparse
+import logging
+import time
+from datetime import datetime
+import jsonrpcclient
+import psutil
+import numpy
+from decimal import Decimal
+
+
+# disable jsonrpcclient verbose logging
+logging.getLogger("jsonrpcclient.client.request").setLevel(logging.WARNING)
+logging.getLogger("jsonrpcclient.client.response").setLevel(logging.WARNING)
+
+
+def now():
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+def checkHeight(private_client, public_client):
+    s_p = private_client.send(jsonrpcclient.Request("getRootBlockByHeight"))
+    s_b = public_client.send(jsonrpcclient.Request("getRootBlockByHeight"))
+    return {
+        "time": now(),
+        "syncing": "True",
+        "height": str(s_p["height"]),
+        "currentHeight": str(s_b["height"]),
+    }
+
+
+
+def query_height(private_client, public_client, args):
+    format = "{time:20} {syncing:>15}{height:>30}{currentHeight:>30}"
+    print(
+        format.format(
+            time="Timestamp",
+            syncing="Syncing",
+            height="LocalRootHeight",
+            currentHeight="CurrentRootHeight",
+        )
+    )
+    while True:
+        data = checkHeight(private_client, public_client)
+        if data["height"] >= data["currentHeight"]:
+            break
+
+        print(format.format(time=now(), syncing="True", height=int(data["height"], 16), currentHeight=int(data["currentHeight"], 16)))
+        time.sleep(args.interval)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ip", default="localhost", type=str, help="Cluster IP")
+
+
+    parser.add_argument("--bootstrapip", default="54.70.162.141", type=str, help="Bootstrap Cluster IP")
+
+    parser.add_argument(
+        "-i", "--interval", default=10, type=int, help="Query interval in second"
+    )
+
+    args = parser.parse_args()
+
+    private_endpoint = "http://{}:38391".format(args.ip)
+    private_client = jsonrpcclient.HTTPClient(private_endpoint)
+
+    public_endpoint = "http://{}:38391".format(args.bootstrapip)
+    public_client = jsonrpcclient.HTTPClient(public_endpoint)
+
+
+
+
+    query_height(private_client, public_client, args)
+
+
+if __name__ == "__main__":
+    # query syncing state
+    main()

--- a/quarkchain/tools/check_syncing_state.py
+++ b/quarkchain/tools/check_syncing_state.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#! /usr/bin/env pypy3
 
 import argparse
 import logging
@@ -9,6 +9,7 @@ import psutil
 import numpy
 from decimal import Decimal
 
+TIMEOUT=10
 
 # disable jsonrpcclient verbose logging
 logging.getLogger("jsonrpcclient.client.request").setLevel(logging.WARNING)
@@ -18,14 +19,16 @@ logging.getLogger("jsonrpcclient.client.response").setLevel(logging.WARNING)
 def now():
     return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
-def checkHeight(private_client, public_client):
-    s_p = private_client.send(jsonrpcclient.Request("getRootBlockByHeight"))
-    s_b = public_client.send(jsonrpcclient.Request("getRootBlockByHeight"))
+def checkHeight(private_client, public_client, timeout=TIMEOUT):
+    result_private = private_client.send(
+        jsonrpcclient.Request("getRootBlockByHeight"),
+        timeout=timeout,)
+    result_public = public_client.send(
+        jsonrpcclient.Request("getRootBlockByHeight"),
+        timeout=timeout,)
     return {
-        "time": now(),
-        "syncing": "True",
-        "height": str(s_p["height"]),
-        "currentHeight": str(s_b["height"]),
+        "height": str(result_private["height"]),
+        "currentHeight": str(result_public["height"]),
     }
 
 
@@ -41,11 +44,20 @@ def query_height(private_client, public_client, args):
         )
     )
     while True:
-        data = checkHeight(private_client, public_client)
+        while True:
+            try:
+                data = checkHeight(private_client, public_client)
+                break
+            except Exception as e:
+                print("Failed to get the current root height", e)
+                time.sleep(2)
+
+        syncing_state = ("False" if data["height"] >= data["currentHeight"] else "True")
+        
+        print(format.format(time=now(), syncing=syncing_state, height=int(data["height"], 16), currentHeight=int(data["currentHeight"], 16)))
+
         if data["height"] >= data["currentHeight"]:
             break
-
-        print(format.format(time=now(), syncing="True", height=int(data["height"], 16), currentHeight=int(data["currentHeight"], 16)))
         time.sleep(args.interval)
 
 

--- a/quarkchain/tools/quick_miner_stopper.sh
+++ b/quarkchain/tools/quick_miner_stopper.sh
@@ -4,6 +4,10 @@ pkill -f master.py
 
 pkill -f slave.py
 
-screen -ls | grep -i detached | cut -d. -f1 | tr -d [:blank:]| xargs kill
+pkill -f external_miner.py
+
+pkill -f check_syncing_state.py
+
+screen -ls | grep -i detached | cut -d. -f1 | tr -d [:blank:] | xargs kill
 
 wait

--- a/quarkchain/tools/quick_miner_stopper.sh
+++ b/quarkchain/tools/quick_miner_stopper.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+
+pkill pypy3
+
+screen -ls | grep -i detached | cut -d. -f1 | tr -d [:blank:]| xargs kill

--- a/quarkchain/tools/quick_miner_stopper.sh
+++ b/quarkchain/tools/quick_miner_stopper.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
+pkill -f master.py
 
-pkill pypy3
+pkill -f slave.py
 
 screen -ls | grep -i detached | cut -d. -f1 | tr -d [:blank:]| xargs kill
+
+wait

--- a/quarkchain/tools/quick_miner_tool.sh
+++ b/quarkchain/tools/quick_miner_tool.sh
@@ -1,27 +1,15 @@
 #!/bin/bash
 
+screen -dmS jobs
+
 clear
 echo "Step 1: Enter or generate your coinbase address!"
 
 miner_tools_path="$(pwd -P)/quarkchain/tools/miner_address.py"
 pypy3 $miner_tools_path
 
-                                  
-
-screen -dmS jobs
-
-screen -S jobs -X screen bash
-
-screen -S jobs -p bash -X title cluster
-
-screen -S jobs -p cluster -X stuff $'pypy3 quarkchain/cluster/cluster.py --cluster_config "$(pwd -P)/testnet/2/cluster_config_template.json" 
-'
-
-
-
 echo "Step 2: Download a snapshot of the database. Your cluster only need to sync
 the blocks mined in the past 12 hours or less."
-
 
 
 curl https://s3-us-west-2.amazonaws.com/testnet2/data/22/`curl https://s3-us-west-2.amazonaws.com/testnet2/data/22/LATEST`.tar.gz --output data.tar.gz 
@@ -33,6 +21,15 @@ miner_data_path="$(pwd -P)/quarkchain/cluster/data"
 rm -rf $miner_data_path
 
 mv data $miner_data_path
+
+
+screen -S jobs -X screen bash
+
+screen -S jobs -p bash -X title cluster
+
+screen -S jobs -p cluster -X stuff $'pypy3 quarkchain/cluster/cluster.py --cluster_config "$(pwd -P)/testnet/2/cluster_config_template.json" 
+'
+
 
 seconds_left=20
 

--- a/quarkchain/tools/quick_miner_tool.sh
+++ b/quarkchain/tools/quick_miner_tool.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+clear
+echo "Step 1: Enter or generate your coinbase address!"
+
+miner_tools_path="$(pwd -P)/quarkchain/tools/miner_address.py"
+pypy3 $miner_tools_path
+
+echo -n "Enter your coinbase address again!"   
+echo -n "Paste your address:"                
+read  address                                   
+    
+
+
+
+screen -dmS jobs
+
+screen -S jobs -X screen bash
+
+screen -S jobs -p bash -X title cluster
+
+screen -S jobs -p cluster -X stuff $'pypy3 quarkchain/cluster/cluster.py --cluster_config "$(pwd -P)/testnet/2/cluster_config_template.json" 
+'
+
+echo "Dear quarkchain miner, your tQkc address is $address." 
+
+
+echo "Step 2: Download a snapshot of the database. Your cluster only need to sync
+the blocks mined in the past 12 hours or less."
+
+
+
+#curl https://s3-us-west-2.amazonaws.com/testnet2/data/22/`curl https://s3-us-west-2.amazonaws.com/testnet2/data/22/LATEST`.tar.gz --output data.tar.gz 
+
+#tar xvfz data.tar.gz
+
+#miner_data_path="$(pwd -P)/quarkchain/cluster/data"
+
+#rm -rf $miner_data_path
+
+#mv data $miner_data_path
+
+seconds_left=20
+
+echo "Step 3: Initial the cluster and start synchorizing blocks in the past 12 hours or less. Please wait for time: ${seconds_left} seconds……"
+while [ $seconds_left -gt 0 ];do
+    echo -n "${seconds_left} seconds left"
+    sleep 1
+    seconds_left=$(($seconds_left - 1))
+    echo -ne "\r     \r" 
+done
+
+echo "Step 4: Start synchorizing blocks in the past 12 hours or less. It takes about five minutes. Be patient!"
+pypy3 quarkchain/tools/check_syncing_state.py
+
+
+
+
+
+while true; do
+    read -p "Step 4: Do you wish to start mining now?(Y or N)" yn
+    case $yn in
+        [Yy]* ) bash quarkchain/tools/external_miner_manager.sh -c "$(pwd -P)/testnet/2/cluster_config_template.json" -p 9 -t 1 -h localhost;
+                break;;
+        [Nn]* ) bash quarkchain/tools/quick_miner_stopper.sh
+                exit;;
+        * ) echo "Please answer Y or N.";;
+    esac
+done
+
+screen -rd

--- a/quarkchain/tools/quick_miner_tool.sh
+++ b/quarkchain/tools/quick_miner_tool.sh
@@ -6,12 +6,7 @@ echo "Step 1: Enter or generate your coinbase address!"
 miner_tools_path="$(pwd -P)/quarkchain/tools/miner_address.py"
 pypy3 $miner_tools_path
 
-echo -n "Enter your coinbase address again!"   
-echo -n "Paste your address:"                
-read  address                                   
-    
-
-
+                                  
 
 screen -dmS jobs
 
@@ -22,7 +17,6 @@ screen -S jobs -p bash -X title cluster
 screen -S jobs -p cluster -X stuff $'pypy3 quarkchain/cluster/cluster.py --cluster_config "$(pwd -P)/testnet/2/cluster_config_template.json" 
 '
 
-echo "Dear quarkchain miner, your tQkc address is $address." 
 
 
 echo "Step 2: Download a snapshot of the database. Your cluster only need to sync
@@ -60,7 +54,7 @@ pypy3 quarkchain/tools/check_syncing_state.py
 while true; do
     read -p "Step 4: Do you wish to start mining now?(Y or N)" yn
     case $yn in
-        [Yy]* ) bash quarkchain/tools/external_miner_manager.sh -c "$(pwd -P)/testnet/2/cluster_config_template.json" -p 9 -t 1 -h localhost;
+        [Yy]* ) bash quarkchain/tools/external_miner_manager.sh -c "$(pwd -P)/testnet/2/cluster_config_template.json" -p 8 -h localhost;
                 break;;
         [Nn]* ) bash quarkchain/tools/quick_miner_stopper.sh
                 exit;;
@@ -68,4 +62,4 @@ while true; do
     esac
 done
 
-screen -rd
+wait

--- a/quarkchain/tools/quick_miner_tool.sh
+++ b/quarkchain/tools/quick_miner_tool.sh
@@ -30,15 +30,15 @@ the blocks mined in the past 12 hours or less."
 
 
 
-#curl https://s3-us-west-2.amazonaws.com/testnet2/data/22/`curl https://s3-us-west-2.amazonaws.com/testnet2/data/22/LATEST`.tar.gz --output data.tar.gz 
+curl https://s3-us-west-2.amazonaws.com/testnet2/data/22/`curl https://s3-us-west-2.amazonaws.com/testnet2/data/22/LATEST`.tar.gz --output data.tar.gz 
 
-#tar xvfz data.tar.gz
+tar xvfz data.tar.gz
 
-#miner_data_path="$(pwd -P)/quarkchain/cluster/data"
+miner_data_path="$(pwd -P)/quarkchain/cluster/data"
 
-#rm -rf $miner_data_path
+rm -rf $miner_data_path
 
-#mv data $miner_data_path
+mv data $miner_data_path
 
 seconds_left=20
 


### PR DESCRIPTION
The quick miner tools are designed for the non-technical miners. Just run the bash file and follow the guidance. Then the tools can help them initialize the cluster and external miners.

cd pyquarkchain

When you want to start the quick miner, just use the following command lines.
bash quarkchain/tools/quick_miner_tool.sh

When you want to stop it, just run 
bash quarkchain/tools/quick_miner_stopper.sh