### PR TITLE
send coinbase token map to master

### DIFF
--- a/quarkchain/cluster/jsonrpc.py
+++ b/quarkchain/cluster/jsonrpc.py
@@ -153,7 +153,7 @@ def root_block_encoder(block):
         "nonce": quantity_encoder(header.nonce),
         "hashMerkleRoot": data_encoder(header.hash_merkle_root),
         "miner": address_encoder(header.coinbase_address.serialize()),
-        "coinbase": quantity_encoder(header.coinbase_amount),
+        "coinbase": balances_encoder(header.coinbase_amount_map),
         "difficulty": quantity_encoder(header.difficulty),
         "timestamp": quantity_encoder(header.create_time),
         "size": quantity_encoder(len(block.serialize())),
@@ -176,7 +176,7 @@ def root_block_encoder(block):
             "nonce": quantity_encoder(header.nonce),
             "difficulty": quantity_encoder(header.difficulty),
             "miner": address_encoder(header.coinbase_address.serialize()),
-            "coinbase": quantity_encoder(header.coinbase_amount),
+            "coinbase": balances_encoder(header.coinbase_amount_map),
             "timestamp": quantity_encoder(header.create_time),
         }
         d["minorBlockHeaders"].append(h)
@@ -210,7 +210,7 @@ def minor_block_encoder(block, include_transactions=False):
         "hashMerkleRoot": data_encoder(meta.hash_merkle_root),
         "hashEvmStateRoot": data_encoder(meta.hash_evm_state_root),
         "miner": address_encoder(header.coinbase_address.serialize()),
-        "coinbase": quantity_encoder(header.coinbase_amount),
+        "coinbase": balances_encoder(header.coinbase_amount_map),
         "difficulty": quantity_encoder(header.difficulty),
         "extraData": data_encoder(header.extra_data),
         "gasLimit": quantity_encoder(header.evm_gas_limit),
@@ -318,12 +318,12 @@ def receipt_encoder(block: MinorBlock, i: int, receipt: TransactionReceipt):
 
 def balances_encoder(balances: TokenBalanceMap) -> List[Dict]:
     balance_list = []
-    for pair in balances.balance_map:
+    for k, v in balances.balance_map.items():
         balance_list.append(
             {
-                "tokenId": quantity_encoder(pair.token_id),
-                "tokenStr": token_id_decode(pair.token_id),
-                "balance": quantity_encoder(pair.balance),
+                "tokenId": quantity_encoder(k),
+                "tokenStr": token_id_decode(k),
+                "balance": quantity_encoder(v),
             }
         )
     return balance_list

--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -266,14 +266,14 @@ class SyncTask:
                 raise RuntimeError("Unable to download minor blocks from root block")
             if result.shard_stats:
                 self.master_server.update_shard_stats(result.shard_stats)
+            for k, v in result.block_coinbase_map:
+                self.root_state.add_validated_minor_block_hash(k, v.balance_map)
 
         for m_header in minor_block_header_list:
-            self.root_state.add_validated_minor_block_hash(
-                m_header.get_hash(),
-                {
-                    self.master_server.env.quark_chain_config.genesis_token: m_header.coinbase_amount
-                },
-            )
+            if not self.root_state.contain_minor_block_by_hash(m_header.get_hash()):
+                raise RuntimeError(
+                    "minor block is still unavailable in master after root block sync"
+                )
 
 
 class Synchronizer:
@@ -567,10 +567,7 @@ class SlaveConnection(ClusterConnection):
 
     async def handle_add_minor_block_header_request(self, req):
         self.master_server.root_state.add_validated_minor_block_hash(
-            req.minor_block_header.get_hash(),
-            {
-                self.master_server.env.quark_chain_config.genesis_token: req.minor_block_header.coinbase_amount
-            },
+            req.minor_block_header.get_hash(), req.coinbase_amount_map.balance_map
         )
         self.master_server.update_shard_stats(req.shard_stats)
         self.master_server.update_tx_count_history(

--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -266,11 +266,11 @@ class SyncTask:
                 raise RuntimeError("Unable to download minor blocks from root block")
             if result.shard_stats:
                 self.master_server.update_shard_stats(result.shard_stats)
-            for k, v in result.block_coinbase_map:
+            for k, v in result.block_coinbase_map.items():
                 self.root_state.add_validated_minor_block_hash(k, v.balance_map)
 
         for m_header in minor_block_header_list:
-            if not self.root_state.contain_minor_block_by_hash(m_header.get_hash()):
+            if not self.root_state.is_minor_block_validated(m_header.get_hash()):
                 raise RuntimeError(
                     "minor block is still unavailable in master after root block sync"
                 )

--- a/quarkchain/cluster/root_state.py
+++ b/quarkchain/cluster/root_state.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import time
 from fractions import Fraction
-from typing import Optional, List
+from typing import Optional, List, Dict
 
 from quarkchain.cluster.guardian import Guardian
 from quarkchain.cluster.miner import validate_seal
@@ -259,7 +259,7 @@ class RootState:
             create_time = max(self.tip.create_time + 1, int(time.time()))
         return self.diff_calc.calculate_diff_with_parent(self.tip, create_time)
 
-    def _calculate_root_block_coinbase(self, m_hash_list: List[bytes]) -> dict:
+    def _calculate_root_block_coinbase(self, m_hash_list: List[bytes]) -> Dict:
         """
         assumes all minor blocks in m_hash_list have been processed by slaves and thus available when looking up
         """
@@ -301,15 +301,13 @@ class RootState:
         )
         block.minor_block_header_list = m_header_list
 
-        coinbase_amount_map = self._calculate_root_block_coinbase(
+        coinbase_tokens = self._calculate_root_block_coinbase(
             [header.get_hash() for header in m_header_list]
         )
 
         tracking_data["creation_ms"] = time_ms() - tracking_data["inception"]
         block.tracking_data = json.dumps(tracking_data).encode("utf-8")
-        return block.finalize(
-            coinbase_amount_map=coinbase_amount_map, coinbase_address=address
-        )
+        return block.finalize(coinbase_tokens=coinbase_tokens, coinbase_address=address)
 
     def validate_block_header(self, block_header: RootBlockHeader, block_hash=None):
         """ Validate the block header.
@@ -399,13 +397,13 @@ class RootState:
             actual_coinbase_amount = block.header.coinbase_amount_map.balance_map
 
             # TODO:  Support collecting tax from multiple native tokens
-            if len(block.header.coinbase_amount_map.balance_map) > 1:
+            if len(actual_coinbase_amount) > 1:
                 raise ValueError("Incorrect coinbase_amount_map: too many tokens")
 
             if (
-                len(block.header.coinbase_amount_map.balance_map) == 1
+                len(actual_coinbase_amount) == 1
                 and self.env.quark_chain_config.genesis_token
-                not in block.header.coinbase_amount_map.balance_map
+                not in actual_coinbase_amount
             ):
                 raise ValueError(
                     "Incorrect coinbase_amount_map: genesis_token_id not found"

--- a/quarkchain/cluster/root_state.py
+++ b/quarkchain/cluster/root_state.py
@@ -251,7 +251,7 @@ class RootState:
     def get_tip_block(self):
         return self.db.get_root_block_by_hash(self.tip.get_hash())
 
-    def add_validated_minor_block_hash(self, hash: bytes, coinbase_tokens: dict):
+    def add_validated_minor_block_hash(self, hash: bytes, coinbase_tokens: Dict):
         self.db.put_minor_block_coinbase(hash, coinbase_tokens)
 
     def get_next_block_difficulty(self, create_time=None):

--- a/quarkchain/cluster/rpc.py
+++ b/quarkchain/cluster/rpc.py
@@ -570,7 +570,7 @@ class SyncMinorBlockListResponse(Serializable):
         ("shard_stats", Optional(ShardStats)),
     ]
 
-    def __init__(self, error_code, coinbase_amount_map=None, shard_stats=None):
+    def __init__(self, error_code, coinbase_tokens=None, shard_stats=None):
         self.error_code = error_code
         self.block_coinbase_map = block_coinbase_map or {}
         self.shard_stats = shard_stats

--- a/quarkchain/cluster/rpc.py
+++ b/quarkchain/cluster/rpc.py
@@ -22,6 +22,7 @@ from quarkchain.core import (
     Branch,
     ChainMask,
     TokenBalanceMap,
+    PrependedSizeMapSerializer,
 )
 from quarkchain.core import hash256, uint16, uint32, uint64, uint128, uint256, boolean
 
@@ -563,10 +564,15 @@ class SyncMinorBlockListRequest(Serializable):
 
 
 class SyncMinorBlockListResponse(Serializable):
-    FIELDS = [("error_code", uint32), ("shard_stats", Optional(ShardStats))]
+    FIELDS = [
+        ("error_code", uint32),
+        ("block_coinbase_map", PrependedSizeMapSerializer(4, hash256, TokenBalanceMap)),
+        ("shard_stats", Optional(ShardStats)),
+    ]
 
-    def __init__(self, error_code, shard_stats=None):
+    def __init__(self, error_code, coinbase_amount_map=None, shard_stats=None):
         self.error_code = error_code
+        self.block_coinbase_map = block_coinbase_map or {}
         self.shard_stats = shard_stats
 
 

--- a/quarkchain/cluster/rpc.py
+++ b/quarkchain/cluster/rpc.py
@@ -574,7 +574,7 @@ class SyncMinorBlockListResponse(Serializable):
 
 
 class AddMinorBlockHeaderRequest(Serializable):
-    """ Notify master about a successfully added minro block.
+    """ Notify master about a successfully added minor block.
     Piggyback the ShardStats in the same request.
     """
 
@@ -582,13 +582,22 @@ class AddMinorBlockHeaderRequest(Serializable):
         ("minor_block_header", MinorBlockHeader),
         ("tx_count", uint32),  # the total number of tx in the block
         ("x_shard_tx_count", uint32),  # the number of xshard tx in the block
+        ("coinbase_amount_map", TokenBalanceMap),
         ("shard_stats", ShardStats),
     ]
 
