### PR TITLE
s/full_shard_id/full_shard_key/g

### DIFF
--- a/fixtures/0001-Necessary-changes-to-let-evm-tests-pass.patch
+++ b/fixtures/0001-Necessary-changes-to-let-evm-tests-pass.patch
@@ -24,9 +24,9 @@ index 04213c9..5b4a595 100644
 @@ -424,9 +423,7 @@ def _apply_msg(ext, msg, code):
  
  
- def mk_contract_address(sender, full_shard_id, nonce):
+ def mk_contract_address(sender, full_shard_key, nonce):
 -    return utils.sha3(
--        rlp.encode([utils.normalize_address(sender), full_shard_id, nonce])
+-        rlp.encode([utils.normalize_address(sender), full_shard_key, nonce])
 -    )[12:]
 +    return utils.sha3(rlp.encode([utils.normalize_address(sender), nonce]))[12:]
  
@@ -40,19 +40,19 @@ index 1cd0341..e7156d8 100644
          ("balance", big_endian_int),
          ("storage", trie_root),
          ("code_hash", hash32),
--        ("full_shard_id", BigEndianInt(4)),
+-        ("full_shard_key", BigEndianInt(4)),
      ]
  
  
  class Account(rlp.Serializable):
      def __init__(
--        self, nonce, balance, storage, code_hash, full_shard_id, env, address, db=None
+-        self, nonce, balance, storage, code_hash, full_shard_key, env, address, db=None
 +        self,
 +        nonce,
 +        balance,
 +        storage,
 +        code_hash,
-+        full_shard_id=0,
++        full_shard_key=0,
 +        env=None,
 +        address=None,
 +        db=None,
@@ -62,14 +62,14 @@ index 1cd0341..e7156d8 100644
          self.env = env
          self.address = address
  
--        acc = _Account(nonce, balance, storage, code_hash, full_shard_id)
+-        acc = _Account(nonce, balance, storage, code_hash, full_shard_key)
 +        acc = _Account(nonce, balance, storage, code_hash)
          self.nonce = acc.nonce
          self.balance = acc.balance
          self.storage = acc.storage
          self.code_hash = acc.code_hash
--        self.full_shard_id = acc.full_shard_id
-+        self.full_shard_id = full_shard_id
+-        self.full_shard_key = acc.full_shard_key
++        self.full_shard_key = full_shard_key
  
          self.storage_cache = {}
          self.storage_trie = SecureTrie(Trie(self.db))
@@ -77,7 +77,7 @@ index 1cd0341..e7156d8 100644
                  balance=o.balance,
                  storage=o.storage,
                  code_hash=o.code_hash,
--                full_shard_id=o.full_shard_id,
+-                full_shard_key=o.full_shard_key,
                  env=self.env,
                  address=address,
                  db=self.db,
@@ -89,7 +89,7 @@ index 1cd0341..e7156d8 100644
 -                        acct.balance,
 -                        acct.storage,
 -                        acct.code_hash,
--                        acct.full_shard_id,
+-                        acct.full_shard_key,
 +                        acct.nonce, acct.balance, acct.storage, acct.code_hash
                      )
                      self.trie.update(addr, rlp.encode(_acct))
@@ -101,7 +101,7 @@ index acbccec..59425d1 100644
 @@ -71,7 +71,7 @@ class Transaction(rlp.Serializable):
  
      def __init__(self, nonce, gasprice, startgas, to, value, data,
-                  v=0, r=0, s=0, from_full_shard_id=0, to_full_shard_id=0, network_id=1, version=0):
+                  v=0, r=0, s=0, from_full_shard_key=0, to_full_shard_key=0, network_id=1, version=0):
 -        self.shard_size = 0
 +        self.shard_size = 1
  

--- a/fixtures/0001-Necessary-changes-to-let-evm-tests-pass.patch
+++ b/fixtures/0001-Necessary-changes-to-let-evm-tests-pass.patch
@@ -98,10 +98,10 @@ diff --git a/quarkchain/evm/transactions.py b/quarkchain/evm/transactions.py
 index acbccec..59425d1 100644
 --- a/quarkchain/evm/transactions.py
 +++ b/quarkchain/evm/transactions.py
-@@ -71,7 +71,7 @@ class Transaction(rlp.Serializable):
- 
-     def __init__(self, nonce, gasprice, startgas, to, value, data,
-                  v=0, r=0, s=0, from_full_shard_key=0, to_full_shard_key=0, network_id=1, version=0):
+@@ -91,7 +91,7 @@ class Transaction(rlp.Serializable):
+         network_id=1,
+         version=0,
+     ):
 -        self.shard_size = 0
 +        self.shard_size = 1
  

--- a/quarkchain/cluster/shard_db_operator.py
+++ b/quarkchain/cluster/shard_db_operator.py
@@ -41,12 +41,12 @@ class TransactionHistoryMixin:
 
     def __update_transaction_history_index(self, tx, block_height, index, func):
         evm_tx = tx.code.get_evm_transaction()
-        addr = Address(evm_tx.sender, evm_tx.from_full_shard_id)
+        addr = Address(evm_tx.sender, evm_tx.from_full_shard_key)
         key = self.__encode_address_transaction_key(addr, block_height, index, False)
         func(key, b"")
         # "to" can be empty for smart contract deployment
-        if evm_tx.to and self.branch.is_in_shard(evm_tx.to_full_shard_id):
-            addr = Address(evm_tx.to, evm_tx.to_full_shard_id)
+        if evm_tx.to and self.branch.is_in_shard(evm_tx.to_full_shard_key):
+            addr = Address(evm_tx.to, evm_tx.to_full_shard_key)
             key = self.__encode_address_transaction_key(
                 addr, block_height, index, False
             )
