### PR TITLE
Always return shard block's coinbase during slave sync

### DIFF
--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -129,13 +129,19 @@ class SyncTask:
                 )
                 return
 
+            download_start_time = time_ms()
             Logger.info(
-                "[R] downloading block header list from {} {}".format(
+                "[R] downloading block header list from height {} with hash {}".format(
                     height, block_hash.hex()
                 )
             )
             block_header_list = await asyncio.wait_for(
                 self.__download_block_headers(block_hash), SYNC_TIMEOUT
+            )
+            Logger.info(
+                "[R] downloaded block header list from height {} with hash {}, use {} ms".format(
+                    height, block_hash.hex(), time_ms() - download_start_time
+                )
             )
             self.__validate_block_headers(block_header_list)
             for header in block_header_list:

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -192,10 +192,11 @@ class PeerShardConnection(VirtualConnection):
         if self.shard_state.header_tip.height >= m_header.height:
             return
 
-        Logger.info(
+        Logger.info_every_sec(
             "[{}] received new tip with height {}".format(
                 m_header.branch.to_str(), m_header.height
-            )
+            ),
+            5
         )
         self.shard.synchronizer.add_task(m_header, self)
 
@@ -685,7 +686,9 @@ class Shard:
                 xshard_list, coinbase_amount_map = self.state.add_block(
                     block, skip_if_too_old=False
                 )
-                coinbase_amount_list.append(coinbase_amount_map)
+                # coinbase_amount_map may be None if the block exists
+                # adding the block header one since the block is already validated.
+                coinbase_amount_list.append(block.header.coinbase_amount_map)
             except Exception as e:
                 Logger.error_exception()
                 return False, coinbase_amount_list

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -667,7 +667,6 @@ class Shard:
 
         Returns true if blocks are successfully added. False on any error.
         Additionally, returns list of coinbase_amount_map for each block
-            (list can contain None indicating that the block has been added and master should receive token map soon)
         This function only adds blocks to local and propagate xshard list to other shards.
         It does NOT notify master because the master should already have the minor header list,
         and will add them once this function returns successfully.

--- a/quarkchain/cluster/slave.py
+++ b/quarkchain/cluster/slave.py
@@ -452,8 +452,7 @@ class MasterConnection(ClusterConnection):
                     )
                 check(len(blocks_to_download) == len(coinbase_amount_list))
                 for hash, coinbase in zip(blocks_to_download, coinbase_amount_list):
-                    if coinbase:
-                        block_coinbase_map[hash] = coinbase
+                    block_coinbase_map[hash] = coinbase
                 block_hash_list = block_hash_list[BLOCK_BATCH_SIZE:]
 
             branch = block_chain[0].header.branch


### PR DESCRIPTION
fix a root block synchronizer bug that
- a shard block is added in the local db
- the shard block is not in master (due to shutdown or sync fail)
so that it returns None coinbase_map, and not added in master db (in sync block logic)

- log root block header download time
- make shard tip receive log less verbose