### PR TITLE
store minor coinbase in root state

### DIFF
--- a/quarkchain/cluster/jsonrpc.py
+++ b/quarkchain/cluster/jsonrpc.py
@@ -13,7 +13,6 @@ from jsonrpcserver.async_methods import AsyncMethods
 from jsonrpcserver.exceptions import InvalidParams
 
 from quarkchain.cluster.master import MasterServer
-from quarkchain.cluster.rpc import TokenBalancePair
 from quarkchain.core import (
     Address,
     Branch,
@@ -23,6 +22,7 @@ from quarkchain.core import (
     RootBlock,
     Transaction,
     TransactionReceipt,
+    TokenBalanceMap,
 )
 from quarkchain.evm.transactions import Transaction as EvmTransaction
 from quarkchain.evm.utils import denoms, is_numeric
@@ -316,9 +316,9 @@ def receipt_encoder(block: MinorBlock, i: int, receipt: TransactionReceipt):
     return resp
 
 
-def balances_encoder(balances: List[TokenBalancePair]) -> List[Dict]:
+def balances_encoder(balances: TokenBalanceMap) -> List[Dict]:
     balance_list = []
-    for pair in balances:
+    for pair in balances.balance_map:
         balance_list.append(
             {
                 "tokenId": quantity_encoder(pair.token_id),

--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -268,7 +268,12 @@ class SyncTask:
                 self.master_server.update_shard_stats(result.shard_stats)
 
         for m_header in minor_block_header_list:
-            self.root_state.add_validated_minor_block_hash(m_header.get_hash())
+            self.root_state.add_validated_minor_block_hash(
+                m_header.get_hash(),
+                {
+                    self.master_server.env.quark_chain_config.genesis_token: m_header.coinbase_amount
+                },
+            )
 
 
 class Synchronizer:
@@ -562,7 +567,10 @@ class SlaveConnection(ClusterConnection):
 
     async def handle_add_minor_block_header_request(self, req):
         self.master_server.root_state.add_validated_minor_block_hash(
-            req.minor_block_header.get_hash()
+            req.minor_block_header.get_hash(),
+            {
+                self.master_server.env.quark_chain_config.genesis_token: req.minor_block_header.coinbase_amount
+            },
         )
         self.master_server.update_shard_stats(req.shard_stats)
         self.master_server.update_tx_count_history(

--- a/quarkchain/cluster/root_state.py
+++ b/quarkchain/cluster/root_state.py
@@ -190,7 +190,7 @@ class RootDb:
     def contain_minor_block_by_hash(self, h):
         return h in self.m_hash_dict.keys()
 
-    def put_minor_block_hash(self, m_hash: bytes, coinbase_tokens: dict):
+    def put_minor_block_coinbase(self, m_hash: bytes, coinbase_tokens: dict):
         tokens = TokenBalanceMap(coinbase_tokens)
         self.db.put(b"mheader_" + m_hash, tokens.serialize())
         self.m_hash_dict[m_hash] = coinbase_tokens
@@ -252,7 +252,7 @@ class RootState:
         return self.db.get_root_block_by_hash(self.tip.get_hash())
 
     def add_validated_minor_block_hash(self, hash: bytes, coinbase_tokens: dict):
-        self.db.put_minor_block_hash(hash, coinbase_tokens)
+        self.db.put_minor_block_coinbase(hash, coinbase_tokens)
 
     def get_next_block_difficulty(self, create_time=None):
         if create_time is None:

--- a/quarkchain/cluster/rpc.py
+++ b/quarkchain/cluster/rpc.py
@@ -21,6 +21,7 @@ from quarkchain.core import (
     Address,
     Branch,
     ChainMask,
+    TokenBalancePair,
 )
 from quarkchain.core import hash256, uint16, uint32, uint64, uint128, uint256, boolean
 
@@ -464,18 +465,6 @@ class GetAccountDataRequest(Serializable):
     def __init__(self, address: Address, block_height: typing.Optional[int] = None):
         self.address = address
         self.block_height = block_height
-
-
-def token_pair_list_to_dict(l):
-    return {p.token_id: p.balance for p in l}
-
-
-class TokenBalancePair(Serializable):
-    FIELDS = [("token_id", uint64), ("balance", uint256)]
-
-    def __init__(self, token_id, balance):
-        self.token_id = token_id
-        self.balance = balance
 
 
 class AccountBranchData(Serializable):

--- a/quarkchain/cluster/rpc.py
+++ b/quarkchain/cluster/rpc.py
@@ -21,7 +21,7 @@ from quarkchain.core import (
     Address,
     Branch,
     ChainMask,
-    TokenBalancePair,
+    TokenBalanceMap,
 )
 from quarkchain.core import hash256, uint16, uint32, uint64, uint128, uint256, boolean
 
@@ -471,7 +471,7 @@ class AccountBranchData(Serializable):
     FIELDS = [
         ("branch", Branch),
         ("transaction_count", uint256),
-        ("token_balances", PrependedSizeListSerializer(4, TokenBalancePair)),
+        ("token_balances", TokenBalanceMap),
         ("is_contract", boolean),
     ]
 

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -79,7 +79,7 @@ class ShardState:
         self.tx_queue = TransactionQueue()  # queue of EvmTransaction
         self.tx_dict = dict()  # hash -> Transaction for explorer
         self.initialized = False
-        self.header_tip = None
+        self.header_tip = None  # MinorBlockHeader
         # TODO: make the oracle configurable
         self.gas_price_suggestion_oracle = GasPriceSuggestionOracle(
             last_price=0, last_head=b"", check_blocks=5, percentile=50

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -1311,13 +1311,18 @@ class ShardState:
         if self.branch.is_in_branch(r_block.header.coinbase_address.full_shard_key):
             check(len(r_block.header.coinbase_amount_map.balance_map) <= 1)
             if len(r_block.header.coinbase_amount_map.balance_map) == 1:
-                check(self.genesis_token_id in r_block.header.coinbase_amount_map.balance_map)
+                check(
+                    self.genesis_token_id
+                    in r_block.header.coinbase_amount_map.balance_map
+                )
             tx_list.append(
                 CrossShardTransactionDeposit(
                     tx_hash=bytes(32),
                     from_address=Address.create_empty_account(0),
                     to_address=r_block.header.coinbase_address,
-                    value=r_block.header.coinbase_amount_map.balance_map.get(self.genesis_token_id, 0),
+                    value=r_block.header.coinbase_amount_map.balance_map.get(
+                        self.genesis_token_id, 0
+                    ),
                     gas_price=0,
                     gas_token_id=self.genesis_token_id,
                     transfer_token_id=self.genesis_token_id,  # root block coinbase is only in QKC

--- a/quarkchain/cluster/slave.py
+++ b/quarkchain/cluster/slave.py
@@ -47,7 +47,6 @@ from quarkchain.cluster.rpc import (
     GetMinorBlockResponse,
     GetTransactionResponse,
     AccountBranchData,
-    TokenBalancePair,
     BatchAddXshardTxListRequest,
     BatchAddXshardTxListResponse,
     MineResponse,
@@ -75,6 +74,7 @@ from quarkchain.core import (
     RootBlock,
     RootBlockHeader,
     TransactionReceipt,
+    TokenBalanceMap,
 )
 from quarkchain.env import DEFAULT_ENV
 from quarkchain.protocol import Connection
@@ -1152,20 +1152,14 @@ class SlaveServer:
     ) -> List[AccountBranchData]:
         results = []
         for branch, shard in self.shards.items():
-            balance_list = []
             token_balances = shard.state.get_balances(address.recipient, block_height)
-            for k in sorted(
-                token_balances
-            ):  # keep token balance sorted to maintain deterministic serialization
-                kv = TokenBalancePair(k, token_balances[k])
-                balance_list.append(kv)
             results.append(
                 AccountBranchData(
                     branch=branch,
                     transaction_count=shard.state.get_transaction_count(
                         address.recipient, block_height
                     ),
-                    token_balances=balance_list,
+                    token_balances=TokenBalanceMap(token_balances),
                     is_contract=len(
                         shard.state.get_code(address.recipient, block_height)
                     )

--- a/quarkchain/cluster/tests/test_cluster.py
+++ b/quarkchain/cluster/tests/test_cluster.py
@@ -7,7 +7,7 @@ from quarkchain.cluster.tests.test_utils import (
 from quarkchain.core import Address, Branch, Identity
 from quarkchain.evm import opcodes
 from quarkchain.utils import call_async, assert_true_with_timeout
-from quarkchain.cluster.rpc import token_pair_list_to_dict
+from quarkchain.cluster.root_state import token_pair_list_to_dict
 
 
 class TestCluster(unittest.TestCase):

--- a/quarkchain/cluster/tests/test_cluster.py
+++ b/quarkchain/cluster/tests/test_cluster.py
@@ -7,7 +7,6 @@ from quarkchain.cluster.tests.test_utils import (
 from quarkchain.core import Address, Branch, Identity
 from quarkchain.evm import opcodes
 from quarkchain.utils import call_async, assert_true_with_timeout
-from quarkchain.cluster.root_state import token_pair_list_to_dict
 
 
 class TestCluster(unittest.TestCase):
@@ -102,9 +101,9 @@ class TestCluster(unittest.TestCase):
             self.assertEqual(block1.header.branch.value, 0b10)
             self.assertEqual(len(block1.tx_list), 1)
 
-            original_balance_acc1 = token_pair_list_to_dict(
-                call_async(master.get_primary_account_data(acc1)).token_balances
-            )
+            original_balance_acc1 = call_async(
+                master.get_primary_account_data(acc1)
+            ).token_balances.balance_map
             gas_paid = (opcodes.GTXXSHARDCOST + opcodes.GTXCOST) * 3
             self.assertTrue(
                 call_async(
@@ -112,10 +111,14 @@ class TestCluster(unittest.TestCase):
                 )
             )
             self.assertEqual(
-                token_pair_list_to_dict(
-                    call_async(master.get_primary_account_data(acc1)).token_balances
-                )[genesis_token],
-                original_balance_acc1[genesis_token] - 54321 - gas_paid,
+                call_async(
+                    master.get_primary_account_data(acc1)
+                ).token_balances.balance_map,
+                {
+                    genesis_token: original_balance_acc1[genesis_token]
+                    - 54321
+                    - gas_paid
+                },
             )
             self.assertEqual(
                 clusters[0]
@@ -155,9 +158,9 @@ class TestCluster(unittest.TestCase):
             )
             # Expect withdrawTo is included in acc3's balance
             self.assertEqual(
-                token_pair_list_to_dict(
-                    call_async(master.get_primary_account_data(acc3)).token_balances
-                ),
+                call_async(
+                    master.get_primary_account_data(acc3)
+                ).token_balances.balance_map,
                 {genesis_token: 54321},
             )
 
@@ -671,9 +674,9 @@ class TestCluster(unittest.TestCase):
                 call_async(master.add_raw_minor_block(b4.header.branch, b4.serialize()))
             )
             self.assertEqual(
-                token_pair_list_to_dict(
-                    call_async(master.get_primary_account_data(acc3)).token_balances
-                ),
+                call_async(
+                    master.get_primary_account_data(acc3)
+                ).token_balances.balance_map,
                 {genesis_token: 54321},
             )
 

--- a/quarkchain/cluster/tests/test_root_state.py
+++ b/quarkchain/cluster/tests/test_root_state.py
@@ -201,7 +201,7 @@ class TestRootState(unittest.TestCase):
         root_block1.add_minor_block_header(b2.header).add_minor_block_header(
             b3.header
         ).finalize(
-            coinbase_amount=r_state.coinbase_with_tax(
+            coinbase_amount_map=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block1.minor_block_header_list]
             )
         )
@@ -229,7 +229,7 @@ class TestRootState(unittest.TestCase):
             .add_minor_block_header(b5.header)
         )
         root_block2.finalize(
-            coinbase_amount=r_state.coinbase_with_tax(
+            coinbase_amount_map=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block2.minor_block_header_list]
             )
         )
@@ -288,7 +288,9 @@ class TestRootState(unittest.TestCase):
             self.assertEqual(root_block_tmp.header.signature, bytes(65))  # empty sig
             # still use minor block's coinbase amount, 1
             self.assertEqual(
-                root_block_tmp.header.coinbase_amount_map.balance_map[env.quark_chain_config.genesis_token],
+                root_block_tmp.header.coinbase_amount_map.balance_map[
+                    env.quark_chain_config.genesis_token
+                ],
                 round((1 + 1) / (1 - tax_rate) * tax_rate + 5),
             )
         env.quark_chain_config.REWARD_TAX_RATE = original_reward_tax_rate
@@ -348,7 +350,7 @@ class TestRootState(unittest.TestCase):
         # create a fork
         root_block00.header.create_time += 1
         root_block00.finalize(
-            coinbase_amount=r_state.coinbase_with_tax(
+            coinbase_amount_map=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block00.minor_block_header_list]
             )
         )
@@ -431,7 +433,7 @@ class TestRootState(unittest.TestCase):
             nonce=0
         ).add_minor_block_header(m1.header)
         root_block1.finalize(
-            coinbase_amount=r_state.coinbase_with_tax(
+            coinbase_amount_map=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block1.minor_block_header_list]
             )
         )
@@ -439,7 +441,7 @@ class TestRootState(unittest.TestCase):
             nonce=1
         ).add_minor_block_header(m1.header)
         root_block2.finalize(
-            coinbase_amount=r_state.coinbase_with_tax(
+            coinbase_amount_map=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block2.minor_block_header_list]
             )
         )
@@ -461,7 +463,7 @@ class TestRootState(unittest.TestCase):
             m2.header
         )
         root_block3.finalize(
-            coinbase_amount=r_state.coinbase_with_tax(
+            coinbase_amount_map=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block3.minor_block_header_list]
             )
         )
