### PR TITLE
implement two-phase commitment of adding minor blocks (#487)

### DIFF
--- a/quarkchain/cluster/rpc.py
+++ b/quarkchain/cluster/rpc.py
@@ -615,6 +615,32 @@ class AddMinorBlockHeaderResponse(Serializable):
         self.artificial_tx_config = artificial_tx_config
 
 
+class AddMinorBlockHeaderListRequest(Serializable):
+    """ Notify master about a list of successfully added minor block.
+    Mostly used for minor block sync triggered by root block sync
+    """
+    FIELDS = [
+        ("minor_block_header_list", PrependedSizeListSerializer(4, MinorBlockHeader)),
+        ("coinbase_amount_map_list", PrependedSizeListSerializer(4, TokenBalanceMap)),
+    ]
+
+    def __init__(
+        self,
+        minor_block_header_list,
+        coinbase_amount_map_list
+    ):
+        self.minor_block_header_list = minor_block_header_list
+        self.coinbase_amount_map_list = coinbase_amount_map_list
+
+
+class AddMinorBlockHeaderListResponse(Serializable):
+    FIELDS = [
+        ("error_code", uint32),
+    ]
+
+    def __init__(self, error_code):
+        self.error_code = error_code
+
 # slave -> slave
 
 
@@ -878,6 +904,8 @@ class ClusterOp:
     GET_WORK_RESPONSE = 56 + CLUSTER_OP_BASE
     SUBMIT_WORK_REQUEST = 57 + CLUSTER_OP_BASE
     SUBMIT_WORK_RESPONSE = 58 + CLUSTER_OP_BASE
+    ADD_MINOR_BLOCK_HEADER_LIST_REQUEST = 59 + CLUSTER_OP_BASE
+    ADD_MINOR_BLOCK_HEADER_LIST_RESPONSE = 60 + CLUSTER_OP_BASE
 
 
 CLUSTER_OP_SERIALIZER_MAP = {
@@ -938,4 +966,6 @@ CLUSTER_OP_SERIALIZER_MAP = {
     ClusterOp.GET_WORK_RESPONSE: GetWorkResponse,
     ClusterOp.SUBMIT_WORK_REQUEST: SubmitWorkRequest,
     ClusterOp.SUBMIT_WORK_RESPONSE: SubmitWorkResponse,
+    ClusterOp.ADD_MINOR_BLOCK_HEADER_LIST_REQUEST: AddMinorBlockHeaderListRequest,
+    ClusterOp.ADD_MINOR_BLOCK_HEADER_LIST_RESPONSE: AddMinorBlockHeaderListResponse,
 }

--- a/quarkchain/cluster/shard_db_operator.py
+++ b/quarkchain/cluster/shard_db_operator.py
@@ -347,6 +347,12 @@ class ShardDbOperator(TransactionHistoryMixin):
         """ Return the total number of blocks with the given height"""
         return len(self.height_to_minor_block_hashes.setdefault(height, set()))
 
+    def is_minor_block_committed_by_hash(self, h):
+        return self.db.get(b"commit_" + h) is not None
+
+    def commit_minor_block_by_hash(self, h):
+        self.put(b"commit_" + h, b"")
+
     # ------------------------- Transaction db operations --------------------------------
     def put_transaction_index(self, tx, block_height, index):
         tx_hash = tx.get_hash()

--- a/quarkchain/cluster/slave.py
+++ b/quarkchain/cluster/slave.py
@@ -31,6 +31,7 @@ from quarkchain.cluster.rpc import (
     GetWorkResponse,
     SubmitWorkRequest,
     SubmitWorkResponse,
+    AddMinorBlockHeaderListRequest,
 )
 from quarkchain.cluster.rpc import (
     AddRootBlockResponse,
@@ -964,6 +965,20 @@ class SlaveServer:
         )
         check(resp.error_code == 0)
         self.artificial_tx_config = resp.artificial_tx_config
+
+    async def send_minor_block_header_list_to_master(
+        self,
+        minor_block_header_list,
+        coinbase_amount_map_list,
+    ):
+        request = AddMinorBlockHeaderListRequest(
+            minor_block_header_list,
+            coinbase_amount_map_list
+        )
+        _, resp, _ = await self.master.write_rpc_request(
+            ClusterOp.ADD_MINOR_BLOCK_HEADER_LIST_REQUEST, request
+        )
+        check(resp.error_code == 0)
 
     def __get_branch_to_add_xshard_tx_list_request(
         self, block_hash, xshard_tx_list, prev_root_height


### PR DESCRIPTION
Implement two-phase commitment of adding minor blocks
- Add AddMinorBlockHeaderListRequest/Response so that the blocks downloaded from master (root block sync) will be also sent to master from slaves explicitly - so that a slave knows whether the blocks are committed or not
- Both new minor block and blocks downloaded by root block sync will use similar logic to determine whether a block is committed or not, and may redo if it is not committed
- This fixes an issue that a cross-shard transaction is broadcasted while the cluster is shutdown.  Original logic won't broadcast the cross-shard tx again (since the slaves finds the block in local db)