-    def __init__(self, minor_block_header, tx_count, x_shard_tx_count, shard_stats):
+    def __init__(
+        self,
+        minor_block_header,
+        tx_count,
+        x_shard_tx_count,
+        coinbase_amount_map,
+        shard_stats,
+    ):
         self.minor_block_header = minor_block_header
         self.tx_count = tx_count
         self.x_shard_tx_count = x_shard_tx_count
+        self.coinbase_amount_map = coinbase_amount_map
         self.shard_stats = shard_stats
 
 

--- a/quarkchain/cluster/rpc.py
+++ b/quarkchain/cluster/rpc.py
@@ -570,7 +570,7 @@ class SyncMinorBlockListResponse(Serializable):
         ("shard_stats", Optional(ShardStats)),
     ]
 
-    def __init__(self, error_code, coinbase_tokens=None, shard_stats=None):
+    def __init__(self, error_code, block_coinbase_map=None, shard_stats=None):
         self.error_code = error_code
         self.block_coinbase_map = block_coinbase_map or {}
         self.shard_stats = shard_stats

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -473,7 +473,7 @@ class Shard:
             self.add_peer(conn)
 
     async def __init_genesis_state(self, root_block: RootBlock):
-        block = self.state.init_genesis_state(root_block)
+        block, coinbase_amount_map = self.state.init_genesis_state(root_block)
         xshard_list = []
         await self.slave.broadcast_xshard_tx_list(
             block, xshard_list, root_block.header.height
@@ -482,6 +482,7 @@ class Shard:
             block.header,
             len(block.tx_list),
             len(xshard_list),
+            coinbase_amount_map,
             self.state.get_shard_stats(),
         )
 

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -587,7 +587,7 @@ class Shard:
         """
         old_tip = self.state.header_tip
         try:
-            xshard_list = self.state.add_block(block)
+            xshard_list, coinbase_amount_map = self.state.add_block(block)
         except Exception as e:
             Logger.error_exception()
             return False
@@ -627,6 +627,7 @@ class Shard:
             block.header,
             len(block.tx_list),
             len(xshard_list),
+            coinbase_amount_map,
             self.state.get_shard_stats(),
         )
 
@@ -652,7 +653,9 @@ class Shard:
 
             block_hash = block.header.get_hash()
             try:
-                xshard_list = self.state.add_block(block, skip_if_too_old=False)
+                xshard_list, coinbase_amount_map = self.state.add_block(
+                    block, skip_if_too_old=False
+                )
             except Exception as e:
                 Logger.error_exception()
                 return False

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -68,10 +68,11 @@ class XshardTxCursor:
         self.db = shard_state.db
 
         # Recover cursor
-        self.max_rblock_header = self.db.get_root_block_header_by_hash(mblock_header.hash_prev_root_block)
+        self.max_rblock_header = self.db.get_root_block_header_by_hash(
+            mblock_header.hash_prev_root_block
+        )
         rblock_header = self.db.get_root_block_header_by_height(
-            mblock_header.hash_prev_root_block,
-            cursor_info.root_block_height
+            mblock_header.hash_prev_root_block, cursor_info.root_block_height
         )
         self.mblock_index = cursor_info.minor_block_index
         self.xshard_deposit_index = cursor_info.xshard_deposit_index
@@ -82,7 +83,9 @@ class XshardTxCursor:
             self.rblock = self.db.get_root_block_by_hash(rblock_header.get_hash())
             if self.mblock_index != 0:
                 self.xtx_list = self.db.get_minor_block_xshard_tx_list(
-                    self.rblock.minor_block_header_list[self.mblock_index - 1].get_hash()
+                    self.rblock.minor_block_header_list[
+                        self.mblock_index - 1
+                    ].get_hash()
                 ).tx_list
         else:
             # EOF
@@ -95,7 +98,9 @@ class XshardTxCursor:
             # TODO: For single native token only
             if self.xshard_deposit_index == 1:
                 coinbase_amount = 0
-                if self.shard_state.branch.is_in_branch(self.rblock.header.coinbase_address.full_shard_key):
+                if self.shard_state.branch.is_in_branch(
+                    self.rblock.header.coinbase_address.full_shard_key
+                ):
                     coinbase_amount = self.rblock.header.coinbase_amount_map.balance_map.get(
                         self.shard_state.genesis_token_id, 0
                     )
@@ -108,7 +113,8 @@ class XshardTxCursor:
                     value=coinbase_amount,
                     gas_price=0,
                     gas_token_id=self.shard_state.genesis_token_id,
-                    transfer_token_id=self.shard_state.genesis_token_id)
+                    transfer_token_id=self.shard_state.genesis_token_id,
+                )
 
             return None
         elif self.xshard_deposit_index < len(self.xtx_list):
@@ -117,8 +123,8 @@ class XshardTxCursor:
             return None
 
     def get_next_tx(self):
-        ''' Return XshardDeposit if succeed else return None
-        '''
+        """ Return XshardDeposit if succeed else return None
+        """
         # Check if reach EOF
         if self.rblock is None:
             return None
@@ -137,26 +143,36 @@ class XshardTxCursor:
             # If it is not neighbor, move to next minor block
             mblock_header = self.rblock.minor_block_header_list[self.mblock_index - 1]
             if (
-                not self.shard_state._is_neighbor(mblock_header.branch, self.rblock.header.height) or
-                mblock_header.branch == self.shard_state.branch
+                not self.shard_state._is_neighbor(
+                    mblock_header.branch, self.rblock.header.height
+                )
+                or mblock_header.branch == self.shard_state.branch
             ):
                 check(self.xshard_deposit_index == 0)
                 self.mblock_index += 1
                 continue
 
             # Check if the neighbor has the permission to send tx to local shard
-            prev_root_header = self.db.get_root_block_header_by_hash(mblock_header.hash_prev_root_block)
+            prev_root_header = self.db.get_root_block_header_by_hash(
+                mblock_header.hash_prev_root_block
+            )
             if (
-                prev_root_header.height <= self.shard_state.env.quark_chain_config.get_genesis_root_height(
+                prev_root_header.height
+                <= self.shard_state.env.quark_chain_config.get_genesis_root_height(
                     self.shard_state.full_shard_id
                 )
             ):
                 check(self.xshard_deposit_index == 0)
-                check(self.db.get_minor_block_xshard_tx_list(mblock_header.get_hash()) is None)
+                check(
+                    self.db.get_minor_block_xshard_tx_list(mblock_header.get_hash())
+                    is None
+                )
                 self.mblock_index += 1
                 continue
 
-            self.xtx_list = self.db.get_minor_block_xshard_tx_list(mblock_header.get_hash()).tx_list
+            self.xtx_list = self.db.get_minor_block_xshard_tx_list(
+                mblock_header.get_hash()
+            ).tx_list
 
             tx = self.__get_current_tx()
             if tx is not None:
@@ -168,8 +184,7 @@ class XshardTxCursor:
 
         # Move to next root block
         rblock_header = self.db.get_root_block_header_by_height(
-            self.max_rblock_header.get_hash(),
-            self.rblock.header.height + 1
+            self.max_rblock_header.get_hash(), self.rblock.header.height + 1
         )
         if rblock_header is None:
             # EOF
@@ -185,11 +200,16 @@ class XshardTxCursor:
             return self.__get_current_tx()
 
     def get_cursor_info(self):
-        root_block_height = self.rblock.header.height if self.rblock is not None else self.max_rblock_header.height + 1
+        root_block_height = (
+            self.rblock.header.height
+            if self.rblock is not None
+            else self.max_rblock_header.height + 1
+        )
         return XshardTxCursorInfo(
             root_block_height=root_block_height,
             minor_block_index=self.mblock_index,
-            xshard_deposit_index=self.xshard_deposit_index)
+            xshard_deposit_index=self.xshard_deposit_index,
+        )
 
 
 class ShardState:
@@ -315,12 +335,13 @@ class ShardState:
         If a genesis block has already been created (probably from another root block
         with the same height), create and store the new genesis block from root_block
         without modifying the in-memory state of this ShardState object.
+        Additionally returns the coinbase_amount_map from the genesis block
         """
         height = self.env.quark_chain_config.get_genesis_root_height(self.full_shard_id)
         check(root_block.header.height == height)
 
         genesis_manager = GenesisManager(self.env.quark_chain_config)
