### PR TITLE
Load stale root block from DB

### DIFF
--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -1187,12 +1187,10 @@ class MasterServer:
 
         root_last_block_time = 0
         if self.root_state.tip.height >= 3:
-            prev = self.root_state.db.get_root_block_by_hash(
+            prev = self.root_state.db.get_root_block_header_by_hash(
                 self.root_state.tip.hash_prev_block
             )
-            root_last_block_time = (
-                self.root_state.tip.create_time - prev.header.create_time
-            )
+            root_last_block_time = self.root_state.tip.create_time - prev.create_time
 
         tx_count_history = []
         for item in self.tx_count_history:

--- a/quarkchain/cluster/root_state.py
+++ b/quarkchain/cluster/root_state.py
@@ -107,6 +107,11 @@ class RootDb:
         self.db.put(b"tipHash", block_hash)
 
     def get_root_block_by_hash(self, h, consistency_check=True):
+        """
+        Consistency check being true means whatever in memory should already have enough
+        information (no missing root block, minor block etc). Skipping the check by reading
+        directly from database may have unwanted consequences.
+        """
         if consistency_check and h not in self.r_header_pool:
             return None
 

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -626,9 +626,9 @@ class Shard:
 
         self.add_block_futures[block.header.get_hash()] = self.loop.create_future()
 
-        prev_root_height = self.state.db.get_root_block_by_hash(
+        prev_root_height = self.state.db.get_root_block_header_by_hash(
             block.header.hash_prev_root_block
-        ).header.height
+        ).height
         await self.slave.broadcast_xshard_tx_list(block, xshard_list, prev_root_height)
         await self.slave.send_minor_block_header_to_master(
             block.header,
@@ -679,9 +679,9 @@ class Shard:
                 if future:
                     existing_add_block_futures.append(future)
             else:
-                prev_root_height = self.state.db.get_root_block_by_hash(
+                prev_root_height = self.state.db.get_root_block_header_by_hash(
                     block.header.hash_prev_root_block
-                ).header.height
+                ).height
                 block_hash_to_x_shard_list[block_hash] = (xshard_list, prev_root_height)
                 self.add_block_futures[block_hash] = self.loop.create_future()
 

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -888,6 +888,8 @@ class ShardState:
         prev_root_header = self.db.get_root_block_header_by_hash(
             block.header.hash_prev_root_block
         )
+        if not prev_root_header:
+            raise ValueError("missing prev root block")
         tip_prev_root_header = self.db.get_root_block_header_by_hash(
             self.header_tip.hash_prev_root_block, consistency_check=False
         )

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -153,7 +153,7 @@ class XshardTxCursor:
 
             # Check if the neighbor has the permission to send tx to local shard
             prev_root_header = self.db.get_root_block_header_by_hash(
-                mblock_header.hash_prev_root_block
+                mblock_header.hash_prev_root_block, consistency_check=False
             )
             if (
                 prev_root_header.height
@@ -546,7 +546,9 @@ class ShardState:
 
         header = longer_block_header
         for i in range(longer_block_header.height - shorter_block_header.height):
-            header = self.db.get_root_block_header_by_hash(header.hash_prev_block)
+            header = self.db.get_root_block_header_by_hash(
+                header.hash_prev_block, consistency_check=False
+            )
         return header == shorter_block_header
 
     def __validate_block(
@@ -1331,7 +1333,9 @@ class ShardState:
         # the worst case would be that we go all the way back to orig_block (shard_header)
         while not self.__is_same_root_chain(
             self.root_tip,
-            self.db.get_root_block_header_by_hash(self.header_tip.hash_prev_root_block),
+            self.db.get_root_block_header_by_hash(
+                self.header_tip.hash_prev_root_block, consistency_check=False
+            ),
         ):
             if self.header_tip.height == 0:
                 # we are at genesis block now but the root block it points to is still on a fork from root_tip.

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -886,7 +886,7 @@ class ShardState:
         # or they are equal length but the root height confirmed by the block is longer
         update_tip = False
         prev_root_header = self.db.get_root_block_header_by_hash(
-            block.header.hash_prev_root_block, consistency_check=False
+            block.header.hash_prev_root_block
         )
         tip_prev_root_header = self.db.get_root_block_header_by_hash(
             self.header_tip.hash_prev_root_block, consistency_check=False
@@ -910,9 +910,7 @@ class ShardState:
                 disallow_list = self._get_posw_coinbase_blockcnt(block_hash).keys()
                 self.evm_state.sender_disallow_list = disallow_list
             self.header_tip = block.header
-            tip_prev_root_header = self.db.get_root_block_header_by_hash(
-                self.header_tip.hash_prev_root_block, consistency_check=False
-            )
+            tip_prev_root_header = prev_root_header
             self.meta_tip = block.meta
 
         check(self.__is_same_root_chain(self.root_tip, tip_prev_root_header))

--- a/quarkchain/cluster/simple_network.py
+++ b/quarkchain/cluster/simple_network.py
@@ -231,9 +231,7 @@ class Peer(P2PConnection):
         block_hash = request.block_hash
         header_list = []
         for i in range(request.limit):
-            header = self.root_state.db.get_root_block_header_by_hash(
-                block_hash, consistency_check=False
-            )
+            header = self.root_state.db.get_root_block_header_by_hash(block_hash)
             header_list.append(header)
             if header.height == 0:
                 break


### PR DESCRIPTION
should fix #412 

context: 

for both root db and shard db, `get_root_block_header_by_hash` by default only reads from memory, unless `consistency_check` flag is false, and the reason is we can only assume those root blocks in memory have consistent view of the network (no missing previous block, missing minor block, etc), while root blocks in DB could be forks with missing information.

however, for nodes who experienced a reboot and state recovery, it's possible for a shard's tip (or some other minor block which we are sure to have a consistent view) to point to a very old root block which is not recovered and loaded into memory, thus `get_root_block_header_by_hash` will fail. 

this PR updates several aforementioned cases, where we would directly load root blocks from database:

1. when adding minor block
  a. loading root block pointed from the shard's tip
2. when adding root blocks
  a. loading root block pointed from the shard's tip
  b. loading root block pointed from the last minor block confirmed by the given root block's predecessor
3. when comparing whether root blocks are of the same chain
  a. loading root blocks between the shorter and the longer
4. get next position for xshrad deposit cursor (@qizhou may need your eye on this one)
  a. load root blocks pointed by the given root block's included minor blocks

the testing scenario is a little bit more tricky since we need to simulate cluster shutdown and recovery 

******

confirmed the fix on my node.