@@ -473,7 +475,7 @@ class TestRootState(unittest.TestCase):
             m2.header
         )
         root_block4.finalize(
-            coinbase_amount=r_state.coinbase_with_tax(
+            coinbase_amount_map=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block4.minor_block_header_list]
             )
         )
@@ -521,7 +523,7 @@ class TestRootState(unittest.TestCase):
             nonce=0
         ).add_minor_block_header(m1.header)
         root_block1.finalize(
-            coinbase_amount=r_state.coinbase_with_tax(
+            coinbase_amount_map=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block1.minor_block_header_list]
             )
         )
@@ -529,7 +531,7 @@ class TestRootState(unittest.TestCase):
             nonce=1
         ).add_minor_block_header(m2.header)
         root_block2.finalize(
-            coinbase_amount=r_state.coinbase_with_tax(
+            coinbase_amount_map=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block2.minor_block_header_list]
             )
         )

--- a/quarkchain/cluster/tests/test_root_state.py
+++ b/quarkchain/cluster/tests/test_root_state.py
@@ -200,7 +200,11 @@ class TestRootState(unittest.TestCase):
 
         root_block1.add_minor_block_header(b2.header).add_minor_block_header(
             b3.header
-        ).finalize()
+        ).finalize(
+            coinbase_amount=r_state.coinbase_with_tax(
+                [header.get_hash() for header in root_block1.minor_block_header_list]
+            )
+        )
 
         self.assertFalse(r_state.add_block(root_block1))
         self.assertFalse(s_state0.add_root_block(root_block1))
