### PR TITLE
disable_jsonrpc_by_default

### DIFF
--- a/quarkchain/cluster/cluster_config.py
+++ b/quarkchain/cluster/cluster_config.py
@@ -135,6 +135,8 @@ class ClusterConfig(BaseConfig):
     P2P_PORT = 38291
     JSON_RPC_PORT = 38391
     PRIVATE_JSON_RPC_PORT = 38491
+    JSON_RPC_HOST = "127.0.0.1"
+    PRIVATE_JSON_RPC_HOST = "127.0.0.1"
     ENABLE_TRANSACTION_HISTORY = False
 
     DB_PATH_ROOT = "./db"
@@ -249,6 +251,14 @@ class ClusterConfig(BaseConfig):
             type=int,
         )
         parser.add_argument(
+            "--json_rpc_host", default=ClusterConfig.JSON_RPC_HOST, type=str
+        )
+        parser.add_argument(
+            "--json_rpc_private_host",
+            default=ClusterConfig.PRIVATE_JSON_RPC_HOST,
+            type=str,
+        )
+        parser.add_argument(
             "--enable_transaction_history",
             action="store_true",
             default=False,
@@ -318,6 +328,8 @@ class ClusterConfig(BaseConfig):
             config.P2P_PORT = args.p2p_port
             config.JSON_RPC_PORT = args.json_rpc_port
             config.PRIVATE_JSON_RPC_PORT = args.json_rpc_private_port
+            config.JSON_RPC_HOST = args.json_rpc_host
+            config.PRIVATE_JSON_RPC_HOST = args.json_rpc_private_host
 
             config.CLEAN = args.clean
             config.START_SIMULATED_MINING = args.start_simulated_mining

--- a/quarkchain/cluster/cluster_config.py
+++ b/quarkchain/cluster/cluster_config.py
@@ -135,8 +135,8 @@ class ClusterConfig(BaseConfig):
     P2P_PORT = 38291
     JSON_RPC_PORT = 38391
     PRIVATE_JSON_RPC_PORT = 38491
-    JSON_RPC_HOST = "127.0.0.1"
-    PRIVATE_JSON_RPC_HOST = "127.0.0.1"
+    JSON_RPC_HOST = "localhost"
+    PRIVATE_JSON_RPC_HOST = "localhost"
     ENABLE_TRANSACTION_HISTORY = False
 
     DB_PATH_ROOT = "./db"
@@ -243,7 +243,9 @@ class ClusterConfig(BaseConfig):
         )
         parser.add_argument("--p2p_port", default=ClusterConfig.P2P_PORT, type=int)
         parser.add_argument(
-            "--json_rpc_port", default=ClusterConfig.JSON_RPC_PORT, type=int
+            "--json_rpc_port", 
+            default=ClusterConfig.JSON_RPC_PORT,
+            type=int,
         )
         parser.add_argument(
             "--json_rpc_private_port",
@@ -251,7 +253,9 @@ class ClusterConfig(BaseConfig):
             type=int,
         )
         parser.add_argument(
-            "--json_rpc_host", default=ClusterConfig.JSON_RPC_HOST, type=str
+            "--json_rpc_host",
+            default=ClusterConfig.JSON_RPC_HOST,
+            type=str,
         )
         parser.add_argument(
             "--json_rpc_private_host",

--- a/testnet/2.4/cluster_config_bootnodes.json
+++ b/testnet/2.4/cluster_config_bootnodes.json
@@ -1,9 +1,9 @@
 {
   "P2P_PORT": 38291,
   "JSON_RPC_PORT": 38391,
-  "JSON_RPC_HOST": "127.0.0.1",
+  "JSON_RPC_HOST": "localhost",
   "PRIVATE_JSON_RPC_PORT": 38491,
-  "PRIVATE_JSON_RPC_HOST": "127.0.0.1",
+  "PRIVATE_JSON_RPC_HOST": "localhost",
   "ENABLE_TRANSACTION_HISTORY": false,
   "DB_PATH_ROOT": "./qkc-data/testnet24",
   "LOG_LEVEL": "info",

--- a/testnet/2.4/cluster_config_bootnodes.json
+++ b/testnet/2.4/cluster_config_bootnodes.json
@@ -1,7 +1,9 @@
 {
   "P2P_PORT": 38291,
   "JSON_RPC_PORT": 38391,
+  "JSON_RPC_HOST": "127.0.0.1",
   "PRIVATE_JSON_RPC_PORT": 38491,
+  "PRIVATE_JSON_RPC_HOST": "127.0.0.1",
   "ENABLE_TRANSACTION_HISTORY": false,
   "DB_PATH_ROOT": "./qkc-data/testnet24",
   "LOG_LEVEL": "info",

--- a/testnet/2.4/cluster_config_template.json
+++ b/testnet/2.4/cluster_config_template.json
@@ -1,9 +1,9 @@
 {
   "P2P_PORT": 38291,
   "JSON_RPC_PORT": 38391,
-  "JSON_RPC_HOST": "127.0.0.1",
+  "JSON_RPC_HOST": "localhost",
   "PRIVATE_JSON_RPC_PORT": 38491,
-  "PRIVATE_JSON_RPC_HOST": "127.0.0.1",
+  "PRIVATE_JSON_RPC_HOST": "localhost",
   "ENABLE_TRANSACTION_HISTORY": false,
   "DB_PATH_ROOT": "./qkc-data/testnet24",
   "LOG_LEVEL": "info",

--- a/testnet/2.4/cluster_config_template.json
+++ b/testnet/2.4/cluster_config_template.json
@@ -1,7 +1,9 @@
 {
   "P2P_PORT": 38291,
   "JSON_RPC_PORT": 38391,
+  "JSON_RPC_HOST": "127.0.0.1",
   "PRIVATE_JSON_RPC_PORT": 38491,
+  "PRIVATE_JSON_RPC_HOST": "127.0.0.1",
   "ENABLE_TRANSACTION_HISTORY": false,
   "DB_PATH_ROOT": "./qkc-data/testnet24",
   "LOG_LEVEL": "info",

--- a/testnet/2.5/cluster_config_bootnodes.json
+++ b/testnet/2.5/cluster_config_bootnodes.json
@@ -1,7 +1,9 @@
 {
   "P2P_PORT": 38291,
   "JSON_RPC_PORT": 38391,
+  "JSON_RPC_HOST": "127.0.0.1",
   "PRIVATE_JSON_RPC_PORT": 38491,
+  "PRIVATE_JSON_RPC_HOST": "127.0.0.1",
   "ENABLE_TRANSACTION_HISTORY": false,
   "DB_PATH_ROOT": "./qkc-data/testnet25",
   "LOG_LEVEL": "info",

--- a/testnet/2.5/cluster_config_bootnodes.json
+++ b/testnet/2.5/cluster_config_bootnodes.json
@@ -1,9 +1,9 @@
 {
   "P2P_PORT": 38291,
   "JSON_RPC_PORT": 38391,
-  "JSON_RPC_HOST": "127.0.0.1",
+  "JSON_RPC_HOST": "localhost",
   "PRIVATE_JSON_RPC_PORT": 38491,
-  "PRIVATE_JSON_RPC_HOST": "127.0.0.1",
+  "PRIVATE_JSON_RPC_HOST": "localhost",
   "ENABLE_TRANSACTION_HISTORY": false,
   "DB_PATH_ROOT": "./qkc-data/testnet25",
   "LOG_LEVEL": "info",

--- a/testnet/2.5/cluster_config_template.json
+++ b/testnet/2.5/cluster_config_template.json
@@ -1,7 +1,9 @@
 {
   "P2P_PORT": 38291,
   "JSON_RPC_PORT": 38391,
+  "JSON_RPC_HOST": "127.0.0.1",
   "PRIVATE_JSON_RPC_PORT": 38491,
+  "PRIVATE_JSON_RPC_HOST": "127.0.0.1",
   "ENABLE_TRANSACTION_HISTORY": false,
   "DB_PATH_ROOT": "./qkc-data/testnet25",
   "LOG_LEVEL": "info",

--- a/testnet/2.5/cluster_config_template.json
+++ b/testnet/2.5/cluster_config_template.json
@@ -1,9 +1,9 @@
 {
   "P2P_PORT": 38291,
   "JSON_RPC_PORT": 38391,
-  "JSON_RPC_HOST": "127.0.0.1",
+  "JSON_RPC_HOST": "localhost",
   "PRIVATE_JSON_RPC_PORT": 38491,
-  "PRIVATE_JSON_RPC_HOST": "127.0.0.1",
+  "PRIVATE_JSON_RPC_HOST": "localhost",
   "ENABLE_TRANSACTION_HISTORY": false,
   "DB_PATH_ROOT": "./qkc-data/testnet25",
   "LOG_LEVEL": "info",


### PR DESCRIPTION
Should fix:  #423, #422, #416, #415, #394

We disable public and private json rpc by default value localhost to prevent it from being used by the public.  If the other people want to call it, the owner should turn it on in the configuration.

