### PR TITLE
introduce pytest timeout in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - run:
           name: Run unittest/py.test Tests
           command: |
-            if [[ $CIRCLE_NODE_INDEX = 0 ]]; then pypy3 -m pytest ; fi
+            if [[ $CIRCLE_NODE_INDEX = 0 ]]; then pypy3 -m pytest --timeout=30; fi
 
       - run:
           name: Run EVM Tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ eth-bloom==1.0.0
 pyethash>=0.1.27,<1.0.0
 py_ecc==1.4.3
 eth-hash[pycryptodome]==0.1.4
+pytest-timeout==1.3.3
 
 # p2p
 pytest>=3.6,<3.7


### PR DESCRIPTION
- setup test timeout so that we could detect issues early (30s) without waiting for CI to be timeout, which is much longer.  In addition, this will print out more errors of pytest rather than CI just kill the test process without showing details.