-        genesis_block = genesis_manager.create_minor_block(
+        genesis_block, coinbase_amount_map = genesis_manager.create_minor_block(
             root_block,
             self.full_shard_id,
             self.__create_evm_state(trie_root_hash=None, header_hash=None),
@@ -332,7 +353,7 @@ class ShardState:
 
         if self.initialized:
             # already initialized. just return the block without resetting the state.
-            return genesis_block
+            return genesis_block, coinbase_amount_map
 
         # block index should not be overwritten if there is already a genesis block
         # this must happen after the above initialization check
@@ -358,10 +379,15 @@ class ShardState:
             )
         )
         self.initialized = True
-        return genesis_block
+        return genesis_block, coinbase_amount_map
 
     def __validate_tx(
-        self, tx: Transaction, evm_state, from_address=None, gas=None, xshard_gas_limit=None
+        self,
+        tx: Transaction,
+        evm_state,
+        from_address=None,
+        gas=None,
+        xshard_gas_limit=None,
     ) -> EvmTransaction:
         """from_address will be set for execute_tx"""
         # UTXOs are not supported now
@@ -456,14 +482,17 @@ class ShardState:
         return self.get_gas_limit(gas_limit=gas_limit) // 2
 
     def get_gas_limit_all(self, gas_limit=None, xshard_gas_limit=None):
-        return self.get_gas_limit(gas_limit), self.get_xshard_gas_limit(gas_limit, xshard_gas_limit)
+        return (
+            self.get_gas_limit(gas_limit),
+            self.get_xshard_gas_limit(gas_limit, xshard_gas_limit),
+        )
 
     def add_tx(self, tx: Transaction, xshard_gas_limit=None):
-        ''' Add a tx to the tx queue
+        """ Add a tx to the tx queue
         xshard_gas_limit is used for testing, which discards the tx if
         - tx is x-shard; and
         - tx's startgas exceeds xshard_gas_limit
-        '''
+        """
         if (
             len(self.tx_queue)
             > self.env.quark_chain_config.TRANSACTION_QUEUE_SIZE_LIMIT_PER_SHARD
@@ -482,7 +511,9 @@ class ShardState:
         evm_state = self.evm_state.ephemeral_clone()
         evm_state.gas_used = 0
         try:
-            evm_tx = self.__validate_tx(tx, evm_state, xshard_gas_limit=xshard_gas_limit)
+            evm_tx = self.__validate_tx(
+                tx, evm_state, xshard_gas_limit=xshard_gas_limit
+            )
             self.tx_queue.add_transaction(evm_tx)
             self.tx_dict[tx_hash] = tx
             return True
@@ -533,7 +564,9 @@ class ShardState:
             header = self.db.get_root_block_header_by_hash(header.hash_prev_block)
         return header == shorter_block_header
 
-    def __validate_block(self, block: MinorBlock, gas_limit=None, xshard_gas_limit=None):
+    def __validate_block(
+        self, block: MinorBlock, gas_limit=None, xshard_gas_limit=None
+    ):
         """ Validate a block before running evm transactions
         """
         height = block.header.height
@@ -582,16 +615,24 @@ class ShardState:
             raise ValueError("tracking_data in block is too large")
 
         # Gas limit check
-        gas_limit, xshard_gas_limit = self.get_gas_limit_all(gas_limit=gas_limit, xshard_gas_limit=xshard_gas_limit)
+        gas_limit, xshard_gas_limit = self.get_gas_limit_all(
+            gas_limit=gas_limit, xshard_gas_limit=xshard_gas_limit
+        )
         if block.header.evm_gas_limit != gas_limit:
-            raise ValueError("incorrect gas limit, expected %d, actual %d" % (
-                gas_limit, block.header.evm_gas_limit))
+            raise ValueError(
+                "incorrect gas limit, expected %d, actual %d"
+                % (gas_limit, block.header.evm_gas_limit)
+            )
         if block.meta.evm_xshard_gas_limit >= block.header.evm_gas_limit:
-            raise ValueError("xshard_gas_limit %d should not exceed total gas_limit %d" % (
-                block.meta.evm_xshard_gas_limit, block.header.evm_gas_limit))
+            raise ValueError(
+                "xshard_gas_limit %d should not exceed total gas_limit %d"
+                % (block.meta.evm_xshard_gas_limit, block.header.evm_gas_limit)
+            )
         if block.meta.evm_xshard_gas_limit != xshard_gas_limit:
-            raise ValueError("incorrect xshard gas limit, expected %d, actual %d" % (
-                xshard_gas_limit, block.meta.evm_xshard_gas_limit))
+            raise ValueError(
+                "incorrect xshard gas limit, expected %d, actual %d"
+                % (xshard_gas_limit, block.meta.evm_xshard_gas_limit)
+            )
 
         # Make sure merkle tree is valid
         merkle_hash = calculate_merkle_root(block.tx_list)
@@ -648,11 +689,7 @@ class ShardState:
         self.validate_minor_block_seal(block)
 
     def run_block(
-        self,
-        block,
-        evm_state=None,
-        evm_tx_included=None,
-        x_shard_receive_tx_list=None,
+        self, block, evm_state=None, evm_tx_included=None, x_shard_receive_tx_list=None
     ):
         if evm_tx_included is None:
             evm_tx_included = []
@@ -668,21 +705,18 @@ class ShardState:
         )
 
         xtx_list, evm_state.xshard_tx_cursor_info = self.__run_cross_shard_tx_with_cursor(
-            evm_state=evm_state,
-            mblock=block,
+            evm_state=evm_state, mblock=block
         )
         x_shard_receive_tx_list.extend(xtx_list)
 
         # Adjust inshard gas limit if xshard gas limit is not exhausted
         if evm_state.gas_used < block.meta.evm_xshard_gas_limit:
-            evm_state.gas_limit -= (block.meta.evm_xshard_gas_limit - evm_state.gas_used)
+            evm_state.gas_limit -= block.meta.evm_xshard_gas_limit - evm_state.gas_used
 
         for idx, tx in enumerate(block.tx_list):
             try:
                 evm_tx = self.__validate_tx(
-                    tx,
-                    evm_state,
-                    xshard_gas_limit=block.meta.evm_xshard_gas_limit
+                    tx, evm_state, xshard_gas_limit=block.meta.evm_xshard_gas_limit
                 )
                 evm_tx.set_quark_chain_config(self.env.quark_chain_config)
                 apply_transaction(evm_state, evm_tx, tx.get_hash())
@@ -773,7 +807,9 @@ class ShardState:
             evm_tx_list.append(tx.code.get_evm_transaction())
         self.tx_queue = self.tx_queue.diff(evm_tx_list)
 
-    def add_block(self, block, skip_if_too_old=True, gas_limit=None, xshard_gas_limit=None):
+    def add_block(
+        self, block, skip_if_too_old=True, gas_limit=None, xshard_gas_limit=None
+    ):
         """  Add a block to local db.  Perform validate and update tip accordingly
         gas_limit and xshard_gas_limit are used for testing only.
         Returns None if block is already added.
@@ -809,7 +845,9 @@ class ShardState:
         evm_tx_included = []
         x_shard_receive_tx_list = []
         # Throw exception if fail to run
