### PR TITLE
Fix sort syntax for token

### DIFF
--- a/fixtures/0001-Necessary-changes-to-let-evm-tests-pass.patch
+++ b/fixtures/0001-Necessary-changes-to-let-evm-tests-pass.patch
@@ -287,15 +287,6 @@ index 2c0dc14..7862f6b 100644
          retv = self.enum
          if self.enum == b"\x00":
              l = []
-@@ -107,7 +103,7 @@ class TokenBalances:
-                 l.append(TokenBalancePair(k, v))
-             l.sort(
-                 lambda b: b.token_id
--            )  # sort by token id to make token balances serialization deterministic
-+            )  # sort by token id to make balance deterministic
-             retv = retv + rlp.encode(l)
-         elif self.enum == b"\x01":
-             raise Exception("Token balance trie is not yet implemented")
 @@ -116,22 +112,22 @@ class TokenBalances:
          return retv
 

--- a/quarkchain/evm/state.py
+++ b/quarkchain/evm/state.py
@@ -107,9 +107,8 @@ class TokenBalances:
             l = []
             for k, v in self.balances.items():
                 l.append(TokenBalancePair(k, v))
-            l.sort(
-                lambda b: b.token_id
-            )  # sort by token id to make token balances serialization deterministic
+            # sort by token id to make token balances serialization deterministic
+            l.sort(key=lambda b: b.token_id)
             retv = retv + rlp.encode(l)
         elif self.enum == b"\x01":
             raise Exception("Token balance trie is not yet implemented")


### PR DESCRIPTION
without `key` the syntax will break in python3.6 and above 