### PR TITLE
Do not timeout add_block

### DIFF
--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -166,7 +166,7 @@ class SyncTask:
                 raise RuntimeError("Bad peer missing blocks for headers they have")
 
             for block in block_chain:
-                await asyncio.wait_for(self.__add_block(block), TIMEOUT)
+                await self.__add_block(block)
                 block_header_chain.pop(0)
 
     def __has_block_hash(self, block_hash):

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -305,7 +305,7 @@ class SyncTask:
                     block.header.hash_prev_root_block
                 ):
                     return
-                await asyncio.wait_for(self.shard.add_block(block), TIMEOUT)
+                await self.shard.add_block(block)
                 block_header_chain.pop(0)
 
     def __has_block_hash(self, block_hash):


### PR DESCRIPTION
add_block should be treated as "atomic" operation.
Timing out in the middle broke this assumption and left cluster in
bad state, e.g., unable to sync new blocks.