-        self.__validate_block(block, gas_limit=gas_limit, xshard_gas_limit=xshard_gas_limit)
+        self.__validate_block(
+            block, gas_limit=gas_limit, xshard_gas_limit=xshard_gas_limit
+        )
         evm_state = self.run_block(
             block,
             evm_tx_included=evm_tx_included,
@@ -955,9 +993,9 @@ class ShardState:
         return self.db.get_minor_block_by_hash(self.header_tip.get_hash())
 
     def finalize_and_add_block(self, block, gas_limit=None, xshard_gas_limit=None):
-        ''' Finalize the block by filling post-tx data including tx fee collected
+        """ Finalize the block by filling post-tx data including tx fee collected
         gas_limit and xshard_gas_limit is used to verify customized gas limits and they are for test purpose only
-        '''
+        """
         evm_state = self.run_block(block)
         coinbase_amount_map = self.get_coinbase_amount_map()
         coinbase_amount_map.add(
@@ -1120,7 +1158,7 @@ class ShardState:
         address=None,
         gas_limit=None,
         xshard_gas_limit=None,
-        include_tx=True
+        include_tx=True,
     ):
         """ Create a block to append and include TXs to maximize rewards
         """
@@ -1139,7 +1177,9 @@ class ShardState:
 
         # Add corrected gas limit
         # Set gas_limit.  Since gas limit is fixed between blocks, this is for test purpose only.
-        gas_limit, xshard_gas_limit = self.get_gas_limit_all(gas_limit, xshard_gas_limit)
+        gas_limit, xshard_gas_limit = self.get_gas_limit_all(
+            gas_limit, xshard_gas_limit
+        )
         block.header.evm_gas_limit = gas_limit
         block.meta.evm_xshard_gas_limit = xshard_gas_limit
         evm_state = self._get_evm_state_for_new_block(block)
@@ -1148,13 +1188,12 @@ class ShardState:
         # This is part of consensus.
         block.header.hash_prev_root_block = self.root_tip.get_hash()
         xtx_list, evm_state.xshard_tx_cursor_info = self.__run_cross_shard_tx_with_cursor(
-            evm_state=evm_state,
-            mblock=block,
+            evm_state=evm_state, mblock=block
         )
 
         # Adjust inshard tx limit if xshard gas limit is not exhausted
         if evm_state.gas_used < xshard_gas_limit:
-            evm_state.gas_limit -= (xshard_gas_limit - evm_state.gas_used)
+            evm_state.gas_limit -= xshard_gas_limit - evm_state.gas_used
 
         if include_tx:
             self.__add_transactions_to_block(block, evm_state)
@@ -1384,11 +1423,16 @@ class ShardState:
         evm_state.delta_token_balance(
             tx.to_address.recipient, tx.transfer_token_id, tx.value
         )
-        evm_state.gas_used = evm_state.gas_used + (opcodes.GTXXSHARDCOST if tx.gas_price != 0 else 0)
+        evm_state.gas_used = evm_state.gas_used + (
+            opcodes.GTXXSHARDCOST if tx.gas_price != 0 else 0
+        )
         check(evm_state.gas_used <= evm_state.gas_limit)
 
         xshard_fee = (
-            opcodes.GTXXSHARDCOST * tx.gas_price * self.local_fee_rate.numerator // self.local_fee_rate.denominator
+            opcodes.GTXXSHARDCOST
+            * tx.gas_price
+            * self.local_fee_rate.numerator
+            // self.local_fee_rate.denominator
         )
         evm_state.block_fee += xshard_fee
         evm_state.delta_token_balance(
@@ -1396,7 +1440,9 @@ class ShardState:
         )
 
     def __run_cross_shard_tx_with_cursor(self, evm_state, mblock):
-        cursor_info = self.db.get_minor_block_meta_by_hash(mblock.header.hash_prev_minor_block).xshard_tx_cursor_info
+        cursor_info = self.db.get_minor_block_meta_by_hash(
+            mblock.header.hash_prev_minor_block
+        ).xshard_tx_cursor_info
         cursor = XshardTxCursor(self, mblock.header, cursor_info)
         tx_list = []
 

--- a/quarkchain/cluster/slave.py
+++ b/quarkchain/cluster/slave.py
@@ -949,7 +949,7 @@ class SlaveServer:
         minor_block_header,
         tx_count,
         x_shard_tx_count,
-        coinbase_amount_map,
+        coinbase_amount_map: TokenBalanceMap,
         shard_stats,
     ):
         """ Update master that a minor block has been appended successfully """

--- a/quarkchain/cluster/slave.py
+++ b/quarkchain/cluster/slave.py
@@ -938,11 +938,20 @@ class SlaveServer:
     # Cluster functions
 
     async def send_minor_block_header_to_master(
-        self, minor_block_header, tx_count, x_shard_tx_count, shard_stats
+        self,
+        minor_block_header,
+        tx_count,
+        x_shard_tx_count,
+        coinbase_amount_map,
+        shard_stats,
     ):
         """ Update master that a minor block has been appended successfully """
         request = AddMinorBlockHeaderRequest(
-            minor_block_header, tx_count, x_shard_tx_count, shard_stats
+            minor_block_header,
+            tx_count,
+            x_shard_tx_count,
+            coinbase_amount_map,
+            shard_stats,
         )
         _, resp, _ = await self.master.write_rpc_request(
             ClusterOp.ADD_MINOR_BLOCK_HEADER_REQUEST, request

--- a/quarkchain/cluster/slave.py
+++ b/quarkchain/cluster/slave.py
@@ -408,6 +408,7 @@ class MasterConnection(ClusterConnection):
 
         BLOCK_BATCH_SIZE = 100
         block_hash_list = req.minor_block_hash_list
+        block_coinbase_map = {}
         # empty
         if not block_hash_list:
             return SyncMinorBlockListResponse(error_code=0)
@@ -444,20 +445,26 @@ class MasterConnection(ClusterConnection):
                     )
 
                 # Step 2: Check if the blocks are valid
-                add_block_success = await self.slave_server.add_block_list_for_sync(
+                add_block_success, coinbase_amount_list = await self.slave_server.add_block_list_for_sync(
                     block_chain
                 )
                 if not add_block_success:
                     raise RuntimeError(
                         "Failed to add minor blocks for syncing root block"
                     )
+                check(len(blocks_to_download) == len(coinbase_amount_list))
+                for hash, coinbase in zip(blocks_to_download, coinbase_amount_list):
+                    if coinbase:
+                        block_coinbase_map[hash] = coinbase
                 block_hash_list = block_hash_list[BLOCK_BATCH_SIZE:]
 
             branch = block_chain[0].header.branch
             shard = self.slave_server.shards.get(branch, None)
             check(shard is not None)
             return SyncMinorBlockListResponse(
-                error_code=0, shard_stats=shard.state.get_shard_stats()
+                error_code=0,
+                shard_stats=shard.state.get_shard_stats(),
+                block_coinbase_map=block_coinbase_map,
             )
         except Exception:
             Logger.error_exception()
@@ -1099,7 +1106,7 @@ class SlaveServer:
         Returns true if blocks are successfully added. False on any error.
         """
         if not block_list:
-            return True
+            return True, None
         branch = block_list[0].header.branch
         shard = self.shards.get(branch, None)
         check(shard is not None)

--- a/quarkchain/cluster/tests/test_cluster.py
+++ b/quarkchain/cluster/tests/test_cluster.py
@@ -4,7 +4,7 @@ from quarkchain.cluster.tests.test_utils import (
     create_transfer_transaction,
     ClusterContext,
 )
-from quarkchain.core import Address, Branch, Identity
+from quarkchain.core import Address, Branch, Identity, TokenBalanceMap
 from quarkchain.evm import opcodes
 from quarkchain.utils import call_async, assert_true_with_timeout
 
@@ -266,7 +266,12 @@ class TestCluster(unittest.TestCase):
             evm_state = shard_state.run_block(b1)
             b1.finalize(
                 evm_state=evm_state,
-                coinbase_amount=evm_state.block_fee + coinbase_amount,
+                coinbase_amount_map=TokenBalanceMap(
+                    {
+                        shard_state.env.quark_chain_config.genesis_token: evm_state.block_fee
+                        + coinbase_amount
+                    }
+                ),
             )
             add_result = call_async(
                 clusters[0].master.add_raw_minor_block(b1.header.branch, b1.serialize())
@@ -319,7 +324,12 @@ class TestCluster(unittest.TestCase):
                 evm_state = shard_state0.run_block(b1)
                 b1.finalize(
                     evm_state=evm_state,
-                    coinbase_amount=evm_state.block_fee + coinbase_amount,
+                    coinbase_amount_map=TokenBalanceMap(
+                        {
+                            shard_state0.env.quark_chain_config.genesis_token: evm_state.block_fee
+                            + coinbase_amount
+                        }
+                    ),
                 )
                 add_result = call_async(
                     clusters[0].master.add_raw_minor_block(
@@ -341,7 +351,12 @@ class TestCluster(unittest.TestCase):
             evm_state = shard_state0.run_block(b2)
             b2.finalize(
                 evm_state=evm_state,
-                coinbase_amount=evm_state.block_fee + coinbase_amount,
+                coinbase_amount_map=TokenBalanceMap(
+                    {
+                        shard_state0.env.quark_chain_config.genesis_token: evm_state.block_fee
+                        + coinbase_amount
+                    }
+                ),
             )
             add_result = call_async(
                 clusters[0].master.add_raw_minor_block(b2.header.branch, b2.serialize())
@@ -361,7 +376,12 @@ class TestCluster(unittest.TestCase):
             evm_state = shard_state1.run_block(b3)
             b3.finalize(
                 evm_state=evm_state,
-                coinbase_amount=evm_state.block_fee + coinbase_amount,
+                coinbase_amount_map=TokenBalanceMap(
+                    {
+                        shard_state1.env.quark_chain_config.genesis_token: evm_state.block_fee
+                        + coinbase_amount
+                    }
+                ),
             )
             add_result = call_async(
                 clusters[1].master.add_raw_minor_block(b3.header.branch, b3.serialize())
@@ -424,7 +444,12 @@ class TestCluster(unittest.TestCase):
                 evm_state = shard_state0.run_block(block)
                 block.finalize(
                     evm_state=evm_state,
-                    coinbase_amount=evm_state.block_fee + coinbase_amount,
+                    coinbase_amount_map=TokenBalanceMap(
+                        {
+                            shard_state0.env.quark_chain_config.genesis_token: evm_state.block_fee
+                            + coinbase_amount
+                        }
+                    ),
                 )
                 add_result = call_async(
                     clusters[0].master.add_raw_minor_block(
@@ -448,7 +473,12 @@ class TestCluster(unittest.TestCase):
                 evm_state = shard_state0.run_block(block)
                 block.finalize(
                     evm_state=evm_state,
-                    coinbase_amount=evm_state.block_fee + coinbase_amount,
+                    coinbase_amount_map=TokenBalanceMap(
+                        {
+                            shard_state0.env.quark_chain_config.genesis_token: evm_state.block_fee
+                            + coinbase_amount
+                        }
+                    ),
                 )
                 add_result = call_async(
                     clusters[1].master.add_raw_minor_block(
@@ -478,7 +508,12 @@ class TestCluster(unittest.TestCase):
             evm_state = shard_state0.run_block(block)
             block.finalize(
                 evm_state=evm_state,
-                coinbase_amount=evm_state.block_fee + coinbase_amount,
+                coinbase_amount_map=TokenBalanceMap(
+                    {
+                        shard_state0.env.quark_chain_config.genesis_token: evm_state.block_fee
+                        + coinbase_amount
+                    }
+                ),
             )
             add_result = call_async(
                 clusters[0].master.add_raw_minor_block(

--- a/quarkchain/cluster/tests/test_root_state.py
+++ b/quarkchain/cluster/tests/test_root_state.py
@@ -201,7 +201,7 @@ class TestRootState(unittest.TestCase):
         root_block1.add_minor_block_header(b2.header).add_minor_block_header(
             b3.header
         ).finalize(
-            coinbase_amount_map=r_state._calculate_root_block_coinbase(
+            coinbase_tokens=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block1.minor_block_header_list]
             )
         )
@@ -229,7 +229,7 @@ class TestRootState(unittest.TestCase):
             .add_minor_block_header(b5.header)
         )
         root_block2.finalize(
-            coinbase_amount_map=r_state._calculate_root_block_coinbase(
+            coinbase_tokens=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block2.minor_block_header_list]
             )
         )
@@ -349,7 +349,7 @@ class TestRootState(unittest.TestCase):
         # create a fork
         root_block00.header.create_time += 1
         root_block00.finalize(
-            coinbase_amount_map=r_state._calculate_root_block_coinbase(
+            coinbase_tokens=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block00.minor_block_header_list]
             )
         )
@@ -432,7 +432,7 @@ class TestRootState(unittest.TestCase):
             nonce=0
         ).add_minor_block_header(m1.header)
         root_block1.finalize(
-            coinbase_amount_map=r_state._calculate_root_block_coinbase(
+            coinbase_tokens=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block1.minor_block_header_list]
             )
         )
@@ -440,7 +440,7 @@ class TestRootState(unittest.TestCase):
             nonce=1
         ).add_minor_block_header(m1.header)
         root_block2.finalize(
-            coinbase_amount_map=r_state._calculate_root_block_coinbase(
+            coinbase_tokens=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block2.minor_block_header_list]
             )
         )
@@ -462,7 +462,7 @@ class TestRootState(unittest.TestCase):
             m2.header
         )
         root_block3.finalize(
-            coinbase_amount_map=r_state._calculate_root_block_coinbase(
+            coinbase_tokens=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block3.minor_block_header_list]
             )
         )
@@ -474,7 +474,7 @@ class TestRootState(unittest.TestCase):
             m2.header
         )
         root_block4.finalize(
-            coinbase_amount_map=r_state._calculate_root_block_coinbase(
+            coinbase_tokens=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block4.minor_block_header_list]
             )
         )
