### PR TITLE
blacklist IP for connection or handshake failures; remove blacklist from routing table

### DIFF
--- a/quarkchain/p2p/constants.py
+++ b/quarkchain/p2p/constants.py
@@ -79,3 +79,5 @@ DEFAULT_PEER_BOOT_TIMEOUT = 20
 
 # period between adding a blacklisted node and removing it
 BLACKLIST_COOLDOWN_SEC = 24 * 3600
+
+UNBLACKLIST_INTERVAL = 15 * 60

--- a/quarkchain/p2p/constants.py
+++ b/quarkchain/p2p/constants.py
@@ -77,5 +77,5 @@ SEAL_CHECK_RANDOM_SAMPLE_RATE = 48
 # aborting the connection attempt.
 DEFAULT_PEER_BOOT_TIMEOUT = 20
 
-# expectation of period between adding a blacklisted node and removing it
+# period between adding a blacklisted node and removing it
 BLACKLIST_COOLDOWN_SEC = 24 * 3600

--- a/quarkchain/p2p/constants.py
+++ b/quarkchain/p2p/constants.py
@@ -76,3 +76,6 @@ SEAL_CHECK_RANDOM_SAMPLE_RATE = 48
 # The amount of time that the BasePeerPool will wait for a peer to boot before
 # aborting the connection attempt.
 DEFAULT_PEER_BOOT_TIMEOUT = 20
+
+# expectation of period between adding a blacklisted node and removing it
+BLACKLIST_COOLDOWN_SEC = 24 * 3600

--- a/quarkchain/p2p/discovery.py
+++ b/quarkchain/p2p/discovery.py
@@ -991,7 +991,7 @@ class DiscoveryService(BaseService):
         for bucket in self.proto.routing.buckets:
             for node in bucket.nodes:
                 if self.peer_pool.chk_blacklist(node.address):
-                    self.logger.info_every_n("{} is blacklisted, removing from routing table".format(node), 100)
+                    Logger.info_every_n("{} is blacklisted, removing from routing table".format(node), 100)
                     self.proto.routing.remove_node(node)
 
         await self.peer_pool.connect_to_nodes(

--- a/quarkchain/p2p/discovery.py
+++ b/quarkchain/p2p/discovery.py
@@ -987,6 +987,13 @@ class DiscoveryService(BaseService):
         if self._last_lookup + self._lookup_interval < time.time():
             self.run_task(self.maybe_lookup_random_node())
 
+        # remove blacklisted nodes from the routing table, then return results
+        for bucket in self.proto.routing.buckets:
+            for node in bucket.nodes:
+                if self.peer_pool.chk_blacklist(node.address):
+                    self.logger.info_every_n("{} is blacklisted, removing from routing table".format(node), 100)
+                    self.proto.routing.remove_node(node)
+
         await self.peer_pool.connect_to_nodes(
             self.proto.get_nodes_to_connect(self.peer_pool.max_peers))
 

--- a/quarkchain/p2p/exceptions.py
+++ b/quarkchain/p2p/exceptions.py
@@ -167,3 +167,6 @@ class UnableToGetDiscV5Ticket(BaseP2PError):
     Raised when we're unable to get a discv5 ticket from a remote peer.
     """
     pass
+
+class BlacklistedPeer(BaseP2PError):
+    pass

--- a/quarkchain/p2p/p2p_manager.py
+++ b/quarkchain/p2p/p2p_manager.py
@@ -331,11 +331,17 @@ class QuarkServer(BaseServer):
     """
 
     def _make_peer_pool(self):
+        whitelist_nodes = []
+        if self.bootstrap_nodes:
+            whitelist_nodes.extend(self.bootstrap_nodes)
+        if self.preferred_nodes:
+            whitelist_nodes.extend(self.preferred_nodes)
         return QuarkPeerPool(
             privkey=self.privkey,
             context=QuarkContext(),
             listen_port=self.port,
             token=self.cancel_token,
+            whitelist_nodes=whitelist_nodes,
         )
 
     def _make_syncer(self):

--- a/quarkchain/p2p/p2p_server.py
+++ b/quarkchain/p2p/p2p_server.py
@@ -148,6 +148,15 @@ class BaseServer(BaseService):
     async def receive_handshake(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
+        ip, socket, *_ = writer.get_extra_info("peername")
+        remote_address = Address(ip, socket)
+        if self.peer_pool.chk_blacklist(remote_address):
+            self.logger.info_every_n(
+                "{} has been blacklisted, refusing connection".format(remote_address),
+                100,
+            )
+            reader.feed_eof()
+            writer.close()
         expected_exceptions = (
             TimeoutError,
             PeerConnectionLost,
@@ -158,7 +167,7 @@ class BaseServer(BaseService):
             await self._receive_handshake(reader, writer)
         except expected_exceptions as e:
             self.logger.debug("Could not complete handshake: %s", e)
-            self.logger.error("Could not complete handshake: %s", e)
+            self.logger.error_every_n("Could not complete handshake: {}".format(e), 100)
             reader.feed_eof()
             writer.close()
         except OperationCancelled:
@@ -169,6 +178,7 @@ class BaseServer(BaseService):
             self.logger.exception("Unexpected error handling handshake")
             reader.feed_eof()
             writer.close()
+            self.peer_pool.blacklist(remote_address)
 
     async def _receive_handshake(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
@@ -176,7 +186,6 @@ class BaseServer(BaseService):
         msg = await self.wait(
             reader.read(ENCRYPTED_AUTH_MSG_LEN), timeout=REPLY_TIMEOUT
         )
-
         ip, socket, *_ = writer.get_extra_info("peername")
         remote_address = Address(ip, socket)
         self.logger.debug("Receiving handshake from %s", remote_address)

--- a/quarkchain/p2p/p2p_server.py
+++ b/quarkchain/p2p/p2p_server.py
@@ -167,7 +167,7 @@ class BaseServer(BaseService):
             await self._receive_handshake(reader, writer)
         except expected_exceptions as e:
             self.logger.debug("Could not complete handshake: %s", e)
-            self.logger.error_every_n("Could not complete handshake: {}".format(e), 100)
+            Logger.error_every_n("Could not complete handshake: {}".format(e), 100)
             reader.feed_eof()
             writer.close()
         except OperationCancelled:

--- a/quarkchain/p2p/peer.py
+++ b/quarkchain/p2p/peer.py
@@ -70,6 +70,7 @@ from .constants import (
     HEADER_LEN,
     MAC_LEN,
     BLACKLIST_COOLDOWN_SEC,
+    UNBLACKLIST_INTERVAL,
 )
 
 
@@ -825,7 +826,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         self.listen_port = listen_port
         self.dialedout_pubkeys = set()  # type: Set[datatypes.PublicKey]
 
-        self.whitelist_nodes = whitelist_nodes
+        self.whitelist_nodes = whitelist_nodes or []
         # IP to unblacklist time, we blacklist by IP
         self._blacklist = {}  # type: Dict[str, int]
 
@@ -963,7 +964,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                     remove.add(ip)
             for ip in remove:
                 del self._blacklist[ip]
-            await self.sleep(self._report_interval)
+            await self.sleep(UNBLACKLIST_INTERVAL)
 
     async def connect(self, remote: Node) -> BasePeer:
         """


### PR DESCRIPTION
fixes #427

we do not blacklist on `close_with_error` yet, I think 24-hour blacklist is too harsh for it