### PR TITLE
add db_browser.py

### DIFF
--- a/quarkchain/cluster/root_state.py
+++ b/quarkchain/cluster/root_state.py
@@ -193,6 +193,13 @@ class RootDb:
         block_hash = self.db.get(key)
         return self.get_root_block_by_hash(block_hash, consistency_check=False)
 
+    def get_root_block_header_by_height(self, height):
+        key = b"ri_%d" % height
+        if key not in self.db:
+            return None
+        block_hash = self.db.get(key)
+        return self.get_root_block_header_by_hash(block_hash, consistency_check=False)
+
     # ------------------------- Minor block db operations --------------------------------
     def contain_minor_block_by_hash(self, h):
         if h in self.m_hash_dict:

--- a/quarkchain/core.py
+++ b/quarkchain/core.py
@@ -263,6 +263,16 @@ class Serializable:
             h_list.append(getattr(self, name))
         return hash(tuple(h_list))
 
+    def to_dict(self):
+        d = dict()
+        for name, ser in self.FIELDS:
+            v = getattr(self, name)
+            if isinstance(v, Serializable):
+                d[name] = v.to_dict()
+            else:
+                d[name] = v
+        return d
+
 
 class Optional:
     def __init__(self, serializer):

--- a/quarkchain/tools/db_browser.py
+++ b/quarkchain/tools/db_browser.py
@@ -1,0 +1,109 @@
+import argparse
+import os
+import sys
+from quarkchain.cluster.cluster_config import ClusterConfig
+
+from quarkchain.cluster.root_state import (
+    RootState
+)
+from quarkchain.cluster.shard import Shard
+from quarkchain.env import DEFAULT_ENV
+from quarkchain.db import PersistentDb
+from pprint import pprint
+
+
+def get_root_state():
+    env, args = parse_args()
+    return RootState(env)
+
+
+def get_shard_state(full_shard_id):
+    env, args = parse_args()
+    shard = Shard(env, full_shard_id, None)
+    return shard.state
+
+
+def handle_root_print_tip(env, args):
+    root_state = RootState(env)
+    pprint(root_state.tip.to_dict())
+    print("hash: {}".format(root_state.tip.get_hash().hex()))
+    return 0
+
+
+def handle_root_print_by_height(env, args):
+    root_state = RootState(env)
+    header = root_state.db.get_root_block_header_by_height(args.height)
+    if header is None:
+        print("header not found")
+        return 1
+    pprint(header.to_dict())
+    print("hash: {}".format(header.get_hash().hex()))
+    return 0
+
+
+def handle_root_print_by_hash(env, args):
+    root_state = RootState(env)
+    header = root_state.db.get_root_block_header_by_hash(bytes.fromhex(args.hash))
+    if header is None:
+        print("header not found")
+        return 1
+    pprint(header.to_dict())
+    print("hash: {}".format(header.get_hash().hex()))
+    return 0
+
+
+def handle_root_print_block(env, args):
+    root_state = RootState(env)
+    block = root_state.db.get_root_block_by_hash(bytes.fromhex(args.hash))
+    if block is None:
+        print("header not found")
+        return 1
+    pprint(block.to_dict())
+    print("hash: {}".format(block.header.get_hash().hex()))
+    return 0
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("action", type=str, help="action to take")
+    parser.add_argument("--height", type=int, help="block height to operate")
+    parser.add_argument("--hash", type=str, help="block hash to operate")
+    ClusterConfig.attach_arguments(parser)
+    args = parser.parse_args()
+
+    env = DEFAULT_ENV.copy()
+    env.cluster_config = ClusterConfig.create_from_args(args)
+
+    # initialize database
+    if not env.cluster_config.use_mem_db():
+        env.db = PersistentDb(
+            "{path}/master.db".format(path=env.cluster_config.DB_PATH_ROOT),
+            clean=env.cluster_config.CLEAN,
+        )
+
+    return env, args
+
+
+def main():
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    env, args = parse_args()
+
+    handlers = {
+        "root_print_tip": handle_root_print_tip,
+        "root_print_by_height": handle_root_print_by_height,
+        "root_print_by_hash": handle_root_print_by_hash,
+        "root_print_block": handle_root_print_block,
+    }
+
+    if args.action == "interactive":
+        pass
+    elif args.action not in handlers:
+        print("Cannot recognize action {}".format(args.action))
+        sys.exit(1)
+    else:
+        sys.exit(handlers[args.action](env, args))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This allows more interactive exploration of db.  Some usage:

```bash
- python3 quarkchain/tools/db_browser.py --cluster_config /code/pyquarkchain/testnet/2.5/cluster_config_template.json root_print_tip
====== WARNING: qkchash native is not loaded ======
W0416 20:19:29.151610 cluster_config.py:60] Error importing genesis accounts from /dev/null/alloc/0.json: [Errno 20] Not a directory: '/dev/null/alloc/0.json'
W0416 20:19:29.151780 cluster_config.py:63] Cleared all partially imported genesis accounts!
I0416 20:19:29.151946 cluster_config.py:82] No loadtest accounts imported into genesis alloc
I0416 20:19:29.197342 root_state.py:62] Recovering root chain from local database...
I0416 20:19:29.198257 root_state.py:267] Created genesis root block
{'coinbase_address': {'full_shard_key': 0,
                      'recipient': b'\x00\x00\x00\x00\x00\x00\x00\x00'
                                   b'\x00\x00\x00\x00\x00\x00\x00\x00'
                                   b'\x00\x00\x00\x00'},
 'coinbase_amount_map': {'balance_map': {}},
 'create_time': 1519147489,
 'difficulty': 1000000000000,
 'extra_data': b'',
 'hash_evm_state_root': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
                        b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
                        b'\x00\x00\x00\x00\x00\x00\x00\x00',
 'hash_merkle_root': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
                     b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
                     b'\x00\x00\x00\x00\x00\x00\x00\x00',
 'hash_prev_block': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
                    b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
                    b'\x00\x00\x00\x00\x00\x00\x00\x00',
 'height': 0,
 'mixhash': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
            b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
 'nonce': 0,
 'signature': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
              b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
              b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
              b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
              b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
              b'\x00\x00\x00\x00\x00',
 'total_difficulty': 1000000000000,
 'version': 0}
hash: 487b751dba8785f99acbfe03c66f92907099a0f19e0853e05ad27b0d121315b6
```