@@ -522,7 +522,7 @@ class TestRootState(unittest.TestCase):
             nonce=0
         ).add_minor_block_header(m1.header)
         root_block1.finalize(
-            coinbase_amount_map=r_state._calculate_root_block_coinbase(
+            coinbase_tokens=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block1.minor_block_header_list]
             )
         )
@@ -530,7 +530,7 @@ class TestRootState(unittest.TestCase):
             nonce=1
         ).add_minor_block_header(m2.header)
         root_block2.finalize(
-            coinbase_amount_map=r_state._calculate_root_block_coinbase(
+            coinbase_tokens=r_state._calculate_root_block_coinbase(
                 [header.get_hash() for header in root_block2.minor_block_header_list]
             )
         )

--- a/quarkchain/cluster/tests/test_root_state.py
+++ b/quarkchain/cluster/tests/test_root_state.py
@@ -17,18 +17,19 @@ def create_default_state(env, diff_calc=None):
         shard_state = ShardState(
             env=env, full_shard_id=full_shard_id, db=quarkchain.db.InMemoryDb()
         )
-        shard_state.init_genesis_state(r_state.get_tip_block())
+        mblock, coinbase_amount_map = shard_state.init_genesis_state(
+            r_state.get_tip_block()
+        )
+        block_hash = mblock.header.get_hash()
+        r_state.add_validated_minor_block_hash(
+            block_hash, coinbase_amount_map.balance_map
+        )
         s_state_list[full_shard_id] = shard_state
 
     # add a root block so that later minor blocks will be broadcasted to neighbor shards
     minor_header_list = []
     for state in s_state_list.values():
         minor_header_list.append(state.header_tip)
-        block_hash = state.header_tip.get_hash()
-        r_state.add_validated_minor_block_hash(
-            block_hash,
-            {env.quark_chain_config.genesis_token: state.header_tip.coinbase_amount},
-        )
 
     root_block = r_state.create_block_to_mine(minor_header_list)
     assert r_state.add_block(root_block)
@@ -68,12 +69,10 @@ class TestRootState(unittest.TestCase):
         add_minor_block_to_cluster(s_states, b1)
 
         r_state.add_validated_minor_block_hash(
-            b0.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b0.header.coinbase_amount},
+            b0.header.get_hash(), b0.header.coinbase_amount_map.balance_map
         )
         r_state.add_validated_minor_block_hash(
-            b1.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b1.header.coinbase_amount},
+            b1.header.get_hash(), b1.header.coinbase_amount_map.balance_map
         )
         root_block = r_state.create_block_to_mine([b0.header, b1.header])
 
@@ -102,12 +101,10 @@ class TestRootState(unittest.TestCase):
         s_state1.finalize_and_add_block(b1)
 
         r_state.add_validated_minor_block_hash(
-            b0.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b0.header.coinbase_amount},
+            b0.header.get_hash(), b0.header.coinbase_amount_map.balance_map
         )
         r_state.add_validated_minor_block_hash(
-            b1.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b1.header.coinbase_amount},
+            b1.header.get_hash(), b1.header.coinbase_amount_map.balance_map
         )
 
         root_block = r_state.create_block_to_mine([])
@@ -128,12 +125,10 @@ class TestRootState(unittest.TestCase):
         add_minor_block_to_cluster(s_states, b1)
 
         r_state.add_validated_minor_block_hash(
-            b0.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b0.header.coinbase_amount},
+            b0.header.get_hash(), b0.header.coinbase_amount_map.balance_map
         )
         r_state.add_validated_minor_block_hash(
-            b1.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b1.header.coinbase_amount},
+            b1.header.get_hash(), b1.header.coinbase_amount_map.balance_map
         )
         root_block0 = r_state.create_block_to_mine([b0.header, b1.header])
 
@@ -145,12 +140,10 @@ class TestRootState(unittest.TestCase):
         add_minor_block_to_cluster(s_states, b3)
 
         r_state.add_validated_minor_block_hash(
-            b2.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b2.header.coinbase_amount},
+            b2.header.get_hash(), b2.header.coinbase_amount_map.balance_map
         )
         r_state.add_validated_minor_block_hash(
-            b3.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b3.header.coinbase_amount},
+            b3.header.get_hash(), b3.header.coinbase_amount_map.balance_map
         )
         root_block1 = r_state.create_block_to_mine([b2.header, b3.header])
 
