### PR TITLE
Add ChainConfig

### DIFF
--- a/quarkchain/cluster/cluster_config.py
+++ b/quarkchain/cluster/cluster_config.py
@@ -8,7 +8,7 @@ from typing import List
 
 from quarkchain.cluster.monitoring import KafkaSampleLogger
 from quarkchain.cluster.rpc import SlaveInfo
-from quarkchain.config import QuarkChainConfig, BaseConfig, ShardConfig
+from quarkchain.config import QuarkChainConfig, BaseConfig, ChainConfig
 from quarkchain.core import Address
 from quarkchain.core import ShardMask
 from quarkchain.utils import is_p2, check, Logger
@@ -38,7 +38,7 @@ def update_genesis_alloc(cluser_config):
                 full_shard_id = qkc_config.get_full_shard_id_by_full_shard_key(
                     address.full_shard_key
                 )
-                qkc_config.SHARDS[full_shard_id].GENESIS.ALLOC[
+                qkc_config.shards[full_shard_id].GENESIS.ALLOC[
                     item["address"]
                 ] = 1000000 * (10 ** 18)
 
@@ -52,7 +52,7 @@ def update_genesis_alloc(cluser_config):
             "Error importing genesis accounts from {}: {}".format(alloc_file, e)
         )
 
-        for shard_config in qkc_config.SHARDS.values():
+        for shard_config in qkc_config.shards.values():
             shard_config.GENESIS.ALLOC = dict()
         Logger.warning("Cleared all genesis accounts from config!")
 
@@ -64,7 +64,7 @@ def update_genesis_alloc(cluser_config):
 
         for item in items:
             address = Address.create_from(item["address"])
-            for full_shard_id, shard_config in qkc_config.SHARDS.items():
+            for full_shard_id, shard_config in qkc_config.shards.items():
                 shard_config.GENESIS.ALLOC[
                     address.address_in_shard(full_shard_id).serialize().hex()
                 ] = 1000 * (10 ** 18)
@@ -214,7 +214,7 @@ class ClusterConfig(BaseConfig):
             "--num_chains", default=QuarkChainConfig.CHAIN_SIZE, type=int
         )
         parser.add_argument(
-            "--num_shards_per_chain", default=ShardConfig.SHARD_SIZE, type=int
+            "--num_shards_per_chain", default=ChainConfig.SHARD_SIZE, type=int
         )
         parser.add_argument("--root_block_interval_sec", default=10, type=int)
         parser.add_argument("--minor_block_interval_sec", default=3, type=int)

--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -607,7 +607,7 @@ class MasterServer:
         self.artificial_tx_config = ArtificialTxConfig(
             target_root_block_time=self.env.quark_chain_config.ROOT.CONSENSUS_CONFIG.TARGET_BLOCK_TIME,
             target_minor_block_time=next(
-                iter(self.env.quark_chain_config.SHARDS.values())
+                iter(self.env.quark_chain_config.shards.values())
             ).CONSENSUS_CONFIG.TARGET_BLOCK_TIME,
         )
 

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -17,7 +17,7 @@ from quarkchain.cluster.miner import Miner, validate_seal
 from quarkchain.cluster.tx_generator import TransactionGenerator
 from quarkchain.cluster.protocol import VirtualConnection, ClusterMetadata
 from quarkchain.cluster.shard_state import ShardState