@@ -141,8 +141,8 @@ class TransactionHistoryMixin:
                 tx_list.append(
                     TransactionDetail(
                         tx.get_hash(),
-                        Address(evm_tx.sender, evm_tx.from_full_shard_id),
-                        Address(evm_tx.to, evm_tx.to_full_shard_id)
+                        Address(evm_tx.sender, evm_tx.from_full_shard_key),
+                        Address(evm_tx.to, evm_tx.to_full_shard_key)
                         if evm_tx.to
                         else None,
                         evm_tx.value,

--- a/quarkchain/cluster/tests/test_cluster.py
+++ b/quarkchain/cluster/tests/test_cluster.py
@@ -12,7 +12,7 @@ from quarkchain.utils import call_async, assert_true_with_timeout
 class TestCluster(unittest.TestCase):
     def test_single_cluster(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
         with ClusterContext(1, acc1) as clusters:
             self.assertEqual(len(clusters), 1)
 
@@ -54,10 +54,10 @@ class TestCluster(unittest.TestCase):
 
     def test_get_next_block_to_mine(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_random_account(full_shard_id=0)
-        acc3 = Address.create_random_account(full_shard_id=1)
-        acc4 = Address.create_random_account(full_shard_id=1)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_random_account(full_shard_key=0)
+        acc3 = Address.create_random_account(full_shard_key=1)
+        acc4 = Address.create_random_account(full_shard_key=1)
 
         with ClusterContext(1, acc1) as clusters:
             master = clusters[0].master
@@ -140,8 +140,8 @@ class TestCluster(unittest.TestCase):
 
     def test_get_primary_account_data(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_random_account(full_shard_id=1)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_random_account(full_shard_key=1)
 
         with ClusterContext(1, acc1) as clusters:
             master = clusters[0].master
@@ -183,8 +183,8 @@ class TestCluster(unittest.TestCase):
 
     def test_add_transaction(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_from_identity(id1, full_shard_id=1)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_from_identity(id1, full_shard_key=1)
 
         with ClusterContext(2, acc1) as clusters:
             master = clusters[0].master
@@ -224,7 +224,7 @@ class TestCluster(unittest.TestCase):
 
     def test_add_minor_block_request_list(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         with ClusterContext(2, acc1) as clusters:
             shard_state = clusters[0].slave_list[0].shards[Branch(0b10)].state
@@ -273,7 +273,7 @@ class TestCluster(unittest.TestCase):
 
     def test_add_root_block_request_list(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         with ClusterContext(2, acc1) as clusters:
             # shutdown cluster connection
@@ -383,7 +383,7 @@ class TestCluster(unittest.TestCase):
 
     def test_shard_synchronizer_with_fork(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         with ClusterContext(2, acc1) as clusters:
             # shutdown cluster connection
@@ -547,8 +547,8 @@ class TestCluster(unittest.TestCase):
     def test_broadcast_cross_shard_transactions(self):
         """ Test the cross shard transactions are broadcasted to the destination shards """
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc3 = Address.create_random_account(full_shard_id=1)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc3 = Address.create_random_account(full_shard_key=1)
 
         with ClusterContext(1, acc1) as clusters:
             master = clusters[0].master
@@ -649,7 +649,7 @@ class TestCluster(unittest.TestCase):
     def test_broadcast_cross_shard_transactions_to_neighbor_only(self):
         """ Test the broadcast is only done to the neighbors """
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         # create 64 shards so that the neighbor rule can kick in
         # explicitly set num_slaves to 4 so that it does not spin up 64 slaves

--- a/quarkchain/cluster/tests/test_filter.py
+++ b/quarkchain/cluster/tests/test_filter.py
@@ -17,7 +17,7 @@ class TestFilter(unittest.TestCase):
     def setUp(self):
         super().setUp()
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         state = create_default_shard_state(env=env)
@@ -25,7 +25,7 @@ class TestFilter(unittest.TestCase):
             shard_state=state,
             key=id1.get_key(),
             from_address=acc1,
-            to_full_shard_id=acc1.full_shard_id,
+            to_full_shard_key=acc1.full_shard_key,
         )
         self.assertTrue(state.add_tx(tx))
         b = state.create_block_to_mine(address=acc1)
@@ -43,7 +43,7 @@ class TestFilter(unittest.TestCase):
                 key=id1.get_key(),
                 from_address=acc1,
                 to_address=Address.create_from_identity(
-                    Identity.create_random_identity(), full_shard_id=0
+                    Identity.create_random_identity(), full_shard_key=0
                 ),
                 value=1,
                 gas=40000,
@@ -84,7 +84,7 @@ class TestFilter(unittest.TestCase):
         for criteria in hit_criteria:
             addresses = []
             if not criteria:
-                addresses = [Address(self.log.recipient, full_shard_id=0)]
+                addresses = [Address(self.log.recipient, full_shard_key=0)]
             f = self.filter_gen_with_criteria(criteria, addresses)
             blocks = f._get_block_candidates()
             self.assertEqual(len(blocks), 1)

--- a/quarkchain/cluster/tests/test_jsonrpc.py
+++ b/quarkchain/cluster/tests/test_jsonrpc.py
@@ -52,8 +52,8 @@ def send_request(*args):
 class TestJSONRPC(unittest.TestCase):
     def test_getTransactionCount(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_random_account(full_shard_id=1)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_random_account(full_shard_key=1)
 
         with ClusterContext(
             1, acc1, small_coinbase=True
@@ -101,8 +101,8 @@ class TestJSONRPC(unittest.TestCase):
 
     def test_sendTransaction(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_random_account(full_shard_id=1)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_random_account(full_shard_key=1)
 
         with ClusterContext(
             1, acc1, small_coinbase=True
@@ -117,8 +117,8 @@ class TestJSONRPC(unittest.TestCase):
                 to=acc2.recipient,
                 value=15,
                 data=b"",
-                from_full_shard_id=acc1.full_shard_id,
-                to_full_shard_id=acc2.full_shard_id,
+                from_full_shard_key=acc1.full_shard_key,
+                to_full_shard_key=acc2.full_shard_key,
                 network_id=slaves[0].env.quark_chain_config.NETWORK_ID,
             )
             evm_tx.sign(id1.get_key())
@@ -147,8 +147,8 @@ class TestJSONRPC(unittest.TestCase):
     def test_sendTransaction_with_bad_signature(self):
         """ sendTransaction validates signature """
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_random_account(full_shard_id=1)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_random_account(full_shard_key=1)
 
         with ClusterContext(
             1, acc1, small_coinbase=True
@@ -171,9 +171,9 @@ class TestJSONRPC(unittest.TestCase):
             self.assertIsNone(send_request("sendTransaction", [request]))
             self.assertEqual(len(slaves[0].shards[branch].state.tx_queue), 0)
 
-    def test_sendTransaction_missing_from_full_shard_id(self):
+    def test_sendTransaction_missing_from_full_shard_key(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         with ClusterContext(
             1, acc1, small_coinbase=True
@@ -194,7 +194,7 @@ class TestJSONRPC(unittest.TestCase):
 
     def test_getMinorBlock(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         with ClusterContext(
             1, acc1, small_coinbase=True
@@ -256,7 +256,7 @@ class TestJSONRPC(unittest.TestCase):
 
     def test_getTransactionById(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         with ClusterContext(
             1, acc1, small_coinbase=True
@@ -284,13 +284,13 @@ class TestJSONRPC(unittest.TestCase):
                 "getTransactionById",
                 "0x"
                 + tx.get_hash().hex()
-                + acc1.full_shard_id.to_bytes(4, "big").hex(),
+                + acc1.full_shard_key.to_bytes(4, "big").hex(),
             )
             self.assertEqual(resp["hash"], "0x" + tx.get_hash().hex())
 
     def test_call_success(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         with ClusterContext(
             1, acc1, small_coinbase=True
@@ -311,7 +311,7 @@ class TestJSONRPC(unittest.TestCase):
 
     def test_call_success_default_gas(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         with ClusterContext(
             1, acc1, small_coinbase=True
@@ -333,7 +333,7 @@ class TestJSONRPC(unittest.TestCase):
 
     def test_call_failure(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         with ClusterContext(
             1, acc1, small_coinbase=True
@@ -355,7 +355,7 @@ class TestJSONRPC(unittest.TestCase):
 
     def test_getTransactionReceipt_not_exist(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         with ClusterContext(
             1, acc1, small_coinbase=True
@@ -366,7 +366,7 @@ class TestJSONRPC(unittest.TestCase):
 
     def test_getTransactionReceipt_on_transfer(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         with ClusterContext(
             1, acc1, small_coinbase=True
@@ -392,7 +392,7 @@ class TestJSONRPC(unittest.TestCase):
                     endpoint,
                     "0x"
                     + tx.get_hash().hex()
-                    + acc1.full_shard_id.to_bytes(4, "big").hex(),
+                    + acc1.full_shard_key.to_bytes(4, "big").hex(),
                 )
                 self.assertEqual(resp["transactionHash"], "0x" + tx.get_hash().hex())
                 self.assertEqual(resp["status"], "0x1")
@@ -401,8 +401,8 @@ class TestJSONRPC(unittest.TestCase):
 
     def test_getTransactionReceipt_on_x_shard_transfer(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_from_identity(id1, full_shard_id=1)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_from_identity(id1, full_shard_key=1)
 
         with ClusterContext(
             1, acc1, small_coinbase=True
@@ -447,7 +447,7 @@ class TestJSONRPC(unittest.TestCase):
                     endpoint,
                     "0x"
                     + tx.get_hash().hex()
-                    + acc2.full_shard_id.to_bytes(4, "big").hex(),
+                    + acc2.full_shard_key.to_bytes(4, "big").hex(),
                 )
                 self.assertEqual(resp["transactionHash"], "0x" + tx.get_hash().hex())
                 self.assertEqual(resp["status"], "0x1")
@@ -457,7 +457,7 @@ class TestJSONRPC(unittest.TestCase):
 
     def test_getTransactionReceipt_on_contract_creation(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         with ClusterContext(
             1, acc1, small_coinbase=True
@@ -466,12 +466,12 @@ class TestJSONRPC(unittest.TestCase):
             slaves = clusters[0].slave_list
 
             branch = Branch.create(2, 0)
-            to_full_shard_id = acc1.full_shard_id + 2
+            to_full_shard_key = acc1.full_shard_key + 2
             tx = create_contract_creation_transaction(
                 shard_state=slaves[0].shards[branch].state,
                 key=id1.get_key(),
                 from_address=acc1,
-                to_full_shard_id=to_full_shard_id,
+                to_full_shard_key=to_full_shard_key,
             )
             self.assertTrue(slaves[0].add_tx(tx))
 
@@ -487,18 +487,18 @@ class TestJSONRPC(unittest.TestCase):
                 self.assertEqual(resp["cumulativeGasUsed"], "0x213eb")
 
                 contract_address = mk_contract_address(
-                    acc1.recipient, to_full_shard_id, 0
+                    acc1.recipient, to_full_shard_key, 0
                 )
                 self.assertEqual(
                     resp["contractAddress"],
                     "0x"
                     + contract_address.hex()
-                    + to_full_shard_id.to_bytes(4, "big").hex(),
+                    + to_full_shard_key.to_bytes(4, "big").hex(),
                 )
 
     def test_getTransactionReceipt_on_contract_creation_failure(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         with ClusterContext(
             1, acc1, small_coinbase=True
@@ -513,14 +513,14 @@ class TestJSONRPC(unittest.TestCase):
             call_async(master.add_root_block(root_block))
 
             branch = Branch.create(2, 0)
-            to_full_shard_id = (
-                acc1.full_shard_id + 1
+            to_full_shard_key = (
+                acc1.full_shard_key + 1
             )  # x-shard contract creation should fail
             tx = create_contract_creation_transaction(
                 shard_state=slaves[0].shards[branch].state,
                 key=id1.get_key(),
                 from_address=acc1,
-                to_full_shard_id=to_full_shard_id,
+                to_full_shard_key=to_full_shard_key,
             )
             self.assertTrue(slaves[0].add_tx(tx))
 
@@ -538,7 +538,7 @@ class TestJSONRPC(unittest.TestCase):
 
     def test_getLogs(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         expected_log_parts = {
             "logIndex": "0x0",
@@ -559,7 +559,7 @@ class TestJSONRPC(unittest.TestCase):
                 shard_state=slaves[0].shards[branch].state,
                 key=id1.get_key(),
                 from_address=acc1,
-                to_full_shard_id=acc1.full_shard_id,
+                to_full_shard_key=acc1.full_shard_key,
             )
             self.assertTrue(slaves[0].add_tx(tx))
 
@@ -567,7 +567,7 @@ class TestJSONRPC(unittest.TestCase):
             self.assertTrue(call_async(clusters[0].get_shard(0).add_block(block)))
 
             for using_eth_endpoint in (True, False):
-                shard_id = hex(acc1.full_shard_id)
+                shard_id = hex(acc1.full_shard_key)
                 if using_eth_endpoint:
                     req = lambda o: send_request("eth_getLogs", o, shard_id)
                 else:
@@ -581,7 +581,7 @@ class TestJSONRPC(unittest.TestCase):
 
                 # filter by contract address
                 contract_addr = mk_contract_address(
-                    acc1.recipient, acc1.full_shard_id, 0
+                    acc1.recipient, acc1.full_shard_key, 0
                 )
                 filter_obj = {
                     "address": "0x"
@@ -589,7 +589,7 @@ class TestJSONRPC(unittest.TestCase):
                     + (
                         ""
                         if using_eth_endpoint
-                        else hex(acc1.full_shard_id)[2:].zfill(8)
+                        else hex(acc1.full_shard_key)[2:].zfill(8)
                     )
                 }
                 resp = req(filter_obj)
@@ -619,7 +619,7 @@ class TestJSONRPC(unittest.TestCase):
 
     def test_estimateGas(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         with ClusterContext(
             1, acc1, small_coinbase=True
@@ -634,7 +634,7 @@ class TestJSONRPC(unittest.TestCase):
             "c987d4506fb6824639f9a9e3b8834584f5165e94680501d1b0044071cd36c3b3"
         )
         id1 = Identity.create_from_key(key)
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
         created_addr = "0x8531eb33bba796115f56ffa1b7df1ea3acdd8cdd00000000"
 
         with ClusterContext(
@@ -648,7 +648,7 @@ class TestJSONRPC(unittest.TestCase):
                 shard_state=slaves[0].shards[branch].state,
                 key=id1.get_key(),
                 from_address=acc1,
-                to_full_shard_id=acc1.full_shard_id,
+                to_full_shard_key=acc1.full_shard_key,
             )
             self.assertTrue(slaves[0].add_tx(tx))
 
@@ -693,7 +693,7 @@ class TestJSONRPC(unittest.TestCase):
             "c987d4506fb6824639f9a9e3b8834584f5165e94680501d1b0044071cd36c3b3"
         )
         id1 = Identity.create_from_key(key)
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
         created_addr = "0x8531eb33bba796115f56ffa1b7df1ea3acdd8cdd00000000"
 
         with ClusterContext(
@@ -707,7 +707,7 @@ class TestJSONRPC(unittest.TestCase):
                 shard_state=slaves[0].shards[branch].state,
                 key=id1.get_key(),
                 from_address=acc1,
-                to_full_shard_id=acc1.full_shard_id,
+                to_full_shard_key=acc1.full_shard_key,
             )
             self.assertTrue(slaves[0].add_tx(tx))
 
@@ -727,7 +727,7 @@ class TestJSONRPC(unittest.TestCase):
 
     def test_gasPrice(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         with ClusterContext(
             1, acc1, small_coinbase=True
@@ -761,7 +761,7 @@ class TestJSONRPC(unittest.TestCase):
 
     def test_getWork_and_submitWork(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         with ClusterContext(
             1, acc1, remote_mining=True, shard_size=1, small_coinbase=True

--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -39,7 +39,7 @@ class TestShardState(unittest.TestCase):
 
     def test_gas_price(self):
         id_list = [Identity.create_random_identity() for _ in range(5)]
-        acc_list = [Address.create_from_identity(i, full_shard_id=0) for i in id_list]
+        acc_list = [Address.create_from_identity(i, full_shard_key=0) for i in id_list]
         env = get_test_env(genesis_account=acc_list[0], genesis_minor_quarkash=10000000)
         state = create_default_shard_state(env=env)
 
@@ -70,8 +70,8 @@ class TestShardState(unittest.TestCase):
 
     def test_estimate_gas(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_random_account(full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_random_account(full_shard_key=0)
         env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         state = create_default_shard_state(env=env)
         tx_gen = lambda data: create_transfer_transaction(
@@ -91,8 +91,8 @@ class TestShardState(unittest.TestCase):
 
     def test_execute_tx(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_random_account(full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_random_account(full_shard_key=0)
         env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         state = create_default_shard_state(env=env)
         tx = create_transfer_transaction(
@@ -109,8 +109,8 @@ class TestShardState(unittest.TestCase):
 
     def test_add_tx_incorrect_from_shard_id(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=1)
-        acc2 = Address.create_random_account(full_shard_id=1)
+        acc1 = Address.create_from_identity(id1, full_shard_key=1)
+        acc2 = Address.create_random_account(full_shard_key=1)
         env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         state = create_default_shard_state(env=env)
         # state is shard 0 but tx from shard 1
@@ -126,9 +126,9 @@ class TestShardState(unittest.TestCase):
 
     def test_one_tx(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_random_account(full_shard_id=0)
-        acc3 = Address.create_random_account(full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_random_account(full_shard_key=0)
+        acc3 = Address.create_random_account(full_shard_key=0)
 
         env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         state = create_default_shard_state(env=env)
@@ -186,9 +186,9 @@ class TestShardState(unittest.TestCase):
         self.assertEqual(r.success, b"\x01")
         self.assertEqual(r.gas_used, 21000)
 
-        # Check Account has full_shard_id
+        # Check Account has full_shard_key
         self.assertEqual(
-            state.evm_state.get_full_shard_id(acc2.recipient), acc2.full_shard_id
+            state.evm_state.get_full_shard_key(acc2.recipient), acc2.full_shard_key
         )
 
         tx_list, _ = state.db.get_transactions_by_address(acc1)
@@ -198,9 +198,9 @@ class TestShardState(unittest.TestCase):
 
     def test_duplicated_tx(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_random_account(full_shard_id=0)
-        acc3 = Address.create_random_account(full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_random_account(full_shard_key=0)
+        acc3 = Address.create_random_account(full_shard_key=0)
 
         env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         state = create_default_shard_state(env=env)
@@ -253,8 +253,8 @@ class TestShardState(unittest.TestCase):
 
     def test_add_invalid_tx_fail(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_random_account(full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_random_account(full_shard_key=0)
 
         env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         state = create_default_shard_state(env=env)
@@ -271,9 +271,9 @@ class TestShardState(unittest.TestCase):
 
     def test_add_non_neighbor_tx_fail(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_random_account(full_shard_id=3)  # not acc1's neighbor
-        acc3 = Address.create_random_account(full_shard_id=8)  # acc1's neighbor
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_random_account(full_shard_key=3)  # not acc1's neighbor
+        acc3 = Address.create_random_account(full_shard_key=8)  # acc1's neighbor
 
         env = get_test_env(
             genesis_account=acc1, genesis_minor_quarkash=10000000, shard_size=64
@@ -304,9 +304,9 @@ class TestShardState(unittest.TestCase):
 
     def test_exceeding_xshard_limit(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_random_account(full_shard_id=1)
-        acc3 = Address.create_random_account(full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_random_account(full_shard_key=1)
+        acc3 = Address.create_random_account(full_shard_key=0)
 
         env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         # a huge number to make xshard tx limit become 0 so that no xshard tx can be
@@ -345,9 +345,9 @@ class TestShardState(unittest.TestCase):
     def test_two_tx_in_one_block(self):
         id1 = Identity.create_random_identity()
         id2 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_from_identity(id2, full_shard_id=0)
-        acc3 = Address.create_random_account(full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_from_identity(id2, full_shard_key=0)
+        acc3 = Address.create_random_account(full_shard_key=0)
 
         env = get_test_env(
             genesis_account=acc1, genesis_minor_quarkash=2000000 + opcodes.GTXCOST
@@ -373,9 +373,9 @@ class TestShardState(unittest.TestCase):
             opcodes.GTXCOST // 2 + self.shard_coinbase // 2,
         )
 
-        # Check Account has full_shard_id
+        # Check Account has full_shard_key
         self.assertEqual(
-            state.evm_state.get_full_shard_id(acc2.recipient), acc2.full_shard_id
+            state.evm_state.get_full_shard_key(acc2.recipient), acc2.full_shard_key
         )
 
         state.add_tx(
@@ -384,7 +384,7 @@ class TestShardState(unittest.TestCase):
                 key=id1.get_key(),
                 from_address=acc1,
                 to_address=Address(
-                    acc2.recipient, acc2.full_shard_id + 2
+                    acc2.recipient, acc2.full_shard_key + 2
                 ),  # set a different full shard id
                 value=12345,
                 gas=50000,
@@ -435,18 +435,18 @@ class TestShardState(unittest.TestCase):
         self.assertEqual(block, b1)
         self.assertEqual(i, 1)
 
-        # Check acc2 full_shard_id doesn't change
+        # Check acc2 full_shard_key doesn't change
         self.assertEqual(
-            state.evm_state.get_full_shard_id(acc2.recipient), acc2.full_shard_id
+            state.evm_state.get_full_shard_key(acc2.recipient), acc2.full_shard_key
         )
 
     def test_fork_does_not_confirm_tx(self):
         """Tx should only be confirmed and removed from tx queue by the best chain"""
         id1 = Identity.create_random_identity()
         id2 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_from_identity(id2, full_shard_id=0)
-        acc3 = Address.create_random_account(full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_from_identity(id2, full_shard_key=0)
+        acc3 = Address.create_random_account(full_shard_key=0)
 
         env = get_test_env(
             genesis_account=acc1, genesis_minor_quarkash=2000000 + opcodes.GTXCOST
@@ -483,9 +483,9 @@ class TestShardState(unittest.TestCase):
         """Tx in the reverted chain should be put back to the queue"""
         id1 = Identity.create_random_identity()
         id2 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_from_identity(id2, full_shard_id=0)
-        acc3 = Address.create_random_account(full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_from_identity(id2, full_shard_key=0)
+        acc3 = Address.create_random_account(full_shard_key=0)
 
         env = get_test_env(
             genesis_account=acc1, genesis_minor_quarkash=2000000 + opcodes.GTXCOST
@@ -530,8 +530,8 @@ class TestShardState(unittest.TestCase):
 
     def test_stale_block_count(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc3 = Address.create_random_account(full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc3 = Address.create_random_account(full_shard_key=0)
 
         env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         state = create_default_shard_state(env=env)
@@ -548,9 +548,9 @@ class TestShardState(unittest.TestCase):
 
     def test_xshard_tx_sent(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_from_identity(id1, full_shard_id=1)
-        acc3 = Address.create_random_account(full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_from_identity(id1, full_shard_key=1)
+        acc3 = Address.create_random_account(full_shard_key=0)
 
         env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         state = create_default_shard_state(env=env, shard_id=0)
@@ -609,9 +609,9 @@ class TestShardState(unittest.TestCase):
 
     def test_xshard_tx_insufficient_gas(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_from_identity(id1, full_shard_id=1)
-        acc3 = Address.create_random_account(full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_from_identity(id1, full_shard_key=1)
+        acc3 = Address.create_random_account(full_shard_key=0)
 
         env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         state = create_default_shard_state(env=env, shard_id=0)
@@ -633,9 +633,9 @@ class TestShardState(unittest.TestCase):
 
     def test_xshard_tx_received(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_from_identity(id1, full_shard_id=16)
-        acc3 = Address.create_random_account(full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_from_identity(id1, full_shard_key=16)
+        acc3 = Address.create_random_account(full_shard_key=0)
 
         env0 = get_test_env(
             genesis_account=acc1, genesis_minor_quarkash=10000000, shard_size=64
@@ -716,9 +716,9 @@ class TestShardState(unittest.TestCase):
 
     def test_xshard_tx_received_exclude_non_neighbor(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_from_identity(id1, full_shard_id=3)
-        acc3 = Address.create_random_account(full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_from_identity(id1, full_shard_key=3)
+        acc3 = Address.create_random_account(full_shard_key=0)
 
         env0 = get_test_env(
             genesis_account=acc1, genesis_minor_quarkash=10000000, shard_size=64
@@ -784,9 +784,9 @@ class TestShardState(unittest.TestCase):
 
     def test_xshard_for_two_root_blocks(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
-        acc2 = Address.create_from_identity(id1, full_shard_id=1)
-        acc3 = Address.create_random_account(full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_from_identity(id1, full_shard_key=1)
+        acc3 = Address.create_random_account(full_shard_key=0)
 
         env0 = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         env1 = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
@@ -909,7 +909,7 @@ class TestShardState(unittest.TestCase):
 
     def test_fork_resolve(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         state = create_default_shard_state(env=env, shard_id=0)
@@ -931,7 +931,7 @@ class TestShardState(unittest.TestCase):
 
     def test_root_chain_first_consensus(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         env0 = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         env1 = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
@@ -977,7 +977,7 @@ class TestShardState(unittest.TestCase):
 
     def test_shard_state_add_root_block(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         env0 = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         env1 = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
@@ -1062,7 +1062,7 @@ class TestShardState(unittest.TestCase):
 
     def test_shard_state_add_root_block_too_many_minor_blocks(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         env = get_test_env(
             genesis_account=acc1, genesis_minor_quarkash=10000000, shard_size=1
@@ -1093,7 +1093,7 @@ class TestShardState(unittest.TestCase):
 
     def test_shard_state_fork_resolve_with_higher_root_chain(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         state = create_default_shard_state(env=env, shard_id=0)
@@ -1161,7 +1161,7 @@ class TestShardState(unittest.TestCase):
 
     def test_shard_state_recovery_from_root_block(self):
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
 
         env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         state = create_default_shard_state(env=env, shard_id=0)
@@ -1211,7 +1211,7 @@ class TestShardState(unittest.TestCase):
     def test_add_block_receipt_root_not_match(self):
         id1 = Identity.create_random_identity()
         acc1 = Address.create_from_identity(id1)
-        acc3 = Address.create_random_account(full_shard_id=0)
+        acc3 = Address.create_random_account(full_shard_key=0)
 
         env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         state = create_default_shard_state(env=env)
@@ -1248,7 +1248,7 @@ class TestShardState(unittest.TestCase):
         are not on the same root chain.
         """
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
         env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         state = create_default_shard_state(env=env, shard_id=0)
 
@@ -1300,7 +1300,7 @@ class TestShardState(unittest.TestCase):
         Adding r3 should change the root_tip to r3, header_tip to m2
         """
         id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_id=0)
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
         env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=10000000)
         state = create_default_shard_state(env=env, shard_id=0)
 

--- a/quarkchain/cluster/tests/test_utils.py
+++ b/quarkchain/cluster/tests/test_utils.py
@@ -94,8 +94,8 @@ def create_transfer_transaction(
         to=to_address.recipient,
         value=value,
         data=data,
-        from_full_shard_id=from_address.full_shard_id,
-        to_full_shard_id=to_address.full_shard_id,
+        from_full_shard_key=from_address.full_shard_key,
+        to_full_shard_key=to_address.full_shard_key,
         network_id=shard_state.env.quark_chain_config.NETWORK_ID,
     )
     evm_tx.sign(key=key)
@@ -128,7 +128,7 @@ contract Storage {
 CONTRACT_WITH_STORAGE = "6080604052348015600f57600080fd5b506104d260008190555061162e600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002081905550603580606c6000396000f3006080604052600080fd00a165627a7a72305820a6ef942c101f06333ac35072a8ff40332c71d0e11cd0e6d86de8cae7b42696550029"
 
 
-def _contract_tx_gen(shard_state, key, from_address, to_full_shard_id, bytecode):
+def _contract_tx_gen(shard_state, key, from_address, to_full_shard_key, bytecode):
     evm_tx = EvmTransaction(
         nonce=shard_state.get_transaction_count(from_address.recipient),
         gasprice=1,
@@ -136,8 +136,8 @@ def _contract_tx_gen(shard_state, key, from_address, to_full_shard_id, bytecode)
         value=0,
         to=b"",
         data=bytes.fromhex(bytecode),
-        from_full_shard_id=from_address.full_shard_id,
-        to_full_shard_id=to_full_shard_id,
+        from_full_shard_key=from_address.full_shard_key,
+        to_full_shard_key=to_full_shard_key,
         network_id=shard_state.env.quark_chain_config.NETWORK_ID,
     )
     evm_tx.sign(key)
@@ -145,30 +145,30 @@ def _contract_tx_gen(shard_state, key, from_address, to_full_shard_id, bytecode)
 
 
 def create_contract_creation_transaction(
-    shard_state, key, from_address, to_full_shard_id
+    shard_state, key, from_address, to_full_shard_key
 ):
     return _contract_tx_gen(
-        shard_state, key, from_address, to_full_shard_id, CONTRACT_CREATION_BYTECODE
+        shard_state, key, from_address, to_full_shard_key, CONTRACT_CREATION_BYTECODE
     )
 
 
 def create_contract_creation_with_event_transaction(
-    shard_state, key, from_address, to_full_shard_id
+    shard_state, key, from_address, to_full_shard_key
 ):
     return _contract_tx_gen(
         shard_state,
         key,
         from_address,
-        to_full_shard_id,
+        to_full_shard_key,
         CONTRACT_CREATION_WITH_EVENT_BYTECODE,
     )
 
 
 def create_contract_with_storage_transaction(
-    shard_state, key, from_address, to_full_shard_id
+    shard_state, key, from_address, to_full_shard_key
 ):
     return _contract_tx_gen(
-        shard_state, key, from_address, to_full_shard_id, CONTRACT_WITH_STORAGE
+        shard_state, key, from_address, to_full_shard_key, CONTRACT_WITH_STORAGE
     )
 
 

--- a/quarkchain/cluster/tx_generator.py
+++ b/quarkchain/cluster/tx_generator.py
@@ -9,10 +9,10 @@ from quarkchain.utils import Logger
 from quarkchain.config import QuarkChainConfig
 
 
-def random_full_shard_id(shard_size, shard_id):
-    full_shard_id = random.randint(0, (2 ** 32) - 1)
+def random_full_shard_key(shard_size, shard_id):
+    full_shard_key = random.randint(0, (2 ** 32) - 1)
     shard_mask = shard_size - 1
-    return full_shard_id & (~shard_mask) | shard_id
+    return full_shard_key & (~shard_mask) | shard_id
 
 
 class Account:
@@ -91,32 +91,32 @@ class TransactionGenerator:
         # skip if from shard is specified and not matching current branch
         # FIXME: it's possible that clients want to specify '0x0' as the full shard ID, however it will not be supported
         if (
-            sample_evm_tx.from_full_shard_id
-            and (sample_evm_tx.from_full_shard_id & shard_mask) != from_shard
+            sample_evm_tx.from_full_shard_key
+            and (sample_evm_tx.from_full_shard_key & shard_mask) != from_shard
         ):
             return None
 
-        if sample_evm_tx.from_full_shard_id:
-            from_full_shard_id = sample_evm_tx.from_full_shard_id
+        if sample_evm_tx.from_full_shard_key:
+            from_full_shard_key = sample_evm_tx.from_full_shard_key
         else:
-            from_full_shard_id = (
-                account.address.full_shard_id & (~shard_mask) | from_shard
+            from_full_shard_key = (
+                account.address.full_shard_key & (~shard_mask) | from_shard
             )
 
         if not sample_evm_tx.to:
             to_address = random.choice(self.accounts).address
             recipient = to_address.recipient
-            to_full_shard_id = to_address.full_shard_id & (~shard_mask) | from_shard
+            to_full_shard_key = to_address.full_shard_key & (~shard_mask) | from_shard
         else:
             recipient = sample_evm_tx.to
-            to_full_shard_id = from_full_shard_id
+            to_full_shard_key = from_full_shard_key
 
         if random.randint(1, 100) <= x_shard_percent:
             # x-shard tx
             to_shard = random.randint(0, self.qkc_config.SHARD_SIZE - 1)
             if to_shard == self.shard_id:
                 to_shard = (to_shard + 1) % self.qkc_config.SHARD_SIZE
-            to_full_shard_id = to_full_shard_id & (~shard_mask) | to_shard
+            to_full_shard_key = to_full_shard_key & (~shard_mask) | to_shard
 
         value = sample_evm_tx.value
         if not sample_evm_tx.data:
@@ -129,8 +129,8 @@ class TransactionGenerator:
             to=recipient,
             value=value,
             data=sample_evm_tx.data,
-            from_full_shard_id=from_full_shard_id,
-            to_full_shard_id=to_full_shard_id,
+            from_full_shard_key=from_full_shard_key,
+            to_full_shard_key=to_full_shard_key,
             network_id=self.qkc_config.NETWORK_ID,
         )
         evm_tx.sign(account.key)

--- a/quarkchain/evm/solidity_abi_utils.py
+++ b/quarkchain/evm/solidity_abi_utils.py
@@ -7,7 +7,7 @@ def int_to_bytes(n: int):
     """
     similar to hex(n), but align to bytes
     """
-    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+    return n.to_bytes((n.bit_length() + 7) // 8, "big")
 
 
 def tx_to_typed_data(raw_tx):
@@ -15,56 +15,44 @@ def tx_to_typed_data(raw_tx):
     see UnsignedTransaction, exludes ['v', 'r', 's', 'version']
     """
     return [
-      {
-        "type": "uint256",
-        "name": "nonce",
-        "value": "0x{}".format(int_to_bytes(raw_tx.nonce).hex())
-      },
-      {
-        "type": "uint256",
-        "name": "gasPrice",
-        "value": "0x{}".format(int_to_bytes(raw_tx.gasprice).hex())
-      },
-      {
-        "type": "uint256",
-        "name": "gasLimit",
-        "value": "0x{}".format(int_to_bytes(raw_tx.startgas).hex())
-      },
-      {
-        "type": "uint160",
-        "name": "to",
-        "value": "0x{}".format(raw_tx.to.hex())
-      },
-      {
-        "type": "uint256",
-        "name": "value",
-        "value": "0x{}".format(int_to_bytes(raw_tx.value).hex())
-      },
-      {
-        "type": "bytes",
-        "name": "data",
-        "value": "0x{}".format(raw_tx.data.hex())
-      },
-      {
-        "type": "uint32",
-        "name": "fromFullShardId",
-        "value": "0x{}".format(int_to_bytes(raw_tx.from_full_shard_id).hex())
-      },
-      {
-        "type": "uint32",
-        "name": "toFullShardId",
-        "value": "0x{}".format(int_to_bytes(raw_tx.to_full_shard_id).hex())
-      },
-      {
-        "type": "uint256",
-        "name": "networkId",
-        "value": "0x{}".format(int_to_bytes(raw_tx.network_id).hex())
-      },
-      {
-        "type": "string",
-        "name": "qkcDomain",
-        "value": "bottom-quark"
-      }
+        {
+            "type": "uint256",
+            "name": "nonce",
+            "value": "0x{}".format(int_to_bytes(raw_tx.nonce).hex()),
+        },
+        {
+            "type": "uint256",
+            "name": "gasPrice",
+            "value": "0x{}".format(int_to_bytes(raw_tx.gasprice).hex()),
+        },
+        {
+            "type": "uint256",
+            "name": "gasLimit",
+            "value": "0x{}".format(int_to_bytes(raw_tx.startgas).hex()),
+        },
+        {"type": "uint160", "name": "to", "value": "0x{}".format(raw_tx.to.hex())},
+        {
+            "type": "uint256",
+            "name": "value",
+            "value": "0x{}".format(int_to_bytes(raw_tx.value).hex()),
+        },
+        {"type": "bytes", "name": "data", "value": "0x{}".format(raw_tx.data.hex())},
+        {
+            "type": "uint32",
+            "name": "fromFullShardId",
+            "value": "0x{}".format(int_to_bytes(raw_tx.from_full_shard_key).hex()),
+        },
+        {
+            "type": "uint32",
+            "name": "toFullShardId",
+            "value": "0x{}".format(int_to_bytes(raw_tx.to_full_shard_key).hex()),
+        },
+        {
+            "type": "uint256",
+            "name": "networkId",
+            "value": "0x{}".format(int_to_bytes(raw_tx.network_id).hex()),
+        },
+        {"type": "string", "name": "qkcDomain", "value": "bottom-quark"},
     ]
 
 
@@ -86,21 +74,21 @@ def solidity_pack(types: Iterable, values: Iterable):
         elif t in ("bool", "address"):
             raise ValueError("unsupported type for now")
         elif t.startswith("bytes"):
-            size = int(re.search(r'\d+', t).group())
+            size = int(re.search(r"\d+", t).group())
             if size < 1 or size > 32:
                 raise ValueError("unsupported byte size")
             value = bytes.fromhex(v[2:])
             if len(value) > size:
                 raise ValueError("data is larger than size")
-            retv += value.rjust(size, b'\x00')
+            retv += value.rjust(size, b"\x00")
         elif t.startswith("int") or t.startswith("uint"):
-            size = int(re.search(r'\d+', t).group())
+            size = int(re.search(r"\d+", t).group())
             if size % 8 != 0 or size < 8 or size > 256:
                 raise ValueError("unsupported int size")
             value = bytes.fromhex(v[2:])
             if len(value) > size // 8:
                 raise ValueError("data is larger than size")
-            retv += value.rjust(size // 8, b'\x00')
+            retv += value.rjust(size // 8, b"\x00")
         else:
             raise ValueError("Unsupported or invalid type: {}".format(t))
     return retv
@@ -116,11 +104,15 @@ def solidity_sha3(types: Iterable, values: Iterable):
 def typed_signature_hash(tx):
     schema = list(map(lambda x: "{} {}".format(x["type"], x["name"]), tx))
     types = list(map(lambda x: x["type"], tx))
-    data = list(map(lambda x: bytes.fromhex(x['value'][2:]) if x['type'] == "bytes" else x['value'], tx))
+    data = list(
+        map(
+            lambda x: bytes.fromhex(x["value"][2:])
+            if x["type"] == "bytes"
+            else x["value"],
+            tx,
+        )
+    )
     return solidity_sha3(
-        ['bytes32', 'bytes32'],
-        [
-            solidity_sha3(['string'] * len(tx), schema),
-            solidity_sha3(types, data)
-        ]
+        ["bytes32", "bytes32"],
+        [solidity_sha3(["string"] * len(tx), schema), solidity_sha3(types, data)],
     )

--- a/quarkchain/evm/tests/test_solidity_abi.py
+++ b/quarkchain/evm/tests/test_solidity_abi.py
@@ -1,102 +1,85 @@
 import unittest
-from quarkchain.evm.solidity_abi_utils import tx_to_typed_data, solidity_pack, typed_signature_hash
+from quarkchain.evm.solidity_abi_utils import (
+    tx_to_typed_data,
+    solidity_pack,
+    typed_signature_hash,
+)
 from quarkchain.evm.transactions import Transaction
 
 
 class TestTypedSignature(unittest.TestCase):
 
-
-    raw_tx = Transaction(nonce=0x0d,
-                        gasprice=0x02540be400,
-                        startgas=0x7530,
-                        to=bytes.fromhex('314b2cd22c6d26618ce051a58c65af1253aecbb8'),
-                        value=0x056bc75e2d63100000,
-                        data=b'',
-                        from_full_shard_id=0xc47decfd,
-                        to_full_shard_id=0xc49c1950,
-                        network_id=0x03)
-
+    raw_tx = Transaction(
+        nonce=0x0d,
+        gasprice=0x02540be400,
+        startgas=0x7530,
+        to=bytes.fromhex("314b2cd22c6d26618ce051a58c65af1253aecbb8"),
+        value=0x056bc75e2d63100000,
+        data=b"",
+        from_full_shard_key=0xc47decfd,
+        to_full_shard_key=0xc49c1950,
+        network_id=0x03,
+    )
 
     tx = [
-      {
-        "type": "uint256",
-        "name": "nonce",
-        "value": "0x0d"
-      },
-      {
-        "type": "uint256",
-        "name": "gasPrice",
-        "value": "0x02540be400"
-      },
-      {
-        "type": "uint256",
-        "name": "gasLimit",
-        "value": "0x7530"
-      },
-      {
-        "type": "uint160",
-        "name": "to",
-        "value": "0x314b2cd22c6d26618ce051a58c65af1253aecbb8"
-      },
-      {
-        "type": "uint256",
-        "name": "value",
-        "value": "0x056bc75e2d63100000"
-      },
-      {
-        "type": "bytes",
-        "name": "data",
-        "value": "0x"
-      },
-      {
-        "type": "uint32",
-        "name": "fromFullShardId",
-        "value": "0xc47decfd"
-      },
-      {
-        "type": "uint32",
-        "name": "toFullShardId",
-        "value": "0xc49c1950"
-      },
-      {
-        "type": "uint256",
-        "name": "networkId",
-        "value": "0x03"
-      },
-      {
-        "type": "string",
-        "name": "qkcDomain",
-        "value": "bottom-quark"
-      }
+        {"type": "uint256", "name": "nonce", "value": "0x0d"},
+        {"type": "uint256", "name": "gasPrice", "value": "0x02540be400"},
+        {"type": "uint256", "name": "gasLimit", "value": "0x7530"},
+        {
+            "type": "uint160",
+            "name": "to",
+            "value": "0x314b2cd22c6d26618ce051a58c65af1253aecbb8",
+        },
+        {"type": "uint256", "name": "value", "value": "0x056bc75e2d63100000"},
+        {"type": "bytes", "name": "data", "value": "0x"},
+        {"type": "uint32", "name": "fromFullShardId", "value": "0xc47decfd"},
+        {"type": "uint32", "name": "toFullShardId", "value": "0xc49c1950"},
+        {"type": "uint256", "name": "networkId", "value": "0x03"},
+        {"type": "string", "name": "qkcDomain", "value": "bottom-quark"},
     ]
-
 
     def test_typed(self):
         assert tx_to_typed_data(self.raw_tx) == self.tx
 
-
     def test_solidity_pack(self):
         schema = list(map(lambda x: "{} {}".format(x["type"], x["name"]), self.tx))
         types = list(map(lambda x: x["type"], self.tx))
-        data = list(map(lambda x: bytes.fromhex(x['value'][2:]) if x['type'] == "bytes" else x['value'], self.tx))
-        h1 = solidity_pack(['string'] * len(self.tx), schema)
+        data = list(
+            map(
+                lambda x: bytes.fromhex(x["value"][2:])
+                if x["type"] == "bytes"
+                else x["value"],
+                self.tx,
+            )
+        )
+        h1 = solidity_pack(["string"] * len(self.tx), schema)
         h2 = solidity_pack(types, data)
-        assert h1.hex() == "75696e74323536206e6f6e636575696e7432353620676173507269636575696e74323536206761734c696d697475696e7431363020746f75696e743235362076616c75656279746573206461746175696e7433322066726f6d46756c6c5368617264496475696e74333220746f46756c6c5368617264496475696e74323536206e6574776f726b4964737472696e6720716b63446f6d61696e"
-        assert h2.hex() == "000000000000000000000000000000000000000000000000000000000000000d00000000000000000000000000000000000000000000000000000002540be4000000000000000000000000000000000000000000000000000000000000007530314b2cd22c6d26618ce051a58c65af1253aecbb80000000000000000000000000000000000000000000000056bc75e2d63100000c47decfdc49c19500000000000000000000000000000000000000000000000000000000000000003626f74746f6d2d717561726b"
-
+        assert (
+            h1.hex()
+            == "75696e74323536206e6f6e636575696e7432353620676173507269636575696e74323536206761734c696d697475696e7431363020746f75696e743235362076616c75656279746573206461746175696e7433322066726f6d46756c6c5368617264496475696e74333220746f46756c6c5368617264496475696e74323536206e6574776f726b4964737472696e6720716b63446f6d61696e"
+        )
+        assert (
+            h2.hex()
+            == "000000000000000000000000000000000000000000000000000000000000000d00000000000000000000000000000000000000000000000000000002540be4000000000000000000000000000000000000000000000000000000000000007530314b2cd22c6d26618ce051a58c65af1253aecbb80000000000000000000000000000000000000000000000056bc75e2d63100000c47decfdc49c19500000000000000000000000000000000000000000000000000000000000000003626f74746f6d2d717561726b"
+        )
 
     def test_typed_signature_hash(self):
         h = typed_signature_hash(self.tx)
         assert h == "0x57dfcc7be8e4249fb6e75a45dc5ecdfed0309ed951b6adc69b8a659c7eca33bf"
-
 
     def test_recover(self):
         """
         """
         self.raw_tx._in_mutable_context = True
         self.raw_tx.version = 1
-        self.raw_tx.r = 0xb5145678e43df2b7ea8e0e969e51dbf72c956dd52e234c95393ad68744394855
-        self.raw_tx.s = 0x44515b465dbbf746a484239c11adb98f967e35347e17e71b84d850d8e5c38a6a
+        self.raw_tx.r = (
+            0xb5145678e43df2b7ea8e0e969e51dbf72c956dd52e234c95393ad68744394855
+        )
+        self.raw_tx.s = (
+            0x44515b465dbbf746a484239c11adb98f967e35347e17e71b84d850d8e5c38a6a
+        )
         self.raw_tx.v = 0x1b
         self.raw_tx._in_mutable_context = False
-        assert self.raw_tx.sender == bytes.fromhex('8b74a79290a437aa9589be3227d9bb81b22beff1')
+        assert self.raw_tx.sender == bytes.fromhex(
+            "8b74a79290a437aa9589be3227d9bb81b22beff1"
+        )

--- a/quarkchain/evm/transactions.py
+++ b/quarkchain/evm/transactions.py
@@ -3,7 +3,13 @@
 import rlp
 from quarkchain.evm import utils
 from quarkchain.evm.exceptions import InvalidTransaction
-from quarkchain.evm.utils import TT256, mk_contract_address, ecsign, ecrecover_to_pub, normalize_key
+from quarkchain.evm.utils import (
+    TT256,
+    mk_contract_address,
+    ecsign,
+    ecrecover_to_pub,
+    normalize_key,
+)
 from quarkchain.evm.utils import encode_hex
 from rlp.sedes import big_endian_int, binary, BigEndianInt
 from quarkchain.rlp.utils import str_to_bytes, ascii_chr
@@ -15,7 +21,7 @@ from quarkchain.evm.solidity_abi_utils import tx_to_typed_data, typed_signature_
 # in the yellow paper it is specified that s should be smaller than
 # secpk1n (eq.205)
 secpk1n = 115792089237316195423570985008687907852837564279074904382605163141518161494337
-null_address = b'\xff' * 20
+null_address = b"\xff" * 20
 
 
 class Transaction(rlp.Serializable):
@@ -38,62 +44,79 @@ class Transaction(rlp.Serializable):
     (ii) the sending account has enough funds to pay the fee and the value.
 
     There are 3 types of transactions:
-        1. Value transfer. In-shard transaction if from_full_shard_id and to_full_shard_id
+        1. Value transfer. In-shard transaction if from_full_shard_key and to_full_shard_key
         refer to the same shard, otherwise it is a cross-shard transaction.
 
-        2. Contract creation. 'to' must be empty. from_full_shard_id and to_full_shard_id
+        2. Contract creation. 'to' must be empty. from_full_shard_key and to_full_shard_key
         must refer to the same shard id. The contract address will have the same
-        full shard id as to_full_shard_id. If the contract does not invoke other contract
-        normally the to_full_shard_id should be the same as from_full_shard_id.
+        full shard id as to_full_shard_key. If the contract does not invoke other contract
+        normally the to_full_shard_key should be the same as from_full_shard_key.
 
-        3. Contract call. from_full_shard_id and to_full_shard_id must refer to the same
+        3. Contract call. from_full_shard_key and to_full_shard_key must refer to the same
         shard id based on the current number of shards in the network. It is possible
         a reshard event would invalidate a tx that was valid before the reshard.
     """
 
     fields = [
-        ('nonce', big_endian_int),
-        ('gasprice', big_endian_int),
-        ('startgas', big_endian_int),
-        ('to', utils.address),
-        ('value', big_endian_int),
-        ('data', binary),
-        ('from_full_shard_id', BigEndianInt(4)),
-        ('to_full_shard_id', BigEndianInt(4)),
-        ('network_id', big_endian_int),
-        ('version', big_endian_int),
-        ('v', big_endian_int),
-        ('r', big_endian_int),
-        ('s', big_endian_int),
+        ("nonce", big_endian_int),
+        ("gasprice", big_endian_int),
+        ("startgas", big_endian_int),
+        ("to", utils.address),
+        ("value", big_endian_int),
+        ("data", binary),
+        ("from_full_shard_key", BigEndianInt(4)),
+        ("to_full_shard_key", BigEndianInt(4)),
+        ("network_id", big_endian_int),
+        ("version", big_endian_int),
+        ("v", big_endian_int),
+        ("r", big_endian_int),
+        ("s", big_endian_int),
     ]
 
     _sender = None
 
-    def __init__(self, nonce, gasprice, startgas, to, value, data,
-                 v=0, r=0, s=0, from_full_shard_id=0, to_full_shard_id=0, network_id=1, version=0):
+    def __init__(
+        self,
+        nonce,
+        gasprice,
+        startgas,
+        to,
+        value,
+        data,
+        v=0,
+        r=0,
+        s=0,
+        from_full_shard_key=0,
+        to_full_shard_key=0,
+        network_id=1,
+        version=0,
+    ):
         self.shard_size = 0
 
         to = utils.normalize_address(to, allow_blank=True)
 
-        super(
-            Transaction,
-            self).__init__(
+        super(Transaction, self).__init__(
             nonce,
             gasprice,
             startgas,
             to,
             value,
             data,
-            from_full_shard_id,
-            to_full_shard_id,
+            from_full_shard_key,
+            to_full_shard_key,
             network_id,
             version,
             v,
             r,
-            s)
+            s,
+        )
 
-        if self.gasprice >= TT256 or self.startgas >= TT256 or \
-                self.value >= TT256 or self.nonce >= TT256:
+        if (
+            self.gasprice >= TT256
+            or self.startgas >= TT256
+            or self.value >= TT256
+            or self.nonce >= TT256
+        ):
             raise InvalidTransaction("Values way too high!")
 
     @property
@@ -109,9 +132,10 @@ class Transaction(rlp.Serializable):
                     pub = ecrecover_to_pub(self.hash_unsigned, self.v, self.r, self.s)
                 if self.version == 1:
                     pub = ecrecover_to_pub(self.hash_typed, self.v, self.r, self.s)
-                if pub == b'\x00' * 64:
+                if pub == b"\x00" * 64:
                     raise InvalidTransaction(
-                        "Invalid signature (zero privkey cannot sign)")
+                        "Invalid signature (zero privkey cannot sign)"
+                    )
                 self._sender = sha3_256(pub)[-20:]
         return self._sender
 
@@ -152,10 +176,10 @@ class Transaction(rlp.Serializable):
         d = {}
         for name, _ in self.__class__._meta.fields:
             d[name] = getattr(self, name)
-            if name in ('to', 'data'):
-                d[name] = '0x' + encode_hex(d[name])
-        d['sender'] = '0x' + encode_hex(self.sender)
-        d['hash'] = '0x' + encode_hex(self.hash)
+            if name in ("to", "data"):
+                d[name] = "0x" + encode_hex(d[name])
+        d["sender"] = "0x" + encode_hex(self.sender)
+        d["hash"] = "0x" + encode_hex(self.hash)
         return d
 
     @property
@@ -163,17 +187,17 @@ class Transaction(rlp.Serializable):
         num_zero_bytes = str_to_bytes(self.data).count(ascii_chr(0))
         num_non_zero_bytes = len(self.data) - num_zero_bytes
         return (
-                opcodes.GTXCOST +
-                (opcodes.CREATE[3] if not self.to else 0) +
-                opcodes.GTXDATAZERO * num_zero_bytes +
-                opcodes.GTXDATANONZERO * num_non_zero_bytes +
-                (opcodes.GTXXSHARDCOST if self.is_cross_shard() else 0)
+            opcodes.GTXCOST
+            + (opcodes.CREATE[3] if not self.to else 0)
+            + opcodes.GTXDATAZERO * num_zero_bytes
+            + opcodes.GTXDATANONZERO * num_non_zero_bytes
+            + (opcodes.GTXXSHARDCOST if self.is_cross_shard() else 0)
         )
 
     @property
     def creates(self):
         "returns the address of a contract created by this tx"
-        if self.to in (b'', '\0' * 20):
+        if self.to in (b"", "\0" * 20):
             return mk_contract_address(self.sender, self.nonce)
 
     def set_shard_size(self, shard_size):
@@ -184,13 +208,13 @@ class Transaction(rlp.Serializable):
         if self.shard_size == 0:
             raise RuntimeError("shard_size is not set")
         shard_mask = self.shard_size - 1
-        return self.from_full_shard_id & shard_mask
+        return self.from_full_shard_key & shard_mask
 
     def to_shard_id(self):
         if self.shard_size == 0:
             raise RuntimeError("shard_size is not set")
         shard_mask = self.shard_size - 1
-        return self.to_full_shard_id & shard_mask
+        return self.to_full_shard_key & shard_mask
 
     def is_cross_shard(self):
         return self.from_shard_id() != self.to_shard_id()
@@ -208,7 +232,7 @@ class Transaction(rlp.Serializable):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return '<Transaction(%s)>' % encode_hex(self.hash)[:4]
+        return "<Transaction(%s)>" % encode_hex(self.hash)[:4]
 
     def __structlog__(self):
         return encode_hex(self.hash)
@@ -227,9 +251,11 @@ class Transaction(rlp.Serializable):
 
 class UnsignedTransaction(rlp.Serializable):
     fields = [
-        (field, sedes) for field, sedes in Transaction._meta.fields
-        if field not in ['v', 'r', 's', 'version']
+        (field, sedes)
+        for field, sedes in Transaction._meta.fields
+        if field not in ["v", "r", "s", "version"]
     ]
+
 
 def unsigned_tx_from_tx(tx):
     return UnsignedTransaction(
@@ -239,7 +265,7 @@ def unsigned_tx_from_tx(tx):
         to=tx.to,
         value=tx.value,
         data=tx.data,
-        from_full_shard_id=tx.from_full_shard_id,
-        to_full_shard_id=tx.to_full_shard_id,
+        from_full_shard_key=tx.from_full_shard_key,
+        to_full_shard_key=tx.to_full_shard_key,
         network_id=tx.network_id,
     )

--- a/quarkchain/evm/vm.py
+++ b/quarkchain/evm/vm.py
@@ -81,8 +81,8 @@ class Message(object):
         transfers_value=True,
         static=False,
         is_cross_shard=False,
-        from_full_shard_id=None,
-        to_full_shard_id=None,
+        from_full_shard_key=None,
+        to_full_shard_key=None,
         tx_hash=None,
     ):
         self.sender = sender
@@ -101,8 +101,8 @@ class Message(object):
         self.transfers_value = transfers_value
         self.static = static
         self.is_cross_shard = is_cross_shard
-        self.from_full_shard_id = from_full_shard_id
-        self.to_full_shard_id = to_full_shard_id
+        self.from_full_shard_key = from_full_shard_key
+        self.to_full_shard_key = to_full_shard_key
         self.tx_hash = (
             tx_hash
         )  # quarkchain.core.Transaction hash (NOT the evm Transaction hash)
@@ -690,7 +690,7 @@ def vm_execute(ext, msg, code):
                     ingas,
                     cd,
                     msg.depth + 1,
-                    to_full_shard_id=msg.from_full_shard_id,
+                    to_full_shard_key=msg.from_full_shard_key,
                 )
                 o, gas, data = ext.create(create_msg)
                 if o:

--- a/quarkchain/experimental/tx_perf.py
+++ b/quarkchain/experimental/tx_perf.py
@@ -75,8 +75,8 @@ def test_perf_evm():
             to=to_addr.recipient,
             value=3,
             data=b"",
-            from_full_shard_id=0,
-            to_full_shard_id=0,
+            from_full_shard_key=0,
+            to_full_shard_key=0,
             network_id=1,
         )
         evm_tx.sign(key=from_id.get_key())

--- a/quarkchain/genesis.py
+++ b/quarkchain/genesis.py
@@ -49,7 +49,7 @@ class GenesisManager:
         for address_hex, amount_in_wei in genesis.ALLOC.items():
             address = Address.create_from(bytes.fromhex(address_hex))
             check(address.get_shard_id(self._qkc_config.SHARD_SIZE) == shard_id)
-            evm_state.full_shard_id = address.full_shard_id
+            evm_state.full_shard_key = address.full_shard_key
             evm_state.delta_balance(address.recipient, amount_in_wei)
 
         evm_state.commit()

--- a/quarkchain/tests/test_accounts.py
+++ b/quarkchain/tests/test_accounts.py
@@ -11,13 +11,12 @@ ADDRESS = "008aeeda4d805471df9b2a5b0f38a0c3bcba786b00802ac3"
 
 
 class TestAccount(unittest.TestCase):
-
     def test_create_account_with_key(self):
         account = Account.new(key=PRIVATE_KEY)
         assert account.privkey == PRIVATE_KEY
         assert account.address == ADDRESS
         # check integer version of full shard id matches
-        assert account.qkc_address.full_shard_id == int(ADDRESS[40:], 16)
+        assert account.qkc_address.full_shard_key == int(ADDRESS[40:], 16)
 
     def test_create_random_account(self):
         account = Account.new()

--- a/quarkchain/tools/accounts
+++ b/quarkchain/tools/accounts
@@ -11,7 +11,7 @@ def print_account(a):
     print("Address: {0}".format(colorify("0x" + str(a.address), "blue")))
     print(
         "Shard ID (uint32): {0}".format(
-            colorify(str(a.qkc_address.full_shard_id), "green")
+            colorify(str(a.qkc_address.full_shard_key), "green")
         )
     )
     print("Private Key: {0}".format(colorify(str(a.privkey), "red")))

--- a/quarkchain/tools/batch_deploy_contract.py
+++ b/quarkchain/tools/batch_deploy_contract.py
@@ -57,8 +57,8 @@ def create_transaction(address, key, nonce, data, network_id) -> EvmTransaction:
         to=b"",
         value=0,
         data=data,
-        from_full_shard_id=address.full_shard_id,
-        to_full_shard_id=address.full_shard_id,
+        from_full_shard_key=address.full_shard_key,
+        to_full_shard_key=address.full_shard_key,
         network_id=network_id,
     )
     evm_tx.sign(key)

--- a/quarkchain/tools/fund_testnet.py
+++ b/quarkchain/tools/fund_testnet.py
@@ -66,8 +66,8 @@ def create_transaction(address, key, nonce, to, network_id, amount) -> EvmTransa
         to=to.recipient,
         value=int(amount) * (10 ** 18),
         data=b"",
-        from_full_shard_id=address.full_shard_id,
-        to_full_shard_id=to.full_shard_id,
+        from_full_shard_key=address.full_shard_key,
+        to_full_shard_key=to.full_shard_key,
         network_id=network_id,
     )
     evm_tx.sign(key)
@@ -81,7 +81,7 @@ async def fund_shard(endpoint, genesisId, to, network_id, shard, amount):
     tx_id = await endpoint.send_transaction(tx)
     cnt = 0
     while True:
-        addr = "0x" + to.recipient.hex() + hex(to.full_shard_id)[2:]
+        addr = "0x" + to.recipient.hex() + hex(to.full_shard_key)[2:]
         print("shard={} tx={} to={} block=(pending)".format(shard, tx_id, addr))
         await asyncio.sleep(5)
         resp = await endpoint.get_transaction_receipt(tx_id)


### PR DESCRIPTION
`full_shard_id` used to mean the last 4 bytes in QKC address. Normally it is randomly generated so that addresses fall onto different shards.
In the new world after introducing `chain_id` it will have a new meaning.
```
(chain_id + shard_id) = full_shard_id
(chain_id + shard_key) = full_shard_key
```