### PR TITLE
Change Qkchash's initial data set and cache seed for every epoch

### DIFF
--- a/qkchash/qkchash.py
+++ b/qkchash/qkchash.py
@@ -163,11 +163,7 @@ class QkcHashNative:
         return QkcHashCache(self, ptr)
 
     def make_cache_block_number(self, entries, block_number):
-        while (len(cache_seeds) <= block_number // EPOCH_LENGTH):
-            new_seed = serialize_hash(sha3_256(cache_seeds[-1]))
-            cache_seeds.append(new_seed)
-        
-        seed = cache_seeds[block_number // EPOCH_LENGTH]
+        seed = get_seed_from_block_number(block_number)
         return self.make_cache(entries, seed)
 
     def dup_cache(self, cache):
@@ -185,6 +181,14 @@ class QkcHashNative:
             "result": serialize_hash(sha3_256(s + result[:])),
         }
 
+
+def get_seed_from_block_number(block_number: int):
+    while (len(cache_seeds) <= block_number // EPOCH_LENGTH):
+        new_seed = serialize_hash(sha3_256(cache_seeds[-1]))
+        cache_seeds.append(new_seed)
+        
+    seed = cache_seeds[block_number // EPOCH_LENGTH]
+    return seed
 
 def qkchash(header: bytes, nonce: bytes, cache: List) -> Dict[str, bytes]:
     s = sha3_512(header + nonce[::-1])

--- a/qkchash/qkcpow.py
+++ b/qkchash/qkcpow.py
@@ -4,7 +4,6 @@ from typing import Optional, Tuple
 
 from qkchash.qkchash import CACHE_ENTRIES, make_cache, qkchash, QkcHashNative
 
-CACHE_SEED = b""
 
 
 def get_qkchashlib_path():
@@ -20,26 +19,19 @@ def init_qkc_hash_native():
 
 
 QKC_HASH_NATIVE = init_qkc_hash_native()
-QKC_HASH_CACHE = (
-    QKC_HASH_NATIVE.make_cache(CACHE_ENTRIES, CACHE_SEED)
-    if QKC_HASH_NATIVE
-    else make_cache(CACHE_ENTRIES, CACHE_SEED)
-)
+
 
 
 @lru_cache(maxsize=32)
 def check_pow(
-    header_hash: bytes, mixhash: bytes, nonce: bytes, difficulty: int
+    block_number: int, header_hash: bytes, mixhash: bytes, nonce: bytes, difficulty: int
 ) -> bool:
     """Check if the proof-of-work of the block is valid."""
     if len(mixhash) != 32 or len(header_hash) != 32 or len(nonce) != 8:
         return False
 
-    if QKC_HASH_NATIVE is None:
-        mining_output = qkchash(header_hash, nonce, QKC_HASH_CACHE)
-    else:
-        dup_cache = QKC_HASH_NATIVE.dup_cache(QKC_HASH_CACHE)
-        mining_output = QKC_HASH_NATIVE.calculate_hash(header_hash, nonce, dup_cache)
+    current_cache = QKC_HASH_NATIVE.make_cache_block_number(CACHE_ENTRIES, block_number)
+    mining_output = QKC_HASH_NATIVE.calculate_hash(header_hash, nonce, current_cache)
 
     if mining_output["mix digest"] != mixhash:
         return False
@@ -48,7 +40,8 @@ def check_pow(
 
 
 class QkchashMiner:
-    def __init__(self, difficulty: int, header_hash: bytes):
+    def __init__(self, block_number: int, difficulty: int, header_hash: bytes):
+        self.block_number = block_number
         self.difficulty = difficulty
         self.header_hash = header_hash
 
@@ -56,7 +49,7 @@ class QkchashMiner:
         self, rounds=1000, start_nonce=0
     ) -> Tuple[Optional[bytes], Optional[bytes]]:
         bin_nonce, mixhash = mine(
-            self.difficulty, self.header_hash, start_nonce=start_nonce, rounds=rounds
+            self.block_number, self.difficulty, self.header_hash, start_nonce=start_nonce, rounds=rounds
         )
         if bin_nonce is not None:
             return bin_nonce, mixhash
@@ -65,20 +58,19 @@ class QkchashMiner:
 
 
 def mine(
-    difficulty: int, header_hash: bytes, start_nonce: int = 0, rounds: int = 1000
+    block_number: int, difficulty: int, header_hash: bytes, start_nonce: int = 0, rounds: int = 1000
 ) -> Tuple[Optional[bytes], Optional[bytes]]:
     nonce = start_nonce
     target = 2 ** 256 // (difficulty or 1)
     for i in range(1, rounds + 1):
         # hashimoto expected big-indian byte representation
         bin_nonce = (nonce + i).to_bytes(8, byteorder="big")
-        if QKC_HASH_NATIVE is None:
-            mining_output = qkchash(header_hash, bin_nonce, QKC_HASH_CACHE)
-        else:
-            dup_cache = QKC_HASH_NATIVE.dup_cache(QKC_HASH_CACHE)
-            mining_output = QKC_HASH_NATIVE.calculate_hash(
-                header_hash, bin_nonce, dup_cache
+
+        current_cache = QKC_HASH_NATIVE.make_cache_block_number(CACHE_ENTRIES, block_number)
+        mining_output = QKC_HASH_NATIVE.calculate_hash(
+                header_hash, bin_nonce, current_cache
             )
+
         result = int.from_bytes(mining_output["result"], byteorder="big")
         if result <= target:
             assert len(bin_nonce) == 8

--- a/qkchash/tests/test_qkcpow.py
+++ b/qkchash/tests/test_qkcpow.py
@@ -7,12 +7,22 @@ class TestQkcpow(unittest.TestCase):
     def test_pow(self):
         header = (2 ** 256 - 1234567890).to_bytes(32, "big")
         diff = 10
-        miner = QkchashMiner(diff, header)
+        height = 10
+        miner = QkchashMiner(height, diff, header)
         nonce, mixhash = miner.mine()
+
         self.assertIsNotNone(nonce)
         self.assertIsNotNone(mixhash)
 
         # wrong nonce, mixhash order
-        self.assertFalse(check_pow(header, nonce, mixhash, diff))
+        self.assertFalse(check_pow(height, header, nonce, mixhash, diff))
 
-        self.assertTrue(check_pow(header, mixhash, nonce, diff))
+        self.assertTrue(check_pow(height, header, mixhash, nonce, diff))
+
+        # In the same epoch
+        height = 3000 
+        self.assertTrue(check_pow(height, header, mixhash, nonce, diff))
+
+        # wrong epoch
+        height = 30001
+        self.assertFalse(check_pow(height, header, mixhash, nonce, diff))

--- a/quarkchain/cluster/miner.py
+++ b/quarkchain/cluster/miner.py
@@ -39,7 +39,11 @@ def validate_seal(
             raise ValueError("invalid pow proof")
     elif consensus_type == ConsensusType.POW_QKCHASH:
         if not qkchash_check_pow(
-            block_header.get_hash_for_mining(), block_header.mixhash, nonce_bytes, diff
+            block_header.height,
+            block_header.get_hash_for_mining(),
+            block_header.mixhash,
+            nonce_bytes,
+            diff,
         ):
             raise ValueError("invalid pow proof")
     elif consensus_type == ConsensusType.POW_DOUBLESHA256:
@@ -98,7 +102,7 @@ class Ethash(MiningAlgorithm):
 
 class Qkchash(MiningAlgorithm):
     def __init__(self, work: MiningWork, **kwargs):
-        self.miner = QkchashMiner(work.difficulty, work.hash)
+        self.miner = QkchashMiner(work.height, work.difficulty, work.hash)
 
     def mine(self, start_nonce: int, end_nonce: int) -> Optional[MiningResult]:
         nonce_found, mixhash = self.miner.mine(


### PR DESCRIPTION
#353 
Similar to ETHASH, QKCHASH's initial data set and cache seed have been changed for every epoch.

Note that this modification changes the consensus, which is incompatible with Testnet 2.4.