### PR TITLE
p2p-handshake: differentiate between useless peer and expected failures

### DIFF
--- a/quarkchain/p2p/auth.py
+++ b/quarkchain/p2p/auth.py
@@ -22,7 +22,11 @@ from quarkchain.p2p.cancel_token.token import CancelToken
 from quarkchain.p2p import ecies
 from quarkchain.p2p import kademlia
 from quarkchain.p2p.constants import REPLY_TIMEOUT
-from quarkchain.p2p.exceptions import BadAckMessage, DecryptionError, HandshakeFailure
+from quarkchain.p2p.exceptions import (
+    BadAckMessage,
+    DecryptionError,
+    HandshakeDisconnectedFailure,
+)
 from quarkchain.p2p.utils import sxor
 
 from .constants import (
@@ -84,7 +88,7 @@ async def _handshake(
     if reader.at_eof():
         # This is what happens when Parity nodes have blacklisted us
         # (https://github.com/ethereum/py-evm/issues/901).
-        raise HandshakeFailure(
+        raise HandshakeDisconnectedFailure(
             "%s disconnected before sending auth ack", repr(initiator.remote)
         )
 

--- a/quarkchain/p2p/exceptions.py
+++ b/quarkchain/p2p/exceptions.py
@@ -1,12 +1,11 @@
-from typing import (
-    Any
-)
+from typing import Any
 
 
 class BaseP2PError(Exception):
     """
     The base class for all p2p errors.
     """
+
     pass
 
 
@@ -14,6 +13,7 @@ class DecryptionError(BaseP2PError):
     """
     Raised when a message could not be decrypted.
     """
+
     pass
 
 
@@ -21,13 +21,27 @@ class PeerConnectionLost(BaseP2PError):
     """
     Raised when the connection to a peer was lost.
     """
+
     pass
 
 
 class HandshakeFailure(BaseP2PError):
     """
     Raised when the protocol handshake was unsuccessful.
+    eg. mismatched capabilities, read timeout
+    if local tries to connect to remote but encounters this error, remote is blacklisted
     """
+
+    pass
+
+
+class HandshakeDisconnectedFailure(BaseP2PError):
+    """
+    Raised when handshake fails for some known reasons:
+    remote tells us eg. "too_many_peers" "already_connected"
+    won't blacklist remote
+    """
+
     pass
 
 
@@ -35,6 +49,7 @@ class MalformedMessage(BaseP2PError):
     """
     Raised when a p2p command is received with a malformed message
     """
+
     pass
 
 
@@ -42,6 +57,7 @@ class UnknownProtocolCommand(BaseP2PError):
     """
     Raised when the received protocal command isn't known.
     """
+
     pass
 
 
@@ -49,6 +65,7 @@ class UnexpectedMessage(BaseP2PError):
     """
     Raised when the received message was unexpected.
     """
+
     pass
 
 
@@ -56,6 +73,7 @@ class UnreachablePeer(BaseP2PError):
     """
     Raised when a peer was unreachable.
     """
+
     pass
 
 
@@ -63,6 +81,7 @@ class EmptyGetBlockHeadersReply(BaseP2PError):
     """
     Raised when the received block headers were empty.
     """
+
     pass
 
 
@@ -70,6 +89,7 @@ class LESAnnouncementProcessingError(BaseP2PError):
     """
     Raised when an LES announcement could not be processed.
     """
+
     pass
 
 
@@ -77,6 +97,7 @@ class TooManyTimeouts(BaseP2PError):
     """
     Raised when too many timeouts occurred.
     """
+
     pass
 
 
@@ -84,6 +105,7 @@ class NoMatchingPeerCapabilities(BaseP2PError):
     """
     Raised when no matching protocol between peers was found.
     """
+
     pass
 
 
@@ -91,6 +113,7 @@ class RemoteDisconnected(BaseP2PError):
     """
     Raised when a remote disconnected.
     """
+
     pass
 
 
@@ -98,6 +121,7 @@ class NoConnectedPeers(BaseP2PError):
     """
     Raised when we are not connected to any peers.
     """
+
     pass
 
 
@@ -105,6 +129,7 @@ class NoEligiblePeers(BaseP2PError):
     """
     Raised when none of our peers have the data we want.
     """
+
     pass
 
 
@@ -112,6 +137,7 @@ class NoIdlePeers(BaseP2PError):
     """
     Raised when none of our peers is idle and can be used for data requests.
     """
+
     pass
 
 
@@ -119,6 +145,7 @@ class EventLoopMismatch(BaseP2PError):
     """
     Raised when two different asyncio event loops are referenced, but must be equal
     """
+
     pass
 
 
@@ -126,6 +153,7 @@ class NoEligibleNodes(BaseP2PError):
     """
     Raised when there are no nodes which meet some filter criteria
     """
+
     pass
 
 
@@ -133,6 +161,7 @@ class BadAckMessage(BaseP2PError):
     """
     Raised when the ack message during a peer handshake is malformed
     """
+
     pass
 
 
@@ -143,6 +172,7 @@ class BadLESResponse(BaseP2PError):
     The peer can be treated as violating protocol. Often, the repurcussion should be
     disconnection and blacklisting.
     """
+
     pass
 
 
@@ -150,7 +180,8 @@ class NoInternalAddressMatchesDevice(BaseP2PError):
     """
     Raised when no internal IP address matches the UPnP device that is being configured.
     """
-    def __init__(self, *args: Any, device_hostname: str=None, **kwargs: Any) -> None:
+
+    def __init__(self, *args: Any, device_hostname: str = None, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.device_hostname = device_hostname
 
@@ -159,6 +190,7 @@ class AlreadyWaitingDiscoveryResponse(BaseP2PError):
     """
     Raised when we are already waiting for a discovery response from a given remote.
     """
+
     pass
 
 
@@ -166,7 +198,9 @@ class UnableToGetDiscV5Ticket(BaseP2PError):
     """
     Raised when we're unable to get a discv5 ticket from a remote peer.
     """
+
     pass
+
 
 class BlacklistedPeer(BaseP2PError):
     pass

--- a/quarkchain/p2p/p2p_server.py
+++ b/quarkchain/p2p/p2p_server.py
@@ -25,6 +25,7 @@ from quarkchain.p2p.exceptions import (
     DecryptionError,
     HandshakeFailure,
     PeerConnectionLost,
+    HandshakeDisconnectedFailure,
 )
 from quarkchain.p2p.p2p_proto import DisconnectReason
 from quarkchain.p2p.peer import BasePeer, PeerConnection
@@ -162,6 +163,7 @@ class BaseServer(BaseService):
             PeerConnectionLost,
             HandshakeFailure,
             asyncio.IncompleteReadError,
+            HandshakeDisconnectedFailure,
         )
         try:
             await self._receive_handshake(reader, writer)

--- a/quarkchain/p2p/peer.py
+++ b/quarkchain/p2p/peer.py
@@ -1011,9 +1011,9 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             )
             return None
         blacklistworthy_exceptions = (
-            HandshakeFailure,    # after secure handshake handshake, when talking p2p command, eg. parsing hello failed no matching p2p capabilities
+            HandshakeFailure,    # after secure handshake handshake, when negotiating p2p command, eg. parsing hello failed; no matching p2p capabilities
             PeerConnectionLost,  # conn lost while reading
-            TimeoutError,        # eg. read timeout, raised by CancelToken
+            TimeoutError,        # eg. read timeout (raised by CancelToken)
             UnreachablePeer,     # ConnectionRefusedError, OSError
         )
         expected_exceptions = (

--- a/quarkchain/p2p/peer.py
+++ b/quarkchain/p2p/peer.py
@@ -51,6 +51,7 @@ from quarkchain.p2p.exceptions import (
     UnexpectedMessage,
     UnknownProtocolCommand,
     UnreachablePeer,
+    HandshakeDisconnectedFailure,
 )
 from quarkchain.p2p.service import BaseService
 from quarkchain.p2p.utils import get_devp2p_cmd_id, roundup_16, sxor, time_since
@@ -281,7 +282,7 @@ class BasePeer(BaseService):
         if isinstance(cmd, Disconnect):
             msg = cast(Dict[str, Any], msg)
             # Peers sometimes send a disconnect msg before they send the sub-proto handshake.
-            raise HandshakeFailure(
+            raise HandshakeDisconnectedFailure(
                 "{} disconnected before completing sub-proto handshake: {}".format(
                     self, msg["reason_name"]
                 )
@@ -306,7 +307,7 @@ class BasePeer(BaseService):
         if isinstance(cmd, Disconnect):
             msg = cast(Dict[str, Any], msg)
             # Peers sometimes send a disconnect msg before they send the initial P2P handshake.
-            raise HandshakeFailure(
+            raise HandshakeDisconnectedFailure(
                 "{} disconnected before completing sub-proto handshake: {}".format(
                     self, msg["reason_name"]
                 )
@@ -1009,11 +1010,14 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                 100
             )
             return None
+        blacklistworthy_exceptions = (
+            HandshakeFailure,    # after secure handshake handshake, when talking p2p command, eg. parsing hello failed no matching p2p capabilities
+            PeerConnectionLost,  # conn lost while reading
+            TimeoutError,        # eg. read timeout, raised by CancelToken
+            UnreachablePeer,     # ConnectionRefusedError, OSError
+        )
         expected_exceptions = (
-            HandshakeFailure,
-            PeerConnectionLost,
-            TimeoutError,
-            UnreachablePeer,
+            HandshakeDisconnectedFailure,  # during secure handshake, disconnected before getting ack; or got Disconnect cmd for some known reason
         )
         try:
             self.logger.debug("Connecting to %s...", remote)
@@ -1028,30 +1032,39 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         except BadAckMessage:
             # This is kept separate from the `expected_exceptions` to be sure that we aren't
             # silencing an error in our authentication code.
-            self.logger.error("Got bad auth ack from %r", remote)
+            Logger.error_every_n("Got bad auth ack from {}".format(remote), 100)
             # dump the full stacktrace in the debug logs
             self.logger.debug("Got bad auth ack from %r", remote, exc_info=True)
+            self.dialout_blacklist(remote.address)
         except MalformedMessage:
             # This is kept separate from the `expected_exceptions` to be sure that we aren't
             # silencing an error in how we decode messages during handshake.
-            self.logger.error("Got malformed response from %r during handshake", remote)
+            Logger.error_every_n("Got malformed response from {} during handshake".format(remote), 100)
             # dump the full stacktrace in the debug logs
             self.logger.debug("Got malformed response from %r", remote, exc_info=True)
-        except expected_exceptions as e:
+            self.dialout_blacklist(remote.address)
+        except blacklistworthy_exceptions as e:
             self.logger.debug(
                 "Could not complete handshake with %r: %s", remote, repr(e)
             )
+            Logger.error_every_n("Could not complete handshake with {}: {}".format(repr(remote), repr(e)), 100)
+            self.dialout_blacklist(remote.address)
+        except expected_exceptions as e:
+            self.logger.debug(
+                "Disconnected during handshake %r: %s", remote, repr(e)
+            )
+            Logger.error_every_n("Disconnected during handshake {}: {}".format(repr(remote), repr(e)), 100)
         except Exception:
             self.logger.exception(
                 "Unexpected error during auth/p2p handshake with %r", remote
             )
+            self.dialout_blacklist(remote.address)
         if remote.__repr__() in auth.opened_connections:
             reader, writer = auth.opened_connections[remote.__repr__()]
             reader.feed_eof()
             writer.close()
             Logger.error_every_n("Closing connection to {}".format(remote.__repr__()), 100)
             del auth.opened_connections[remote.__repr__()]
-        self.dialout_blacklist(remote.address)
         return None
 
     @contextlib.contextmanager


### PR DESCRIPTION
follow https://github.com/QuarkChain/pyquarkchain/wiki/p2p-blacklisting
this does not blacklist some HandshakeFailure cases, which are identified by new Exception type `HandshakeDisconnectedFailure`