@@ -223,7 +227,11 @@ class TestRootState(unittest.TestCase):
             root_block1.create_block_to_append()
             .add_minor_block_header(b4.header)
             .add_minor_block_header(b5.header)
-            .finalize()
+        )
+        root_block2.finalize(
+            coinbase_amount=r_state.coinbase_with_tax(
+                [header.get_hash() for header in root_block2.minor_block_header_list]
+            )
         )
 
         self.assertTrue(r_state.add_block(root_block2))
@@ -339,7 +347,11 @@ class TestRootState(unittest.TestCase):
 
         # create a fork
         root_block00.header.create_time += 1
-        root_block00.finalize()
+        root_block00.finalize(
+            coinbase_amount=r_state.coinbase_with_tax(
+                [header.get_hash() for header in root_block00.minor_block_header_list]
+            )
+        )
         self.assertNotEqual(
             root_block0.header.get_hash(), root_block00.header.get_hash()
         )
@@ -415,15 +427,21 @@ class TestRootState(unittest.TestCase):
             m1.header.get_hash(),
             {env.quark_chain_config.genesis_token: m1.header.coinbase_amount},
         )
-        root_block1 = (
-            root_block0.create_block_to_append(nonce=0)
-            .add_minor_block_header(m1.header)
-            .finalize()
+        root_block1 = root_block0.create_block_to_append(
+            nonce=0
+        ).add_minor_block_header(m1.header)
+        root_block1.finalize(
+            coinbase_amount=r_state.coinbase_with_tax(
+                [header.get_hash() for header in root_block1.minor_block_header_list]
+            )
         )
-        root_block2 = (
-            root_block0.create_block_to_append(nonce=1)
-            .add_minor_block_header(m1.header)
-            .finalize()
+        root_block2 = root_block0.create_block_to_append(
+            nonce=1
+        ).add_minor_block_header(m1.header)
+        root_block2.finalize(
+            coinbase_amount=r_state.coinbase_with_tax(
+                [header.get_hash() for header in root_block2.minor_block_header_list]
+            )
         )
 
         self.assertTrue(r_state.add_block(root_block1))
@@ -439,19 +457,25 @@ class TestRootState(unittest.TestCase):
             m2.header.get_hash(),
             {env.quark_chain_config.genesis_token: m2.header.coinbase_amount},
         )
-        root_block3 = (
-            root_block1.create_block_to_append()
-            .add_minor_block_header(m2.header)
-            .finalize()
+        root_block3 = root_block1.create_block_to_append().add_minor_block_header(
+            m2.header
+        )
+        root_block3.finalize(
+            coinbase_amount=r_state.coinbase_with_tax(
+                [header.get_hash() for header in root_block3.minor_block_header_list]
+            )
         )
 
         with self.assertRaises(ValueError):
             r_state.add_block(root_block3)
 
-        root_block4 = (
-            root_block2.create_block_to_append()
-            .add_minor_block_header(m2.header)
-            .finalize()
+        root_block4 = root_block2.create_block_to_append().add_minor_block_header(
+            m2.header
+        )
+        root_block4.finalize(
+            coinbase_amount=r_state.coinbase_with_tax(
+                [header.get_hash() for header in root_block4.minor_block_header_list]
+            )
         )
         self.assertTrue(r_state.add_block(root_block4))
 
@@ -493,15 +517,21 @@ class TestRootState(unittest.TestCase):
             m2.header.get_hash(),
             {env.quark_chain_config.genesis_token: m2.header.coinbase_amount},
         )
-        root_block1 = (
-            root_block0.create_block_to_append(nonce=0)
-            .add_minor_block_header(m1.header)
-            .finalize()
+        root_block1 = root_block0.create_block_to_append(
+            nonce=0
+        ).add_minor_block_header(m1.header)
+        root_block1.finalize(
+            coinbase_amount=r_state.coinbase_with_tax(
+                [header.get_hash() for header in root_block1.minor_block_header_list]
+            )
         )
-        root_block2 = (
-            root_block0.create_block_to_append(nonce=1)
-            .add_minor_block_header(m2.header)
-            .finalize()
+        root_block2 = root_block0.create_block_to_append(
+            nonce=1
+        ).add_minor_block_header(m2.header)
+        root_block2.finalize(
+            coinbase_amount=r_state.coinbase_with_tax(
+                [header.get_hash() for header in root_block2.minor_block_header_list]
+            )
         )
 
         self.assertTrue(r_state.add_block(root_block1))

--- a/quarkchain/cluster/tests/test_root_state.py
+++ b/quarkchain/cluster/tests/test_root_state.py
@@ -243,7 +243,6 @@ class TestRootState(unittest.TestCase):
 
     def test_root_state_difficulty_and_coinbase(self):
         env = get_test_env()
-        env.quark_chain_config.SKIP_ROOT_COINBASE_CHECK
         env.quark_chain_config.SKIP_ROOT_DIFFICULTY_CHECK = False
         env.quark_chain_config.ROOT.GENESIS.DIFFICULTY = 1000
         diff_calc = EthDifficultyCalculator(cutoff=9, diff_factor=2048, minimum_diff=1)

--- a/quarkchain/cluster/tests/test_root_state.py
+++ b/quarkchain/cluster/tests/test_root_state.py
@@ -25,7 +25,10 @@ def create_default_state(env, diff_calc=None):
     for state in s_state_list.values():
         minor_header_list.append(state.header_tip)
         block_hash = state.header_tip.get_hash()
-        r_state.add_validated_minor_block_hash(block_hash)
+        r_state.add_validated_minor_block_hash(
+            block_hash,
+            {env.quark_chain_config.genesis_token: state.header_tip.coinbase_amount},
+        )
 
     root_block = r_state.create_block_to_mine(minor_header_list)
     assert r_state.add_block(root_block)
@@ -64,8 +67,14 @@ class TestRootState(unittest.TestCase):
         b1 = s_state1.create_block_to_mine()
         add_minor_block_to_cluster(s_states, b1)
 
-        r_state.add_validated_minor_block_hash(b0.header.get_hash())
-        r_state.add_validated_minor_block_hash(b1.header.get_hash())
+        r_state.add_validated_minor_block_hash(
+            b0.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b0.header.coinbase_amount},
+        )
+        r_state.add_validated_minor_block_hash(
+            b1.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b1.header.coinbase_amount},
+        )
         root_block = r_state.create_block_to_mine([b0.header, b1.header])
 
         self.assertTrue(r_state.add_block(root_block))
@@ -92,8 +101,14 @@ class TestRootState(unittest.TestCase):
         b1 = s_state1.create_block_to_mine()
         s_state1.finalize_and_add_block(b1)
 
-        r_state.add_validated_minor_block_hash(b0.header.get_hash())
-        r_state.add_validated_minor_block_hash(b1.header.get_hash())
+        r_state.add_validated_minor_block_hash(
+            b0.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b0.header.coinbase_amount},
+        )
+        r_state.add_validated_minor_block_hash(
+            b1.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b1.header.coinbase_amount},
+        )
 
         root_block = r_state.create_block_to_mine([])
         self.assertTrue(r_state.add_block(root_block))
