### PR TITLE
close peer writer properly

### DIFF
--- a/quarkchain/cluster/tool_multi_cluster.py
+++ b/quarkchain/cluster/tool_multi_cluster.py
@@ -1,16 +1,16 @@
 """
-multi_cluster.py - starts multiple clusters on localhost, and have them inter-connect using either simple network or real p2p
+tool_multi_cluster.py - starts multiple clusters on localhost, and have them inter-connect using either simple network or real p2p
 Usage:
-multi_cluster.py accepts the same arguments as cluster.py
+tool_multi_cluster.py accepts the same arguments as cluster.py
 additional arguments:
 --num_clusters
 also note that p2p bootstrap key is fixed to a test value
 
 Examples:
 1. simple network, with one (random) cluster mining
-python multi_cluster.py --start_simulated_mining
+python tool_multi_cluster.py --start_simulated_mining
 2. p2p module, with one (random) cluster mining
-python multi_cluster.py --p2p --start_simulated_mining
+python tool_multi_cluster.py --p2p --start_simulated_mining
 """
 
 

--- a/quarkchain/cluster/tool_multi_cluster_fd_test.py
+++ b/quarkchain/cluster/tool_multi_cluster_fd_test.py
@@ -1,0 +1,95 @@
+"""
+Direction of use:
+run `python tool_multi_cluster.py --p2p --num_clusters=1`,
+then `python tool_multi_cluster_fd_test.py --p2p --num_clusters=NUM`
+this will launch NUM-1 clusters SEQUENTIALLY, and shut them down after 40 secs, to simulate peers connecting and gone
+"""
+
+
+import argparse
+import asyncio
+import os
+import random
+
+from quarkchain.p2p.utils import colors, COLOR_END
+from quarkchain.cluster import cluster as cl
+from quarkchain.cluster.cluster_config import ClusterConfig
+
+
+async def main():
+    parser = argparse.ArgumentParser()
+    ClusterConfig.attach_arguments(parser)
+    parser.add_argument("--num_clusters", default=2, type=int)
+    args = parser.parse_args()
+    clusters = []
+    mine_i = random.randint(0, args.num_clusters - 1)
+    mine = args.start_simulated_mining
+    if mine:
+        print("cluster {} will be mining".format(mine_i))
+    else:
+        print("No one will be mining")
+
+    db_path_root = args.db_path_root
+    p2p_port = args.p2p_port
+    for i in range(args.num_clusters):
+        args.start_simulated_mining = mine and i == mine_i
+        args.db_path_root = "{}_C{}".format(db_path_root, i)
+
+        # set up p2p bootstrapping, with fixed bootstrap key for now
+        if args.p2p:
+            if i == 0:
+                args.privkey = (
+                    "31552f186bf90908ce386fb547dd0410bf443309125cc43fd0ffd642959bf6d9"
+                )
+            else:
+                args.privkey = ""
+
+            args.bootnodes = "enode://c571e0db93d17cc405cb57640826b70588a6a28785f38b21be471c609ca12fcb06cb306ac44872908f5bed99046031a5af82072d484e3ef9029560c1707193a0@127.0.0.1:{}".format(
+                p2p_port
+            )
+
+        config = ClusterConfig.create_from_args(args)
+        print("Cluster {} config file: {}".format(i, config.json_filepath))
+        print(config.to_json())
+
+        clusters.append(
+            cl.Cluster(config, "{}C{}{}_".format(colors[i % len(colors)], i, COLOR_END))
+        )
+
+        args.p2p_port += 1
+        args.port_start += 100
+        args.json_rpc_port += 1
+        args.json_rpc_private_port += 1
+
+    tasks = list()
+    # tasks.append(asyncio.ensure_future(clusters[0].run()))
+    await asyncio.sleep(3)
+    for cluster in clusters[1:]:
+        asyncio.ensure_future(cluster.run())
+        await asyncio.sleep(40)
+        print("trying to shut down")
+        await cluster.shutdown()
+        await asyncio.sleep(5)
+    try:
+        await asyncio.gather(*tasks)
+    except KeyboardInterrupt:
+        try:
+            for cluster in clusters:
+                asyncio.get_event_loop().run_until_complete(cluster.shutdown())
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    loop = asyncio.get_event_loop()
+    try:
+        loop.run_until_complete(main())
+    except KeyboardInterrupt:
+        try:
+            cl.kill_child_processes(os.getpid())
+        except Exception:
+            pass
+    finally:
+        loop.close()

--- a/quarkchain/p2p/peer.py
+++ b/quarkchain/p2p/peer.py
@@ -345,9 +345,8 @@ class BasePeer(BaseService):
 
         If the streams have already been closed, do nothing.
         """
-        if self.reader.at_eof():
-            return
-        self.reader.feed_eof()
+        if not self.reader.at_eof():
+            self.reader.feed_eof()
         self.writer.close()
 
     @property
@@ -795,7 +794,9 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
 
     _report_interval = 60
     _peer_boot_timeout = DEFAULT_PEER_BOOT_TIMEOUT
-    _fill_pool_ratio = 0.65 # only proactively fill peer pool to _fill_pool_ratio*max_peers
+    _fill_pool_ratio = (
+        0.65
+    )  # only proactively fill peer pool to _fill_pool_ratio*max_peers
 
     def __init__(
         self,


### PR DESCRIPTION
see #382, I think the issue is caused by not closing the socket writer properly when a peer is removed from pool
Testplan:
1. follow instructions in `tool_multi_cluster_fd_test.py`
2. before this change, dead peers leave open fds (`lsof -p PID`):
```
pypy3   88790  dll   33u    IPv4 0x60bc88494b75ba93      0t0      TCP localhost:38291->localhost:50377 (CLOSE_WAIT)
pypy3   88790  dll   34u    IPv4 0x60bc88494e630493      0t0      TCP localhost:38291->localhost:50421 (CLOSE_WAIT)
pypy3   88790  dll   35u    IPv4 0x60bc88494135fa93      0t0      TCP localhost:38291->localhost:50483 (CLOSE_WAIT)
pypy3   88790  dll   36u    IPv4 0x60bc88494be1a113      0t0      TCP localhost:38291->localhost:50561 (CLOSE_WAIT)
```
3. after this change, they are gone

will close #382 