-from quarkchain.config import ShardConfig, ConsensusType
+from quarkchain.config import ConsensusType
 from quarkchain.core import (
     RootBlock,
     MinorBlock,
@@ -226,7 +226,7 @@ class SyncTask:
         self.shard = shard_conn.shard
 
         full_shard_id = self.header.branch.get_full_shard_id()
-        shard_config = self.shard_state.env.quark_chain_config.SHARDS[full_shard_id]
+        shard_config = self.shard_state.env.quark_chain_config.shards[full_shard_id]
         self.max_staleness = shard_config.max_stale_minor_block_height_diff
 
     async def sync(self):
@@ -321,7 +321,7 @@ class SyncTask:
             if header.hash_prev_minor_block != prev.get_hash():
                 return False
             full_shard_id = header.branch.get_full_shard_id()
-            consensus_type = self.shard.env.quark_chain_config.SHARDS[
+            consensus_type = self.shard.env.quark_chain_config.shards[
                 full_shard_id
             ].CONSENSUS_TYPE
             validate_seal(header, consensus_type)
@@ -404,7 +404,7 @@ class Shard:
 
     def __init_miner(self):
         miner_address = Address.create_from(
-            self.env.quark_chain_config.SHARDS[self.full_shard_id].COINBASE_ADDRESS
+            self.env.quark_chain_config.shards[self.full_shard_id].COINBASE_ADDRESS
         )
 
         async def __create_block(retry=True):
@@ -430,7 +430,7 @@ class Shard:
                 "target_block_time": self.slave.artificial_tx_config.target_minor_block_time
             }
 
-        shard_config = self.env.quark_chain_config.SHARDS[
+        shard_config = self.env.quark_chain_config.shards[
             self.full_shard_id
         ]  # type: ShardConfig
         self.miner = Miner(
@@ -520,7 +520,7 @@ class Shard:
                 return
 
         full_shard_id = block.header.branch.get_full_shard_id()
-        consensus_type = self.env.quark_chain_config.SHARDS[
+        consensus_type = self.env.quark_chain_config.shards[
             full_shard_id
         ].CONSENSUS_TYPE
         try:

--- a/quarkchain/cluster/shard_db_operator.py
+++ b/quarkchain/cluster/shard_db_operator.py
@@ -219,7 +219,7 @@ class ShardDbOperator(TransactionHistoryMixin):
             r_hash = block.header.hash_prev_block
 
         m_hash = m_header.get_hash()
-        shard_config = self.env.quark_chain_config.SHARDS[
+        shard_config = self.env.quark_chain_config.shards[
             self.branch.get_full_shard_id()
         ]
         while len(self.m_header_pool) < shard_config.max_minor_blocks_in_memory:

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -62,7 +62,7 @@ class ShardState:
         self.env = env
         self.full_shard_id = full_shard_id
         if not diff_calc:
-            shard_config = self.env.quark_chain_config.SHARDS[full_shard_id]
+            shard_config = self.env.quark_chain_config.shards[full_shard_id]
             cutoff = shard_config.DIFFICULTY_ADJUSTMENT_CUTOFF_TIME
             diff_factor = shard_config.DIFFICULTY_ADJUSTMENT_FACTOR
             min_diff = shard_config.GENESIS.DIFFICULTY
@@ -338,7 +338,7 @@ class ShardState:
             """
             Compute the boundaries for the block gas limit based on the parent block.
             """
-            shard_config = self.env.quark_chain_config.SHARDS[
+            shard_config = self.env.quark_chain_config.shards[
                 self.branch.get_full_shard_id()
             ]
             boundary_range = (
@@ -383,7 +383,7 @@ class ShardState:
 
         - use the GAS_LIMIT_MINIMUM as the new gas limit.
         """
-        shard_config = self.env.quark_chain_config.SHARDS[
+        shard_config = self.env.quark_chain_config.shards[
             self.branch.get_full_shard_id()
         ]
         if gas_limit_floor < shard_config.GAS_LIMIT_MINIMUM:
@@ -517,7 +517,7 @@ class ShardState:
             raise ValueError("prev root blocks are not on the same chain")
 
         # Check PoW if applicable
-        consensus_type = self.env.quark_chain_config.SHARDS[
+        consensus_type = self.env.quark_chain_config.shards[
             self.full_shard_id
         ].CONSENSUS_TYPE
         validate_seal(block.header, consensus_type)
@@ -650,7 +650,7 @@ class ShardState:
         start_ms = time_ms()
 
         if skip_if_too_old:
-            shard_config = self.env.quark_chain_config.SHARDS[
+            shard_config = self.env.quark_chain_config.shards[
                 self.branch.get_full_shard_id()
             ]
             if (
@@ -797,7 +797,7 @@ class ShardState:
             1 - self.env.quark_chain_config.reward_tax_rate
         )  # type: Fraction
         coinbase_amount = (
-            self.env.quark_chain_config.SHARDS[self.full_shard_id].COINBASE_AMOUNT
+            self.env.quark_chain_config.shards[self.full_shard_id].COINBASE_AMOUNT
             * local_fee_rate.numerator
             // local_fee_rate.denominator
         )
@@ -919,7 +919,7 @@ class ShardState:
         return amount
 
     def __get_max_blocks_in_one_root_block(self) -> int:
-        shard_config = self.env.quark_chain_config.SHARDS[
+        shard_config = self.env.quark_chain_config.shards[
             self.branch.get_full_shard_id()
         ]
         return shard_config.max_blocks_per_shard_in_one_root_block
@@ -994,7 +994,7 @@ class ShardState:
         block = prev_block.create_block_to_append(
             create_time=create_time, address=address, difficulty=difficulty
         )
-        shard_config = self.env.quark_chain_config.SHARDS[
+        shard_config = self.env.quark_chain_config.shards[
             self.branch.get_full_shard_id()
         ]
         block.header.evm_gas_limit = self.__compute_gas_limit(

--- a/quarkchain/cluster/slave.py
+++ b/quarkchain/cluster/slave.py
@@ -822,7 +822,7 @@ class SlaveServer:
         """ Create shards based on GENESIS config and root block height if they have
         not been created yet."""
         futures = []
-        for (full_shard_id, shard_config) in self.env.quark_chain_config.SHARDS.items():
+        for (full_shard_id, shard_config) in self.env.quark_chain_config.shards.items():
             branch = Branch(full_shard_id)
             if branch in self.shards:
                 continue

--- a/quarkchain/cluster/tests/test_cluster.py
+++ b/quarkchain/cluster/tests/test_cluster.py
@@ -229,7 +229,7 @@ class TestCluster(unittest.TestCase):
         with ClusterContext(2, acc1) as clusters:
             shard_state = clusters[0].slave_list[0].shards[Branch(0b10)].state
             coinbase_amount = (
-                shard_state.env.quark_chain_config.SHARDS[
+                shard_state.env.quark_chain_config.shards[
                     shard_state.full_shard_id
                 ].COINBASE_AMOUNT
                 // 2
@@ -283,7 +283,7 @@ class TestCluster(unittest.TestCase):
             block_header_list = [clusters[0].get_shard_state(2 | 0).header_tip]
             shard_state0 = clusters[0].slave_list[0].shards[Branch(0b10)].state
             coinbase_amount = (
-                shard_state0.env.quark_chain_config.SHARDS[
+                shard_state0.env.quark_chain_config.shards[
                     shard_state0.full_shard_id
                 ].COINBASE_AMOUNT
                 // 2
@@ -306,7 +306,7 @@ class TestCluster(unittest.TestCase):
             block_header_list.append(clusters[0].get_shard_state(2 | 1).header_tip)
             shard_state0 = clusters[0].slave_list[1].shards[Branch(0b11)].state
             coinbase_amount = (
-                shard_state0.env.quark_chain_config.SHARDS[
+                shard_state0.env.quark_chain_config.shards[
                     shard_state0.full_shard_id
                 ].COINBASE_AMOUNT
                 // 2
@@ -326,7 +326,7 @@ class TestCluster(unittest.TestCase):
             # add 1 block in cluster 1
             shard_state1 = clusters[1].slave_list[1].shards[Branch(0b11)].state
             coinbase_amount = (
-                shard_state1.env.quark_chain_config.SHARDS[
+                shard_state1.env.quark_chain_config.shards[
                     shard_state1.full_shard_id
                 ].COINBASE_AMOUNT
                 // 2
@@ -393,7 +393,7 @@ class TestCluster(unittest.TestCase):
             # cluster 0 has 13 blocks added
             shard_state0 = clusters[0].slave_list[0].shards[Branch(0b10)].state
             coinbase_amount = (
-                shard_state0.env.quark_chain_config.SHARDS[
+                shard_state0.env.quark_chain_config.shards[
                     shard_state0.full_shard_id
                 ].COINBASE_AMOUNT
                 // 2
@@ -420,7 +420,7 @@ class TestCluster(unittest.TestCase):
             # cluster 1 has 12 blocks added
             shard_state0 = clusters[1].slave_list[0].shards[Branch(0b10)].state
             coinbase_amount = (
-                shard_state0.env.quark_chain_config.SHARDS[
+                shard_state0.env.quark_chain_config.shards[
                     shard_state0.full_shard_id
                 ].COINBASE_AMOUNT
                 // 2
@@ -454,7 +454,7 @@ class TestCluster(unittest.TestCase):
             # a new block from cluster 0 will trigger sync in cluster 1
             shard_state0 = clusters[0].slave_list[0].shards[Branch(0b10)].state
             coinbase_amount = (
-                shard_state0.env.quark_chain_config.SHARDS[
+                shard_state0.env.quark_chain_config.shards[
                     shard_state0.full_shard_id
                 ].COINBASE_AMOUNT
                 // 2

--- a/quarkchain/cluster/tests/test_cluster_config.py
+++ b/quarkchain/cluster/tests/test_cluster_config.py
@@ -27,7 +27,7 @@ class TestClusterConfig(unittest.TestCase):
         full_shard_id = 0 | 4 | 0
         # 12000 loadtest accounts + ? alloc accounts
         self.assertGreaterEqual(
-            len(cluster_config.QUARKCHAIN.SHARDS[full_shard_id].GENESIS.ALLOC), 12000
+            len(cluster_config.QUARKCHAIN.shards[full_shard_id].GENESIS.ALLOC), 12000
         )
 
     def test_cluster_dict(self):

--- a/quarkchain/cluster/tests/test_jsonrpc.py
+++ b/quarkchain/cluster/tests/test_jsonrpc.py
@@ -794,7 +794,7 @@ class TestJSONRPC(unittest.TestCase):
                 header_hash_hex = resp[0]
                 if shard_id is not None:  # shard 0
                     miner_address = Address.create_from(
-                        master.env.quark_chain_config.SHARDS[1].COINBASE_ADDRESS
+                        master.env.quark_chain_config.shards[1].COINBASE_ADDRESS
                     )
                 else:  # root
                     miner_address = Address.create_from(

--- a/quarkchain/cluster/tests/test_root_state.py
+++ b/quarkchain/cluster/tests/test_root_state.py
@@ -254,7 +254,7 @@ class TestRootState(unittest.TestCase):
         )  # other network ids will skip difficulty check
         env.quark_chain_config.REWARD_TAX_RATE = 0.8
         env.quark_chain_config.ROOT.COINBASE_AMOUNT = 5
-        for c in env.quark_chain_config.SHARDS.values():
+        for c in env.quark_chain_config.shards.values():
             c.COINBASE_AMOUNT = 5
 
         r_state, s_states = create_default_state(env, diff_calc=diff_calc)

--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -15,7 +15,7 @@ from quarkchain.genesis import GenesisManager
 
 def create_default_shard_state(env, shard_id=0, diff_calc=None):
     genesis_manager = GenesisManager(env.quark_chain_config)
-    shard_size = next(iter(env.quark_chain_config.SHARDS.values())).SHARD_SIZE
+    shard_size = next(iter(env.quark_chain_config.shards.values())).SHARD_SIZE
     full_shard_id = shard_size | shard_id
     shard_state = ShardState(env=env, full_shard_id=full_shard_id, diff_calc=diff_calc)
     shard_state.init_genesis_state(genesis_manager.create_root_block())
@@ -27,7 +27,7 @@ class TestShardState(unittest.TestCase):
         super().setUp()
         config = get_test_env().quark_chain_config
         self.root_coinbase = config.ROOT.COINBASE_AMOUNT
-        self.shard_coinbase = next(iter(config.SHARDS.values())).COINBASE_AMOUNT
+        self.shard_coinbase = next(iter(config.shards.values())).COINBASE_AMOUNT
         # to make test verification easier, assume following tax rate
         assert config.REWARD_TAX_RATE == 0.5
 
@@ -1130,7 +1130,7 @@ class TestShardState(unittest.TestCase):
 
     def test_shard_state_difficulty(self):
         env = get_test_env()
-        for shard_config in env.quark_chain_config.SHARDS.values():
+        for shard_config in env.quark_chain_config.shards.values():
             shard_config.GENESIS.DIFFICULTY = 10000
 
         env.quark_chain_config.SKIP_MINOR_DIFFICULTY_CHECK = False

--- a/quarkchain/cluster/tests/test_utils.py
+++ b/quarkchain/cluster/tests/test_utils.py
@@ -50,11 +50,11 @@ def get_test_env(
         check(len(genesis_root_heights) == shard_size)
         for shard_id in range(shard_size):
             full_shard_id = shard_size | shard_id  # chain_id is 0
-            shard = env.quark_chain_config.SHARDS[full_shard_id]
+            shard = env.quark_chain_config.shards[full_shard_id]
             shard.GENESIS.ROOT_HEIGHT = genesis_root_heights[shard_id]
 
     # fund genesis account in all shards
-    for full_shard_id, shard in env.quark_chain_config.SHARDS.items():
+    for full_shard_id, shard in env.quark_chain_config.shards.items():
         addr = genesis_account.address_in_shard(full_shard_id).serialize().hex()
         shard.GENESIS.ALLOC[addr] = genesis_minor_quarkash
         shard.CONSENSUS_CONFIG.REMOTE_MINE = remote_mining
@@ -242,7 +242,7 @@ def create_test_clusters(
         if small_coinbase:
             # prevent breaking previous tests after tweaking default rewards
             env.quark_chain_config.ROOT.COINBASE_AMOUNT = 5
-            for c in env.quark_chain_config.SHARDS.values():
+            for c in env.quark_chain_config.shards.values():
                 c.COINBASE_AMOUNT = 5
 
         env.cluster_config.SLAVE_LIST = []

--- a/quarkchain/genesis.py
+++ b/quarkchain/genesis.py
@@ -41,7 +41,7 @@ class GenesisManager:
         Genesis state will be committed to the given evm_state.
         """
         branch = Branch(full_shard_id)
-        shard_config = self._qkc_config.SHARDS[full_shard_id]
+        shard_config = self._qkc_config.shards[full_shard_id]
         genesis = shard_config.GENESIS
 
         for address_hex, amount_in_wei in genesis.ALLOC.items():

--- a/quarkchain/tests/test_config.py
+++ b/quarkchain/tests/test_config.py
@@ -2,11 +2,12 @@ import unittest
 from fractions import Fraction
 
 from quarkchain.config import (
+    ChainConfig,
     ConsensusType,
     POWConfig,
-    ShardConfig,
-    RootConfig,
     QuarkChainConfig,
+    RootConfig,
+    ShardConfig,
 )
 
 
@@ -18,29 +19,18 @@ class TestQuarkChainConfig(unittest.TestCase):
         config.ROOT.CONSENSUS_CONFIG = POWConfig()
         config.ROOT.CONSENSUS_CONFIG.TARGET_BLOCK_TIME = 60
 
-        config.CHAIN_SIZE = 2
-        config.SHARDS = dict()
-        for i in range(2):
-            s = ShardConfig()
-            s.CHAIN_ID = 0
-            s.SHARD_SIZE = 2
-            s.SHARD_ID = i
-            s.CONSENSUS_TYPE = ConsensusType.POW_DOUBLESHA256
-            s.CONSENSUS_CONFIG = POWConfig()
-            config.SHARDS[0 | 2 | i] = s
-
-        for i in range(2):
-            s = ShardConfig()
-            s.CHAIN_ID = 1
-            s.SHARD_SIZE = 2
-            s.SHARD_ID = i
-            s.CONSENSUS_TYPE = ConsensusType.POW_ETHASH
-            s.CONSENSUS_CONFIG = POWConfig()
-            s.CONSENSUS_CONFIG.TARGET_BLOCK_TIME = 15
-            config.SHARDS[(1 << 16) | 2 | i] = s
+        config.CHAIN_SIZE = 3
+        config.CHAINS = []
+        for i in range(config.CHAIN_SIZE):
+            chain_config = ChainConfig()
+            chain_config.CHAIN_ID = i
+            chain_config.SHARD_SIZE = 2
+            chain_config.CONSENSUS_TYPE = ConsensusType.POW_DOUBLESHA256
+            chain_config.CONSENSUS_CONFIG = POWConfig()
+            config.CHAINS.append(chain_config)
 
         expected_json = """{
-    "CHAIN_SIZE": 2,
+    "CHAIN_SIZE": 3,
     "MAX_NEIGHBORS": 32,
     "NETWORK_ID": 3,
     "TRANSACTION_QUEUE_SIZE_LIMIT_PER_SHARD": 10000,
@@ -72,45 +62,10 @@ class TestQuarkChainConfig(unittest.TestCase):
         "DIFFICULTY_ADJUSTMENT_CUTOFF_TIME": 40,
         "DIFFICULTY_ADJUSTMENT_FACTOR": 1024
     },
-    "SHARDS": [
+    "CHAINS": [
         {
             "CHAIN_ID": 0,
             "SHARD_SIZE": 2,
-            "SHARD_ID": 0,
-            "CONSENSUS_TYPE": "POW_DOUBLESHA256",
-            "CONSENSUS_CONFIG": {
-                "TARGET_BLOCK_TIME": 10,
-                "REMOTE_MINE": false
-            },
-            "GENESIS": {
-                "ROOT_HEIGHT": 0,
-                "VERSION": 0,
-                "HEIGHT": 0,
-                "HASH_PREV_MINOR_BLOCK": "0000000000000000000000000000000000000000000000000000000000000000",
-                "HASH_MERKLE_ROOT": "0000000000000000000000000000000000000000000000000000000000000000",
-                "EXTRA_DATA": "497420776173207468652062657374206f662074696d65732c206974207761732074686520776f727374206f662074696d65732c202e2e2e202d20436861726c6573204469636b656e73",
-                "TIMESTAMP": 1519147489,
-                "DIFFICULTY": 10000,
-                "GAS_LIMIT": 12000000,
-                "NONCE": 0,
-                "ALLOC": {}
-            },
-            "COINBASE_ADDRESS": "000000000000000000000000000000000000000000000000",
-            "COINBASE_AMOUNT": 5000000000000000000,
-            "GAS_LIMIT_EMA_DENOMINATOR": 1024,
-            "GAS_LIMIT_ADJUSTMENT_FACTOR": 1024,
-            "GAS_LIMIT_MINIMUM": 5000,
-            "GAS_LIMIT_MAXIMUM": 9223372036854775807,
-            "GAS_LIMIT_USAGE_ADJUSTMENT_NUMERATOR": 3,
-            "GAS_LIMIT_USAGE_ADJUSTMENT_DENOMINATOR": 2,
-            "DIFFICULTY_ADJUSTMENT_CUTOFF_TIME": 7,
-            "DIFFICULTY_ADJUSTMENT_FACTOR": 512,
-            "EXTRA_SHARD_BLOCKS_IN_ROOT_BLOCK": 3
-        },
-        {
-            "CHAIN_ID": 0,
-            "SHARD_SIZE": 2,
-            "SHARD_ID": 1,
             "CONSENSUS_TYPE": "POW_DOUBLESHA256",
             "CONSENSUS_CONFIG": {
                 "TARGET_BLOCK_TIME": 10,
@@ -144,10 +99,9 @@ class TestQuarkChainConfig(unittest.TestCase):
         {
             "CHAIN_ID": 1,
             "SHARD_SIZE": 2,
-            "SHARD_ID": 0,
-            "CONSENSUS_TYPE": "POW_ETHASH",
+            "CONSENSUS_TYPE": "POW_DOUBLESHA256",
             "CONSENSUS_CONFIG": {
-                "TARGET_BLOCK_TIME": 15,
+                "TARGET_BLOCK_TIME": 10,
                 "REMOTE_MINE": false
             },
             "GENESIS": {
@@ -176,12 +130,11 @@ class TestQuarkChainConfig(unittest.TestCase):
             "EXTRA_SHARD_BLOCKS_IN_ROOT_BLOCK": 3
         },
         {
-            "CHAIN_ID": 1,
+            "CHAIN_ID": 2,
             "SHARD_SIZE": 2,
-            "SHARD_ID": 1,
-            "CONSENSUS_TYPE": "POW_ETHASH",
+            "CONSENSUS_TYPE": "POW_DOUBLESHA256",
             "CONSENSUS_CONFIG": {
-                "TARGET_BLOCK_TIME": 15,
+                "TARGET_BLOCK_TIME": 10,
                 "REMOTE_MINE": false
             },
             "GENESIS": {
@@ -210,6 +163,7 @@ class TestQuarkChainConfig(unittest.TestCase):
             "EXTRA_SHARD_BLOCKS_IN_ROOT_BLOCK": 3
         }
     ],
+    "SHARDS": null,
     "REWARD_TAX_RATE": 0.5
 }"""
         print(config.to_json())
@@ -223,15 +177,15 @@ class TestQuarkChainConfig(unittest.TestCase):
     def test_missing_one_shard_config(self):
         config = QuarkChainConfig()
         config.CHAIN_SIZE = 1
-        config.SHARDS = dict()
+        config.shards = dict()
         for i in range(1):
-            s = ShardConfig()
+            s = ShardConfig(ChainConfig())
             s.CHAIN_ID = 0
             s.SHARD_SIZE = 2
             s.SHARD_ID = i
             s.CONSENSUS_TYPE = ConsensusType.POW_DOUBLESHA256
             s.CONSENSUS_CONFIG = POWConfig()
-            config.SHARDS[0 | 2 | i] = s
+            config.shards[0 | 2 | i] = s
 
         with self.assertRaises(AssertionError):
             config.init_and_validate()
@@ -239,15 +193,15 @@ class TestQuarkChainConfig(unittest.TestCase):
     def test_bad_shard_size(self):
         config = QuarkChainConfig()
         config.CHAIN_SIZE = 1
-        config.SHARDS = dict()
+        config.shards = dict()
         for i in range(3):
-            s = ShardConfig()
+            s = ShardConfig(ChainConfig())
             s.CHAIN_ID = 0
             s.SHARD_SIZE = 3  # not power of 2
             s.SHARD_ID = i
             s.CONSENSUS_TYPE = ConsensusType.POW_DOUBLESHA256
             s.CONSENSUS_CONFIG = POWConfig()
-            config.SHARDS[0 | 2 | i] = s
+            config.shards[0 | 2 | i] = s
 
         with self.assertRaises(AssertionError):
             config.init_and_validate()
@@ -255,15 +209,15 @@ class TestQuarkChainConfig(unittest.TestCase):
     def test_shard_size_not_match(self):
         config = QuarkChainConfig()
         config.CHAIN_SIZE = 1
-        config.SHARDS = dict()
+        config.shards = dict()
         for i in range(2):
-            s = ShardConfig()
+            s = ShardConfig(ChainConfig())
             s.CHAIN_ID = 0
             s.SHARD_SIZE = i
             s.SHARD_ID = i
             s.CONSENSUS_TYPE = ConsensusType.POW_DOUBLESHA256
             s.CONSENSUS_CONFIG = POWConfig()
-            config.SHARDS[0 | 2 | i] = s
+            config.shards[0 | 2 | i] = s
 
         with self.assertRaises(AssertionError):
             config.init_and_validate()
@@ -271,15 +225,15 @@ class TestQuarkChainConfig(unittest.TestCase):
     def test_bad_shard_id(self):
         config = QuarkChainConfig()
         config.CHAIN_SIZE = 1
-        config.SHARDS = dict()
+        config.shards = dict()
         for i in range(2):
-            s = ShardConfig()
+            s = ShardConfig(ChainConfig())
             s.CHAIN_ID = 0
             s.SHARD_SIZE = 2
             s.SHARD_ID = 0
             s.CONSENSUS_TYPE = ConsensusType.POW_DOUBLESHA256
             s.CONSENSUS_CONFIG = POWConfig()
-            config.SHARDS[0 | 2 | i] = s
+            config.shards[0 | 2 | i] = s
 
         with self.assertRaises(AssertionError):
             config.init_and_validate()
@@ -287,15 +241,15 @@ class TestQuarkChainConfig(unittest.TestCase):
     def test_bad_chain_id(self):
         config = QuarkChainConfig()
         config.CHAIN_SIZE = 1
-        config.SHARDS = dict()
+        config.shards = dict()
         for i in range(2):
-            s = ShardConfig()
+            s = ShardConfig(ChainConfig())
             s.CHAIN_ID = 1
             s.SHARD_SIZE = 2
             s.SHARD_ID = i
             s.CONSENSUS_TYPE = ConsensusType.POW_DOUBLESHA256
             s.CONSENSUS_CONFIG = POWConfig()
-            config.SHARDS[1 << 16 | 2 | i] = s
+            config.shards[1 << 16 | 2 | i] = s
 
         with self.assertRaises(AssertionError):
             config.init_and_validate()

--- a/quarkchain/tools/external_miner.py
+++ b/quarkchain/tools/external_miner.py
@@ -238,7 +238,7 @@ def main():
             full_shard_id = qkc_config.get_full_shard_id_by_full_shard_key(
                 full_shard_key
             )
-            c = qkc_config.SHARDS[full_shard_id]
+            c = qkc_config.shards[full_shard_id]
         else:
             full_shard_id = None
             c = qkc_config.ROOT


### PR DESCRIPTION
s/ShardConfig/ChainConfig/g

Add new ShardConfig as a subclass of ChainConfig.

In cluster_config.json only ChainConfig is persisted.

ShardConfig is derived from ChainConfig during ClusterConfig
initialization and stored in QuarkChainConfig.shards instead of
QuarkChainConfig.SHARDS