### PR TITLE
Use same work dir for m/s processes

### DIFF
--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
-import ipaddress
+import os
+
 import psutil
 import random
 import time
@@ -1532,6 +1533,8 @@ def parse_args():
 
 def main():
     from quarkchain.cluster.jsonrpc import JSONRPCServer
+
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
     env = parse_args()
     root_state = RootState(env)

--- a/quarkchain/cluster/slave.py
+++ b/quarkchain/cluster/slave.py
@@ -1,8 +1,7 @@
 import argparse
 import asyncio
 import errno
-import ipaddress
-import sys
+import os
 from typing import Optional, Tuple, Dict, List, Union
 
 from quarkchain.cluster.cluster_config import ClusterConfig
@@ -1214,6 +1213,8 @@ def parse_args():
 
 def main():
     env = parse_args()
+
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
     slave_server = SlaveServer(env)
     slave_server.start_and_loop()


### PR DESCRIPTION
ran into a problem that the `./data` in config means `/code/pyquarkchain/data` instead of `/code/pyquarkchain/quarkchain/cluster/data` when running master and slave independently