@@ -171,12 +164,10 @@ class TestRootState(unittest.TestCase):
         add_minor_block_to_cluster(s_states, b1)
 
         r_state.add_validated_minor_block_hash(
-            b0.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b0.header.coinbase_amount},
+            b0.header.get_hash(), b0.header.coinbase_amount_map.balance_map
         )
         r_state.add_validated_minor_block_hash(
-            b1.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b1.header.coinbase_amount},
+            b1.header.get_hash(), b1.header.coinbase_amount_map.balance_map
         )
 
         root_block0 = r_state.create_block_to_mine([b0.header, b1.header])
@@ -190,12 +181,10 @@ class TestRootState(unittest.TestCase):
         add_minor_block_to_cluster(s_states, b3)
 
         r_state.add_validated_minor_block_hash(
-            b2.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b2.header.coinbase_amount},
+            b2.header.get_hash(), b2.header.coinbase_amount_map.balance_map
         )
         r_state.add_validated_minor_block_hash(
-            b3.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b3.header.coinbase_amount},
+            b3.header.get_hash(), b3.header.coinbase_amount_map.balance_map
         )
 
         root_block1.add_minor_block_header(b2.header).add_minor_block_header(
@@ -216,12 +205,10 @@ class TestRootState(unittest.TestCase):
         add_minor_block_to_cluster(s_states, b5)
 
         r_state.add_validated_minor_block_hash(
-            b4.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b4.header.coinbase_amount},
+            b4.header.get_hash(), b4.header.coinbase_amount_map.balance_map
         )
         r_state.add_validated_minor_block_hash(
-            b5.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b5.header.coinbase_amount},
+            b5.header.get_hash(), b5.header.coinbase_amount_map.balance_map
         )
         root_block2 = (
             root_block1.create_block_to_append()
@@ -263,16 +250,20 @@ class TestRootState(unittest.TestCase):
         g1 = s_state1.header_tip
         b1 = s_state1.get_tip().create_block_to_append()
         add_minor_block_to_cluster(s_states, b1)
-        self.assertEqual(b0.header.coinbase_amount, 1)
-        self.assertEqual(b1.header.coinbase_amount, 1)
+        self.assertEqual(
+            b0.header.coinbase_amount_map.balance_map,
+            {env.quark_chain_config.genesis_token: 1},
+        )
+        self.assertEqual(
+            b1.header.coinbase_amount_map.balance_map,
+            {env.quark_chain_config.genesis_token: 1},
+        )
 
         r_state.add_validated_minor_block_hash(
-            b0.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b0.header.coinbase_amount},
+            b0.header.get_hash(), b0.header.coinbase_amount_map.balance_map
         )
         r_state.add_validated_minor_block_hash(
-            b1.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b1.header.coinbase_amount},
+            b1.header.get_hash(), b1.header.coinbase_amount_map.balance_map
         )
 
         # Test coinbase
@@ -333,12 +324,10 @@ class TestRootState(unittest.TestCase):
         add_minor_block_to_cluster(s_states, b1)
 
         r_state.add_validated_minor_block_hash(
-            b0.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b0.header.coinbase_amount},
+            b0.header.get_hash(), b0.header.coinbase_amount_map.balance_map
         )
         r_state.add_validated_minor_block_hash(
-            b1.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b1.header.coinbase_amount},
+            b1.header.get_hash(), b1.header.coinbase_amount_map.balance_map
         )
         root_block0 = r_state.create_block_to_mine([b0.header, b1.header])
 
@@ -369,12 +358,10 @@ class TestRootState(unittest.TestCase):
         add_minor_block_to_cluster(s_states, b3)
 
         r_state.add_validated_minor_block_hash(
-            b2.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b2.header.coinbase_amount},
+            b2.header.get_hash(), b2.header.coinbase_amount_map.balance_map
         )
         r_state.add_validated_minor_block_hash(
-            b3.header.get_hash(),
-            {env.quark_chain_config.genesis_token: b3.header.coinbase_amount},
+            b3.header.get_hash(), b3.header.coinbase_amount_map.balance_map
         )
         root_block1 = r_state.create_block_to_mine([b2.header, b3.header])
 
@@ -425,8 +412,7 @@ class TestRootState(unittest.TestCase):
         add_minor_block_to_cluster(s_states, m1)
 
         r_state.add_validated_minor_block_hash(
-            m1.header.get_hash(),
-            {env.quark_chain_config.genesis_token: m1.header.coinbase_amount},
+            m1.header.get_hash(), m1.header.coinbase_amount_map.balance_map
         )
         root_block1 = root_block0.create_block_to_append(
             nonce=0
@@ -455,8 +441,7 @@ class TestRootState(unittest.TestCase):
         add_minor_block_to_cluster(s_states, m2)
 
         r_state.add_validated_minor_block_hash(
-            m2.header.get_hash(),
-            {env.quark_chain_config.genesis_token: m2.header.coinbase_amount},
+            m2.header.get_hash(), m2.header.coinbase_amount_map.balance_map
         )
         root_block3 = root_block1.create_block_to_append().add_minor_block_header(
             m2.header
@@ -511,12 +496,10 @@ class TestRootState(unittest.TestCase):
         add_minor_block_to_cluster(s_states, m2)
 
         r_state.add_validated_minor_block_hash(
-            m1.header.get_hash(),
-            {env.quark_chain_config.genesis_token: m1.header.coinbase_amount},
+            m1.header.get_hash(), m1.header.coinbase_amount_map.balance_map
         )
         r_state.add_validated_minor_block_hash(
-            m2.header.get_hash(),
-            {env.quark_chain_config.genesis_token: m2.header.coinbase_amount},
+            m2.header.get_hash(), m2.header.coinbase_amount_map.balance_map
         )
         root_block1 = root_block0.create_block_to_append(
             nonce=0

--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -9,7 +9,7 @@ from quarkchain.cluster.tests.test_utils import (
 )
 from quarkchain.config import ConsensusType
 from quarkchain.core import CrossShardTransactionDeposit, CrossShardTransactionList
-from quarkchain.core import Identity, Address
+from quarkchain.core import Identity, Address, TokenBalanceMap
 from quarkchain.diff import EthDifficultyCalculator
 from quarkchain.evm import opcodes
 from quarkchain.genesis import GenesisManager
@@ -51,7 +51,10 @@ class TestShardState(unittest.TestCase):
         self.assertEqual(state.root_tip.height, 0)
         self.assertEqual(state.header_tip.height, 0)
         # make sure genesis minor block has the right coinbase after-tax
-        self.assertEqual(state.header_tip.coinbase_amount, 2500000000000000000)
+        self.assertEqual(
+            state.header_tip.coinbase_amount_map.balance_map,
+            {self.genesis_token: 2500000000000000000},
+        )
 
     def test_init_genesis_state(self):
         env = get_test_env()
@@ -500,9 +503,13 @@ class TestShardState(unittest.TestCase):
             )
         )
         # Inshard gas limit is 40000 - 20000
-        b1 = state.create_block_to_mine(address=acc3, gas_limit=40000, xshard_gas_limit=20000)
+        b1 = state.create_block_to_mine(
+            address=acc3, gas_limit=40000, xshard_gas_limit=20000
+        )
         self.assertEqual(len(b1.tx_list), 0)
-        b1 = state.create_block_to_mine(address=acc3, gas_limit=40000, xshard_gas_limit=0)
+        b1 = state.create_block_to_mine(
+            address=acc3, gas_limit=40000, xshard_gas_limit=0
+        )
         self.assertEqual(len(b1.tx_list), 1)
         b1 = state.create_block_to_mine(address=acc3)
         self.assertEqual(len(b1.tx_list), 2)
@@ -902,8 +909,8 @@ class TestShardState(unittest.TestCase):
             state.root_tip.create_block_to_append()
             .add_minor_block_header(state.header_tip)
             .finalize(
-                coinbase_amount_map={env.quark_chain_config.genesis_token: 1000000},
-                coinbase_address=acc2
+                coinbase_tokens={env.quark_chain_config.genesis_token: 1000000},
+                coinbase_address=acc2,
             )
         )
         state.add_root_block(root_block)
@@ -911,7 +918,9 @@ class TestShardState(unittest.TestCase):
         b0 = state.create_block_to_mine()
         state.finalize_and_add_block(b0)
 
-        self.assertEqual(state.get_token_balance(acc2.recipient, self.genesis_token), 1000000)
+        self.assertEqual(
+            state.get_token_balance(acc2.recipient, self.genesis_token), 1000000
+        )
 
     def test_xshard_for_two_root_blocks(self):
         id1 = Identity.create_random_identity()
@@ -1116,7 +1125,7 @@ class TestShardState(unittest.TestCase):
                         gas_price=2,
                         gas_token_id=self.genesis_token,
                         transfer_token_id=self.genesis_token,