@@ -112,8 +127,14 @@ class TestRootState(unittest.TestCase):
         b1 = s_state1.create_block_to_mine()
         add_minor_block_to_cluster(s_states, b1)
 
-        r_state.add_validated_minor_block_hash(b0.header.get_hash())
-        r_state.add_validated_minor_block_hash(b1.header.get_hash())
+        r_state.add_validated_minor_block_hash(
+            b0.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b0.header.coinbase_amount},
+        )
+        r_state.add_validated_minor_block_hash(
+            b1.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b1.header.coinbase_amount},
+        )
         root_block0 = r_state.create_block_to_mine([b0.header, b1.header])
 
         self.assertTrue(r_state.add_block(root_block0))
@@ -123,8 +144,14 @@ class TestRootState(unittest.TestCase):
         b3 = s_state1.create_block_to_mine()
         add_minor_block_to_cluster(s_states, b3)
 
-        r_state.add_validated_minor_block_hash(b2.header.get_hash())
-        r_state.add_validated_minor_block_hash(b3.header.get_hash())
+        r_state.add_validated_minor_block_hash(
+            b2.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b2.header.coinbase_amount},
+        )
+        r_state.add_validated_minor_block_hash(
+            b3.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b3.header.coinbase_amount},
+        )
         root_block1 = r_state.create_block_to_mine([b2.header, b3.header])
 
         self.assertTrue(r_state.add_block(root_block1))
