### PR TITLE
do not allow 0 cluster_peer_id

### DIFF
--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -77,6 +77,7 @@ from quarkchain.core import (
 )
 from quarkchain.db import PersistentDb
 from quarkchain.p2p.p2p_manager import P2PManager
+from quarkchain.p2p.utils import RESERVED_CLUSTER_PEER_ID
 from quarkchain.utils import Logger, check, time_ms
 from quarkchain.cluster.cluster_config import ClusterConfig
 
@@ -369,7 +370,7 @@ class SlaveConnection(ClusterConnection):
         """ Override ProxyConnection.get_connection_to_forward()
         Forward traffic from slave to peer
         """
-        if metadata.cluster_peer_id == 0:
+        if metadata.cluster_peer_id == RESERVED_CLUSTER_PEER_ID:
             return None
 
         peer = self.master_server.get_peer(metadata.cluster_peer_id)
@@ -403,7 +404,9 @@ class SlaveConnection(ClusterConnection):
         op, resp, rpc_id = await self.write_rpc_request(
             op=ClusterOp.PING,
             cmd=req,
-            metadata=ClusterMetadata(branch=ROOT_BRANCH, cluster_peer_id=0),
+            metadata=ClusterMetadata(
+                branch=ROOT_BRANCH, cluster_peer_id=RESERVED_CLUSTER_PEER_ID
+            ),
         )
         return resp.id, resp.chain_mask_list
 

--- a/quarkchain/p2p/utils.py
+++ b/quarkchain/p2p/utils.py
@@ -3,6 +3,10 @@ from typing import Tuple
 
 import rlp
 
+CLUSTER_PEER_ID_LEN = 2 ** 64
+
+RESERVED_CLUSTER_PEER_ID = 0
+
 
 def sxor(s1: bytes, s2: bytes) -> bytes:
     if len(s1) != len(s2):


### PR DESCRIPTION
defend against malicious peer id from 2 places:
1. when establishing peer (subprotocol handshake)
2. handling traffic from remote peer

fixes #448 

we can also use the `__get_next_cluster_peer_id` pattern in simple_network.py, either approach should fix the problem. Note that cluster peer id is accessed in multiple locations and need to be coordinated if anyone is looking for the second approach

Testplan:
```
python tool_multi_cluster.py --p2p --num_cluster=3
```