-                    )
+                    ),
                 ]
             ),
         )
@@ -1126,13 +1135,16 @@ class TestShardState(unittest.TestCase):
             state0.root_tip.create_block_to_append()
             .add_minor_block_header(b1.header)
             .finalize(
-                coinbase_amount_map={env0.quark_chain_config.genesis_token: 1000000},
-                coinbase_address=acc1)
+                coinbase_tokens={env0.quark_chain_config.genesis_token: 1000000},
+                coinbase_address=acc1,
+            )
         )
         state0.add_root_block(root_block)
 
         # Add b0 and make sure one x-shard tx's are added
-        b2 = state0.create_block_to_mine(address=acc3, xshard_gas_limit=opcodes.GTXXSHARDCOST)
+        b2 = state0.create_block_to_mine(
+            address=acc3, xshard_gas_limit=opcodes.GTXXSHARDCOST
+        )
         state0.finalize_and_add_block(b2, xshard_gas_limit=opcodes.GTXXSHARDCOST)
 
         # Root block coinbase does not consume xshard gas
@@ -1151,7 +1163,9 @@ class TestShardState(unittest.TestCase):
         self.assertEqual(evmState0.xshard_receive_gas_used, opcodes.GTXXSHARDCOST)
 
         # Add b2 and make sure all x-shard tx's are added
-        b2 = state0.create_block_to_mine(address=acc3, xshard_gas_limit=opcodes.GTXXSHARDCOST)
+        b2 = state0.create_block_to_mine(
+            address=acc3, xshard_gas_limit=opcodes.GTXXSHARDCOST
+        )
         state0.finalize_and_add_block(b2, xshard_gas_limit=opcodes.GTXXSHARDCOST)
         # Root block coinbase does not consume xshard gas
         self.assertEqual(
@@ -1160,7 +1174,9 @@ class TestShardState(unittest.TestCase):
         )
 
         # Add b3 and make sure no x-shard tx's are added
-        b3 = state0.create_block_to_mine(address=acc3, xshard_gas_limit=opcodes.GTXXSHARDCOST)
+        b3 = state0.create_block_to_mine(
+            address=acc3, xshard_gas_limit=opcodes.GTXXSHARDCOST
+        )
         state0.finalize_and_add_block(b3, xshard_gas_limit=opcodes.GTXXSHARDCOST)
         # Root block coinbase does not consume xshard gas
         self.assertEqual(
@@ -1168,27 +1184,30 @@ class TestShardState(unittest.TestCase):
             10000000 + 1000000 + 888888 + 111111,
         )
 
-        b4 = state0.create_block_to_mine(address=acc3, xshard_gas_limit=opcodes.GTXXSHARDCOST)
+        b4 = state0.create_block_to_mine(
+            address=acc3, xshard_gas_limit=opcodes.GTXXSHARDCOST
+        )
         state0.finalize_and_add_block(b4, xshard_gas_limit=opcodes.GTXXSHARDCOST)
-        self.assertNotEqual(b2.meta.xshard_tx_cursor_info, b3.meta.xshard_tx_cursor_info)
+        self.assertNotEqual(
+            b2.meta.xshard_tx_cursor_info, b3.meta.xshard_tx_cursor_info
+        )
         self.assertEqual(b3.meta.xshard_tx_cursor_info, b4.meta.xshard_tx_cursor_info)
 
         b5 = state0.create_block_to_mine(
             address=acc3,
             gas_limit=opcodes.GTXXSHARDCOST,
-            xshard_gas_limit=2 * opcodes.GTXXSHARDCOST
+            xshard_gas_limit=2 * opcodes.GTXXSHARDCOST,
         )
         with self.assertRaises(ValueError):
             # xsahrd_gas_limit should be smaller than gas_limit
             state0.finalize_and_add_block(
                 b5,
                 gas_limit=opcodes.GTXXSHARDCOST,
-                xshard_gas_limit=2 * opcodes.GTXXSHARDCOST
+                xshard_gas_limit=2 * opcodes.GTXXSHARDCOST,
             )
 
         b6 = state0.create_block_to_mine(
-            address=acc3,
-            xshard_gas_limit=opcodes.GTXXSHARDCOST
+            address=acc3, xshard_gas_limit=opcodes.GTXXSHARDCOST
         )
         with self.assertRaises(ValueError):
             # xshard_gas_limit should be gas_limit // 2
@@ -1272,7 +1291,7 @@ class TestShardState(unittest.TestCase):
                         gas_price=2,
                         gas_token_id=self.genesis_token,
                         transfer_token_id=self.genesis_token,
-                    )
+                    ),
                 ]
             ),
         )
@@ -1304,7 +1323,7 @@ class TestShardState(unittest.TestCase):
                         gas_price=2,
                         gas_token_id=self.genesis_token,
                         transfer_token_id=self.genesis_token,
-                    ),
+                    )
                 ]
             ),
         )
@@ -1315,8 +1334,9 @@ class TestShardState(unittest.TestCase):
             .add_minor_block_header(b2.header)
             .add_minor_block_header(b1.header)
             .finalize(
-                coinbase_amount_map={env0.quark_chain_config.genesis_token: 1000000},
-                coinbase_address=acc1)
+                coinbase_tokens={env0.quark_chain_config.genesis_token: 1000000},
+                coinbase_address=acc1,
+            )
         )
         state0.add_root_block(root_block)
 
@@ -1378,11 +1398,9 @@ class TestShardState(unittest.TestCase):
         state1.add_root_block(root_block)
 
         # Create a root block containing the block with the x-shard tx
-        root_block = (
-            state0.root_tip.create_block_to_append()
-            .finalize(
-                coinbase_amount_map={env0.quark_chain_config.genesis_token: 1000000},
-                coinbase_address=acc1)
+        root_block = state0.root_tip.create_block_to_append().finalize(
+            coinbase_tokens={env0.quark_chain_config.genesis_token: 1000000},
+            coinbase_address=acc1,
         )
         state0.add_root_block(root_block)
         state1.add_root_block(root_block)
@@ -1403,8 +1421,7 @@ class TestShardState(unittest.TestCase):
 
         # Root block coinbase does not consume xshard gas
         self.assertEqual(
-            state1.get_token_balance(acc1.recipient, self.genesis_token),
-            10000000,
+            state1.get_token_balance(acc1.recipient, self.genesis_token), 10000000
         )
 
     def test_xshard_smart_contract(self):
@@ -1443,10 +1460,14 @@ class TestShardState(unittest.TestCase):
         )
         self.assertFalse(state0.add_tx(tx0))
         b0.add_tx(tx0)
-        with self.assertRaisesRegexp(RuntimeError, "xshard evm tx exceeds xshard gas limit"):
+        with self.assertRaisesRegexp(
+            RuntimeError, "xshard evm tx exceeds xshard gas limit"
+        ):
             state0.finalize_and_add_block(b0)
 
-        b2 = state0.create_block_to_mine(xshard_gas_limit=opcodes.GTXCOST * 9, include_tx=False)
+        b2 = state0.create_block_to_mine(
+            xshard_gas_limit=opcodes.GTXCOST * 9, include_tx=False
+        )
         b2.header.hash_prev_root_block = root_block.header.get_hash()
         tx2 = create_transfer_transaction(
             shard_state=state0,
@@ -1459,7 +1480,9 @@ class TestShardState(unittest.TestCase):
         )
         self.assertFalse(state0.add_tx(tx2, xshard_gas_limit=opcodes.GTXCOST * 9))
         b2.add_tx(tx2)
-        with self.assertRaisesRegexp(RuntimeError, "xshard evm tx exceeds xshard gas limit"):
+        with self.assertRaisesRegexp(
+            RuntimeError, "xshard evm tx exceeds xshard gas limit"
+        ):
             state0.finalize_and_add_block(b2, xshard_gas_limit=opcodes.GTXCOST * 9)
 
         b1 = state0.get_tip().create_block_to_append()
@@ -1520,7 +1543,12 @@ class TestShardState(unittest.TestCase):
 
         b1 = state1.get_tip().create_block_to_append()
         evm_state = state1.run_block(b1)