@@ -143,8 +170,14 @@ class TestRootState(unittest.TestCase):
         b3 = s_state1.create_block_to_mine()
         add_minor_block_to_cluster(s_states, b1)
 
-        r_state.add_validated_minor_block_hash(b0.header.get_hash())
-        r_state.add_validated_minor_block_hash(b1.header.get_hash())
+        r_state.add_validated_minor_block_hash(
+            b0.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b0.header.coinbase_amount},
+        )
+        r_state.add_validated_minor_block_hash(
+            b1.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b1.header.coinbase_amount},
+        )
 
         root_block0 = r_state.create_block_to_mine([b0.header, b1.header])
         root_block1 = r_state.create_block_to_mine([])
@@ -156,8 +189,14 @@ class TestRootState(unittest.TestCase):
         add_minor_block_to_cluster(s_states, b2)
         add_minor_block_to_cluster(s_states, b3)
 
-        r_state.add_validated_minor_block_hash(b2.header.get_hash())
-        r_state.add_validated_minor_block_hash(b3.header.get_hash())
+        r_state.add_validated_minor_block_hash(
+            b2.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b2.header.coinbase_amount},
+        )
+        r_state.add_validated_minor_block_hash(
+            b3.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b3.header.coinbase_amount},
+        )
 
         root_block1.add_minor_block_header(b2.header).add_minor_block_header(
             b3.header
@@ -172,8 +211,14 @@ class TestRootState(unittest.TestCase):
         add_minor_block_to_cluster(s_states, b4)
         add_minor_block_to_cluster(s_states, b5)
 
-        r_state.add_validated_minor_block_hash(b4.header.get_hash())
-        r_state.add_validated_minor_block_hash(b5.header.get_hash())
+        r_state.add_validated_minor_block_hash(
+            b4.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b4.header.coinbase_amount},
+        )
+        r_state.add_validated_minor_block_hash(
+            b5.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b5.header.coinbase_amount},
+        )
         root_block2 = (
             root_block1.create_block_to_append()
             .add_minor_block_header(b4.header)
@@ -214,8 +259,14 @@ class TestRootState(unittest.TestCase):
         self.assertEqual(b0.header.coinbase_amount, 1)
         self.assertEqual(b1.header.coinbase_amount, 1)
 
-        r_state.add_validated_minor_block_hash(b0.header.get_hash())
-        r_state.add_validated_minor_block_hash(b1.header.get_hash())
+        r_state.add_validated_minor_block_hash(
+            b0.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b0.header.coinbase_amount},
+        )
+        r_state.add_validated_minor_block_hash(
+            b1.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b1.header.coinbase_amount},
+        )
 
         # Test coinbase
         original_reward_tax_rate = env.quark_chain_config.REWARD_TAX_RATE
