### PR TITLE
[part 1] Query DB for minor blocks in shards

### DIFF
--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -108,9 +108,7 @@ class PeerShardConnection(VirtualConnection):
         block_hash = request.block_hash
         header_list = []
         for i in range(request.limit):
-            header = self.shard_state.db.get_minor_block_header_by_hash(
-                block_hash, consistency_check=False
-            )
+            header = self.shard_state.db.get_minor_block_header_by_hash(block_hash)
             header_list.append(header)
             if header.height == 0:
                 break
@@ -123,9 +121,7 @@ class PeerShardConnection(VirtualConnection):
     async def handle_get_minor_block_list_request(self, request):
         m_block_list = []
         for m_block_hash in request.minor_block_hash_list:
-            m_block = self.shard_state.db.get_minor_block_by_hash(
-                m_block_hash, consistency_check=False
-            )
+            m_block = self.shard_state.db.get_minor_block_by_hash(m_block_hash)
             if m_block is None:
                 continue
             # TODO: Check list size to make sure the resp is smaller than limit

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -2,7 +2,7 @@ import asyncio
 import functools
 import json
 import time
-from collections import Counter, defaultdict, deque
+from collections import Counter, deque
 from fractions import Fraction
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -1065,9 +1065,6 @@ class ShardState:
             create_time = max(int(time.time()), self.header_tip.create_time + 1)
         return self.diff_calc.calculate_diff_with_parent(self.header_tip, create_time)
 
-    def get_next_block_reward(self):
-        return self.reward_calc.get_block_reward(self)
-
     def get_next_block_coinbase_amount(self):
         # TODO: add block reward
         # TODO: the current calculation is bogus and just serves as a placeholder.
@@ -1127,7 +1124,6 @@ class ShardState:
                 break
 
             evm_tx.set_quark_chain_config(self.env.quark_chain_config)
-            to_branch = Branch(evm_tx.to_full_shard_id)
 
             tx = TypedTransaction(SerializedEvmTransaction.from_evm_tx(evm_tx))
 
@@ -1233,9 +1229,6 @@ class ShardState:
 
     def contain_block_by_hash(self, h):
         return self.db.contain_minor_block_by_hash(h)
-
-    def get_pending_tx_size(self):
-        return self.transaction_pool.size()
 
     #
     # ============================ Cross-shard transaction handling =============================

--- a/quarkchain/cluster/slave.py
+++ b/quarkchain/cluster/slave.py
@@ -1190,7 +1190,7 @@ class SlaveServer:
         shard = self.shards.get(branch, None)
         if not shard:
             return None
-        return shard.state.db.get_minor_block_by_hash(block_hash, False)
+        return shard.state.db.get_minor_block_by_hash(block_hash)
 
     def get_minor_block_by_height(self, height, branch):
         shard = self.shards.get(branch, None)

--- a/quarkchain/cluster/tests/test_cluster.py
+++ b/quarkchain/cluster/tests/test_cluster.py
@@ -1,5 +1,4 @@
 import unittest
-from quarkchain.genesis import GenesisManager
 from quarkchain.cluster.tests.test_utils import (
     create_transfer_transaction,
     ClusterContext,

--- a/quarkchain/cluster/tests/test_jsonrpc.py
+++ b/quarkchain/cluster/tests/test_jsonrpc.py
@@ -23,9 +23,7 @@ from quarkchain.core import (
     SerializedEvmTransaction,
     TypedTransaction,
 )
-from quarkchain.core import MinorBlock, RootBlock
 from quarkchain.env import DEFAULT_ENV
-from quarkchain.evm import opcodes
 from quarkchain.evm.messages import mk_contract_address
 from quarkchain.evm.transactions import Transaction as EvmTransaction
 from quarkchain.utils import call_async, sha3_256

--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -1788,15 +1788,8 @@ class TestShardState(unittest.TestCase):
         recovered_state = ShardState(env=env, full_shard_id=2 | 0)
 
         recovered_state.init_from_root_block(root_block)
-        # forks are pruned
-        self.assertIsNone(
-            recovered_state.db.get_minor_block_by_hash(b1.header.get_hash())
-        )
         self.assertEqual(
-            recovered_state.db.get_minor_block_by_hash(
-                b1.header.get_hash(), consistency_check=False
-            ),
-            b1,
+            recovered_state.db.get_minor_block_by_hash(b1.header.get_hash()), b1
         )
 
         self.assertEqual(recovered_state.root_tip, root_block.header)
@@ -1860,10 +1853,6 @@ class TestShardState(unittest.TestCase):
             evm_state=evm_state, coinbase_amount_map=b1.header.coinbase_amount_map
         )
         b1.meta.hash_evm_receipt_root = bytes(32)
-        # low-level db operation to clear existing records
-        del state.db.m_header_pool[b1.header.get_hash()]
-        with self.assertRaises(ValueError):
-            state.add_block(b1)
 
     def test_not_update_tip_on_root_fork(self):
         """ block's hash_prev_root_block must be on the same chain with root_tip to update tip.


### PR DESCRIPTION
part of systematic fixes for using header / block pools in memory, where `consistency_check` will bypass db reading to guarantee consistency. similar to #414, related to #446