### PR TITLE
using ETH2.0 SSZ merkle tree hash

### DIFF
--- a/quarkchain/utils.py
+++ b/quarkchain/utils.py
@@ -39,6 +39,12 @@ def is_p2(v):
     return (v & (v - 1)) == 0
 
 
+def p2_roundup(v):
+    ''' Roundup to nearest P2, v must be non-negative integer
+    '''
+    return 2 ** (v - 1).bit_length()
+
+
 def sha3_256(x):
     if isinstance(x, bytearray):
         x = bytes(x)


### PR DESCRIPTION
Previous merkle tree implementation uses bitcoin merkle tree implementation, which has several flaws (https://gist.github.com/maaku/41b0054de0731321d23e9da90ba4ee0a).  This version borrows ETH2.0's version defined in https://github.com/ethereum/eth2.0-specs/blob/dev/specs/simple-serialize.md#signed-roots