@@ -272,8 +323,14 @@ class TestRootState(unittest.TestCase):
         b1 = s_state1.create_block_to_mine()
         add_minor_block_to_cluster(s_states, b1)
 
-        r_state.add_validated_minor_block_hash(b0.header.get_hash())
-        r_state.add_validated_minor_block_hash(b1.header.get_hash())
+        r_state.add_validated_minor_block_hash(
+            b0.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b0.header.coinbase_amount},
+        )
+        r_state.add_validated_minor_block_hash(
+            b1.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b1.header.coinbase_amount},
+        )
         root_block0 = r_state.create_block_to_mine([b0.header, b1.header])
 
         root_block00 = r_state.create_block_to_mine([b0.header, b1.header])
@@ -298,8 +355,14 @@ class TestRootState(unittest.TestCase):
         b3 = s_state1.create_block_to_mine()
         add_minor_block_to_cluster(s_states, b3)
 
-        r_state.add_validated_minor_block_hash(b2.header.get_hash())
-        r_state.add_validated_minor_block_hash(b3.header.get_hash())
+        r_state.add_validated_minor_block_hash(
+            b2.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b2.header.coinbase_amount},
+        )
+        r_state.add_validated_minor_block_hash(
+            b3.header.get_hash(),
+            {env.quark_chain_config.genesis_token: b3.header.coinbase_amount},
+        )
         root_block1 = r_state.create_block_to_mine([b2.header, b3.header])
 
         self.assertTrue(r_state.add_block(root_block1))