-        b1.finalize(evm_state=evm_state, coinbase_amount=evm_state.block_fee)
+        b1.finalize(
+            evm_state=evm_state,
+            coinbase_amount_map=TokenBalanceMap(
+                {self.genesis_token: evm_state.block_fee}
+            ),
+        )
 
         root_block = (
             state0.root_tip.create_block_to_append()
@@ -1564,7 +1592,12 @@ class TestShardState(unittest.TestCase):
 
         b1 = state1.get_tip().create_block_to_append()
         evm_state = state1.run_block(b1)
-        b1.finalize(evm_state=evm_state, coinbase_amount=evm_state.block_fee)
+        b1.finalize(
+            evm_state=evm_state,
+            coinbase_amount_map=TokenBalanceMap(
+                {self.genesis_token: evm_state.block_fee}
+            ),
+        )
 
         # Add one empty root block
         empty_root = state0.root_tip.create_block_to_append().finalize()
@@ -1818,7 +1851,9 @@ class TestShardState(unittest.TestCase):
         # Should succeed
         state.finalize_and_add_block(b1)
         evm_state = state.run_block(b1)
-        b1.finalize(evm_state=evm_state, coinbase_amount=b1.header.coinbase_amount)
+        b1.finalize(
+            evm_state=evm_state, coinbase_amount_map=b1.header.coinbase_amount_map
+        )
         b1.meta.hash_evm_receipt_root = bytes(32)
         # low-level db operation to clear existing records
         del state.db.m_header_pool[b1.header.get_hash()]
@@ -2096,11 +2131,15 @@ class TestShardState(unittest.TestCase):
 
         b = state.create_block_to_mine()
         evm_state = state.run_block(b)
-        b.finalize(evm_state=evm_state, coinbase_amount=state.get_coinbase_amount())
+        b.finalize(
+            evm_state=evm_state, coinbase_amount_map=state.get_coinbase_amount_map()
+        )
         state.add_block(b)
 
         b = state.create_block_to_mine()
         evm = state.run_block(b)
-        b.finalize(evm_state=evm_state, coinbase_amount=state.get_coinbase_amount() + 1)
+        wrong_coinbase = state.get_coinbase_amount_map()
+        wrong_coinbase.add({self.genesis_token: +1})
+        b.finalize(evm_state=evm_state, coinbase_amount_map=wrong_coinbase)
         with self.assertRaises(ValueError):
             state.add_block(b)

--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -2085,3 +2085,22 @@ class TestShardState(unittest.TestCase):
         m = state.get_tip().create_block_to_append(address=acc, difficulty=1000)
         with self.assertRaises(ValueError):
             state.finalize_and_add_block(m)
+
+    def test_incorrect_coinbase_amount(self):
+        env = get_test_env()
+        state = create_default_shard_state(env=env)
+
+        # Add a root block to have all the shards initialized
+        root_block = state.root_tip.create_block_to_append().finalize()
+        state.add_root_block(root_block)
+
+        b = state.create_block_to_mine()
+        evm_state = state.run_block(b)
+        b.finalize(evm_state=evm_state, coinbase_amount=state.get_coinbase_amount())
+        state.add_block(b)
+
+        b = state.create_block_to_mine()
+        evm = state.run_block(b)
+        b.finalize(evm_state=evm_state, coinbase_amount=state.get_coinbase_amount() + 1)
+        with self.assertRaises(ValueError):
+            state.add_block(b)

--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -64,7 +64,7 @@ class TestShardState(unittest.TestCase):
         root_block.header.height = 0
         root_block.finalize()
 
-        new_genesis_block = state.init_genesis_state(root_block)
+        new_genesis_block, _ = state.init_genesis_state(root_block)
         self.assertNotEqual(
             new_genesis_block.header.get_hash(), genesis_header.get_hash()
         )

--- a/quarkchain/core.py
+++ b/quarkchain/core.py
@@ -647,6 +647,22 @@ class Transaction(Serializable):
         return True
 
 
+class TokenBalanceMap(Serializable):
+    FIELDS = [("balance_map", PrependedSizeMapSerializer(4, biguint, biguint))]
+
+    def __init__(self, balance_map: Dict):
+        if not isinstance(balance_map, Dict):
+            raise TypeError("TokenBalanceMap can only accept dict object")
+        self.balance_map = balance_map
+
+    def add(self, other: Dict):
+        for k, v in other.items():
+            self.balance_map[k] = self.balance_map.get(k, 0) + v
+
+    def get_hash(self):
+        return sha3_256(self.serialize())
+
+
 def calculate_merkle_root(item_list):
     if len(item_list) == 0:
         return bytes(32)
@@ -717,22 +733,6 @@ class MinorBlockMeta(Serializable):
         self.evm_cross_shard_receive_gas_used = evm_cross_shard_receive_gas_used
         self.xshard_tx_cursor_info = xshard_tx_cursor_info
         self.evm_xshard_gas_limit = evm_xshard_gas_limit
-
-    def get_hash(self):
-        return sha3_256(self.serialize())
-
-
-class TokenBalanceMap(Serializable):
-    FIELDS = [("balance_map", PrependedSizeMapSerializer(4, biguint, biguint))]
-
-    def __init__(self, balance_map: Dict):
-        if not isinstance(balance_map, Dict):
-            raise TypeError("TokenBalanceMap can only accept dict object")
-        self.balance_map = balance_map
-
-    def add(self, other: Dict):
-        for k, v in other.items():
-            self.balance_map[k] = self.balance_map.get(k, 0) + v
 
     def get_hash(self):
         return sha3_256(self.serialize())

--- a/quarkchain/genesis.py
+++ b/quarkchain/genesis.py
@@ -9,6 +9,7 @@ from quarkchain.core import (
     Branch,
     RootBlockHeader,
     RootBlock,
+    TokenBalanceMap,
 )
 from quarkchain.evm.state import State as EvmState
 from quarkchain.utils import sha3_256, check, token_id_encode
@@ -72,11 +73,12 @@ class GenesisManager:
         )
 
         local_fee_rate = 1 - self._qkc_config.reward_tax_rate  # type: Fraction
-        coinbase_amount = (
-            shard_config.COINBASE_AMOUNT
+        coinbase_tokens = {
+            self._qkc_config.genesis_token: shard_config.COINBASE_AMOUNT
             * local_fee_rate.numerator
             // local_fee_rate.denominator
-        )
+        }
+
         coinbase_address = Address.create_empty_account(full_shard_id)
 
         header = MinorBlockHeader(
@@ -87,7 +89,7 @@ class GenesisManager:
             hash_prev_root_block=root_block.header.get_hash(),
             evm_gas_limit=genesis.GAS_LIMIT,
             hash_meta=sha3_256(meta.serialize()),
-            coinbase_amount=coinbase_amount,
+            coinbase_amount_map=TokenBalanceMap(coinbase_tokens),
             coinbase_address=coinbase_address,
             create_time=genesis.TIMESTAMP,
             difficulty=genesis.DIFFICULTY,

--- a/quarkchain/genesis.py
+++ b/quarkchain/genesis.py
@@ -95,4 +95,7 @@ class GenesisManager:
             difficulty=genesis.DIFFICULTY,
             extra_data=bytes.fromhex(genesis.EXTRA_DATA),
         )
-        return MinorBlock(header=header, meta=meta, tx_list=[])
+        return (
+            MinorBlock(header=header, meta=meta, tx_list=[]),
+            TokenBalanceMap(coinbase_tokens),
+        )

--- a/quarkchain/p2p/tests/test_discovery.py
+++ b/quarkchain/p2p/tests/test_discovery.py
@@ -449,9 +449,9 @@ def test_topic_table():
 
 def test_get_v5_topic():
     les_topic = discovery.get_v5_topic(LESProtocol, MinorBlockHeader().get_hash())
-    assert les_topic == b"LES@3d7de0b17a11990f"
+    assert les_topic == b"LES@0ce4d51d78f9d944"
     les2_topic = discovery.get_v5_topic(LESProtocolV2, MinorBlockHeader().get_hash())
-    assert les2_topic == b"LES2@3d7de0b17a11990f"
+    assert les2_topic == b"LES2@0ce4d51d78f9d944"
 
 
 def remove_whitespace(s):

--- a/quarkchain/tests/test_core.py
+++ b/quarkchain/tests/test_core.py
@@ -25,7 +25,7 @@ from quarkchain.core import (
 from quarkchain.tests.test_utils import create_random_test_transaction
 from quarkchain.utils import check
 
-SIZE_LIST = [(RootBlockHeader, 216), (MinorBlockHeader, 507), (MinorBlockMeta, 216)]
+SIZE_LIST = [(RootBlockHeader, 216), (MinorBlockHeader, 479), (MinorBlockMeta, 216)]
 
 
 class TestDataSize(unittest.TestCase):


### PR DESCRIPTION
still want to remove the coinbase field from minor block header, we are getting close to the goal

0. change the minor block header coinbase from int to TokenBalanceMap
1. at the end of `add_block()`, calling `send_minor_block_header_to_master` will also send the coinbase token map
2. at the end of `add_block_list_for_sync()` return a list of coinbase token map and piggyback that into `SyncMinorBlockListResponse`

This eliminates the need for coinbase field in minor block header.

After this, the only place left that still makes use of coinbase field in minor block header is from `get_unconfirmed_headers_coinbase_amount`; there are some tests that uses coinbase_amount_map from minor block header as well, but it can be changed easily; also from some jsonrpc calls

This replaces #343 