### PR TITLE
enforce block/blockheader limit from p2p peers

### DIFF
--- a/quarkchain/cluster/simple_network.py
+++ b/quarkchain/cluster/simple_network.py
@@ -25,6 +25,10 @@ from quarkchain.protocol import ConnectionState
 from quarkchain.utils import Logger
 
 
+ROOT_BLOCK_BATCH_SIZE = 100
+ROOT_BLOCK_HEADER_LIST_LIMIT = 500
+
+
 class Peer(P2PConnection):
     """Endpoint for communication with other clusters
 
@@ -43,7 +47,7 @@ class Peer(P2PConnection):
             op_ser_map=OP_SERIALIZER_MAP,
             op_non_rpc_map=OP_NONRPC_MAP,
             op_rpc_map=OP_RPC_MAP,
-            command_size_limit=env.quark_chain_config.P2P_COMMAND_SIZE_LIMIT
+            command_size_limit=env.quark_chain_config.P2P_COMMAND_SIZE_LIMIT,
         )
         self.network = network
         self.master_server = master_server
@@ -228,7 +232,7 @@ class Peer(P2PConnection):
             await self.master_server.add_transaction(tx, self)
 
     async def handle_get_root_block_header_list_request(self, request):
-        if request.limit <= 0:
+        if request.limit <= 0 or request.limit > 2 * ROOT_BLOCK_HEADER_LIST_LIMIT:
             self.close_with_error("Bad limit")
         # TODO: support tip direction
         if request.direction != Direction.GENESIS:
@@ -247,6 +251,8 @@ class Peer(P2PConnection):
         return GetRootBlockHeaderListResponse(self.root_state.tip, header_list)
 
     async def handle_get_root_block_list_request(self, request):
+        if len(request.root_block_hash_list) > 2 * ROOT_BLOCK_BATCH_SIZE:
+            self.close_with_error("Bad number of root block requested")
         r_block_list = []
         for h in request.root_block_hash_list:
             r_block = self.root_state.db.get_root_block_by_hash(


### PR DESCRIPTION
fixes #441 
one major issue that was also fixed in this PR is bad peer could potentially cause cluster crash (because we `check` that returned number of blocks matches requested, which is totally controlled by peer):
https://github.com/QuarkChain/pyquarkchain/blob/6a66a11ad48835163a20b3b06ed3ff59a35dde11/quarkchain/cluster/shard.py#L307

maybe we should have some audit on those unsafe `check`s as well