@@ -348,7 +411,10 @@ class TestRootState(unittest.TestCase):
         m1 = s_state0.get_tip().create_block_to_append()
         add_minor_block_to_cluster(s_states, m1)
 
-        r_state.add_validated_minor_block_hash(m1.header.get_hash())
+        r_state.add_validated_minor_block_hash(
+            m1.header.get_hash(),
+            {env.quark_chain_config.genesis_token: m1.header.coinbase_amount},
+        )
         root_block1 = (
             root_block0.create_block_to_append(nonce=0)
             .add_minor_block_header(m1.header)
@@ -369,7 +435,10 @@ class TestRootState(unittest.TestCase):
         m2.header.hash_prev_root_block = root_block2.header.get_hash()
         add_minor_block_to_cluster(s_states, m2)
 
-        r_state.add_validated_minor_block_hash(m2.header.get_hash())
+        r_state.add_validated_minor_block_hash(
+            m2.header.get_hash(),
+            {env.quark_chain_config.genesis_token: m2.header.coinbase_amount},
+        )
         root_block3 = (
             root_block1.create_block_to_append()
             .add_minor_block_header(m2.header)
@@ -416,8 +485,14 @@ class TestRootState(unittest.TestCase):
         add_minor_block_to_cluster(s_states, m1)
         add_minor_block_to_cluster(s_states, m2)
 
-        r_state.add_validated_minor_block_hash(m1.header.get_hash())
-        r_state.add_validated_minor_block_hash(m2.header.get_hash())
+        r_state.add_validated_minor_block_hash(
+            m1.header.get_hash(),
+            {env.quark_chain_config.genesis_token: m1.header.coinbase_amount},
+        )
+        r_state.add_validated_minor_block_hash(
+            m2.header.get_hash(),
+            {env.quark_chain_config.genesis_token: m2.header.coinbase_amount},
+        )
         root_block1 = (
             root_block0.create_block_to_append(nonce=0)
             .add_minor_block_header(m1.header)

--- a/quarkchain/cluster/tests/test_utils.py
+++ b/quarkchain/cluster/tests/test_utils.py
@@ -75,7 +75,6 @@ def get_test_env(
 
     env.quark_chain_config.SKIP_MINOR_DIFFICULTY_CHECK = True
     env.quark_chain_config.SKIP_ROOT_DIFFICULTY_CHECK = True
-    env.quark_chain_config.SKIP_ROOT_COINBASE_CHECK = True
     env.cluster_config.ENABLE_TRANSACTION_HISTORY = True
     env.cluster_config.DB_PATH_ROOT = ""
 

--- a/quarkchain/core.py
+++ b/quarkchain/core.py
@@ -1023,15 +1023,13 @@ class RootBlock(Serializable):
         self.tracking_data = tracking_data
 
     def finalize(
-        self,
-        coinbase_amount_map=dict(),
-        coinbase_address=Address.create_empty_account(),
+        self, coinbase_amount_map=None, coinbase_address=Address.create_empty_account()
     ):
         self.header.hash_merkle_root = calculate_merkle_root(
             self.minor_block_header_list
         )
 
-        self.header.coinbase_amount_map = TokenBalanceMap(coinbase_amount_map)
+        self.header.coinbase_amount_map = TokenBalanceMap(coinbase_amount_map or {})
         self.header.coinbase_address = coinbase_address
         return self
 

--- a/quarkchain/core.py
+++ b/quarkchain/core.py
@@ -8,7 +8,7 @@ import argparse
 import copy
 import random
 import typing
-from typing import List
+from typing import List, Dict
 
 import ecdsa
 import rlp
@@ -182,7 +182,7 @@ class PrependedSizeMapSerializer:
         self.key_ser = key_ser
         self.value_ser = value_ser
 
-    def serialize(self, item_map: dict, barray):
+    def serialize(self, item_map: Dict, barray):
         barray.extend(len(item_map).to_bytes(self.size_bytes, byteorder="big"))
         # keep keys sorted to maintain deterministic serialization
         for k in sorted(item_map):
@@ -900,11 +900,11 @@ class MinorBlock(Serializable):
 class TokenBalanceMap(Serializable):
     FIELDS = [("balance_map", PrependedSizeMapSerializer(4, biguint, biguint))]
 
-    def __init__(self, balance_map: dict):
+    def __init__(self, balance_map: Dict):
         self.balance_map = balance_map
 
-    def add(self, other):
-        for k, v in other.balance_map.items():
+    def add(self, other: Dict):
+        for k, v in other.items():
             self.balance_map[k] = self.balance_map.get(k, 0) + v
 
     def get_hash(self):
@@ -1184,21 +1184,6 @@ class TransactionReceipt(Serializable):
     @classmethod
     def create_empty_receipt(cls):
         return cls(b"", 0, 0, Address.create_empty_account(0), 0, [])
-
-
-class TokenBalancePair(Serializable):
-    FIELDS = [("token_id", uint64), ("balance", uint256)]
-
-    def __init__(self, token_id, balance):
-        self.token_id = token_id
-        self.balance = balance
-
-
-class TokenBalanceList(Serializable):
-    FIELDS = [("token_balances", PrependedSizeListSerializer(4, TokenBalancePair))]
-
-    def __init__(self, token_balances):
-        self.token_balances = token_balances
 
 
 def test():

--- a/quarkchain/core.py
+++ b/quarkchain/core.py
@@ -1188,6 +1188,21 @@ class TransactionReceipt(Serializable):
         return cls(b"", 0, 0, Address.create_empty_account(0), 0, [])
 
 
+class TokenBalancePair(Serializable):
+    FIELDS = [("token_id", uint64), ("balance", uint256)]
+
+    def __init__(self, token_id, balance):
+        self.token_id = token_id
+        self.balance = balance
+
+
+class TokenBalanceList(Serializable):
+    FIELDS = [("token_balances", PrependedSizeListSerializer(4, TokenBalancePair))]
+
+    def __init__(self, token_balances):
+        self.token_balances = token_balances
+
+
 def test():
     priv = KeyAPI.PrivateKey(
         bytes.fromhex(

--- a/quarkchain/core.py
+++ b/quarkchain/core.py
@@ -898,9 +898,7 @@ class MinorBlock(Serializable):
 
 
 class TokenBalanceMap(Serializable):
-    FIELDS = [
-        ("balance_map", PrependedSizeMapSerializer(4, biguint, biguint))
-    ]
+    FIELDS = [("balance_map", PrependedSizeMapSerializer(4, biguint, biguint))]
 
     def __init__(self, balance_map: dict):
         self.balance_map = balance_map
@@ -1026,14 +1024,14 @@ class RootBlock(Serializable):
 
     def finalize(
         self,
-        coinbase_amount_map=TokenBalanceMap(dict()),
-        coinbase_address=Address.create_empty_account()
+        coinbase_amount_map=dict(),
+        coinbase_address=Address.create_empty_account(),
     ):
         self.header.hash_merkle_root = calculate_merkle_root(
             self.minor_block_header_list
         )
 
-        self.header.coinbase_amount_map = coinbase_amount_map
+        self.header.coinbase_amount_map = TokenBalanceMap(coinbase_amount_map)
         self.header.coinbase_address = coinbase_address
         return self
 

--- a/quarkchain/tests/test_core.py
+++ b/quarkchain/tests/test_core.py
@@ -214,9 +214,7 @@ class TestEnumSerializer(unittest.TestCase):
 
 
 class MapData(Serializable):
-    FIELDS = [
-        ("m", PrependedSizeMapSerializer(4, uint32, boolean))
-    ]
+    FIELDS = [("m", PrependedSizeMapSerializer(4, uint32, boolean))]
 
     def __init__(self, m):
         self.m = m
@@ -253,9 +251,9 @@ class TestTokenBalanceMap(unittest.TestCase):
         m0 = TokenBalanceMap({0: 10})
         m1 = TokenBalanceMap({1: 20})
 
-        m0.add(m1)
+        m0.add(m1.balance_map)
         self.assertEqual(m0.balance_map, {0: 10, 1: 20})
 
         m2 = TokenBalanceMap({0: 30, 2: 50})
-        m0.add(m2)
+        m0.add(m2.balance_map)
         self.assertEqual(m0.balance_map, {0: 40, 1: 20, 2: 50})


### PR DESCRIPTION
one step closer to removing coinbase_amount in RootBlockHeader and MinorBlockHeader, and allowing multi native token as coinbase rewards (both root block and minor block)

when minor blocks are validated and added to shard states, a mapping (also stored in DB) will be available in root_state with corresponding coinbase amounts

this fixes numerous issues in test_root_state.py as coinbase calculations were incorrect; also, fixes #324 