### PR TITLE
optimize root block synchronizer

### DIFF
--- a/quarkchain/cluster/root_state.py
+++ b/quarkchain/cluster/root_state.py
@@ -243,10 +243,11 @@ class RootState:
 
     def __init__(self, env, diff_calc=None):
         self.env = env
+        self.root_config = env.quark_chain_config.ROOT
         if not diff_calc:
-            cutoff = env.quark_chain_config.ROOT.DIFFICULTY_ADJUSTMENT_CUTOFF_TIME
-            diff_factor = env.quark_chain_config.ROOT.DIFFICULTY_ADJUSTMENT_FACTOR
-            min_diff = env.quark_chain_config.ROOT.GENESIS.DIFFICULTY
+            cutoff = self.root_config.DIFFICULTY_ADJUSTMENT_CUTOFF_TIME
+            diff_factor = self.root_config.DIFFICULTY_ADJUSTMENT_FACTOR
+            min_diff = self.root_config.GENESIS.DIFFICULTY
             check(cutoff > 0 and diff_factor > 0 and min_diff > 0)
             diff_calc = EthDifficultyCalculator(
                 cutoff=cutoff, diff_factor=diff_factor, minimum_diff=min_diff
@@ -296,7 +297,7 @@ class RootState:
         assert all(
             [self.db.contain_minor_block_by_hash(m_hash) for m_hash in m_hash_list]
         )
-        epoch = height // self.env.quark_chain_config.ROOT.EPOCH_INTERVAL
+        epoch = height // self.root_config.EPOCH_INTERVAL
         numerator = (
             self.env.quark_chain_config.block_reward_decay_factor.numerator ** epoch
         )
@@ -304,7 +305,7 @@ class RootState:
             self.env.quark_chain_config.block_reward_decay_factor.denominator ** epoch
         )
         coinbase_amount = (
-            self.env.quark_chain_config.ROOT.COINBASE_AMOUNT * numerator // denominator
+            self.root_config.COINBASE_AMOUNT * numerator // denominator
         )
         reward_tax_rate = self.env.quark_chain_config.reward_tax_rate
         # the ratio of minor block coinbase
@@ -405,7 +406,7 @@ class RootState:
             raise ValueError("incorrect total difficulty")
 
         # Check PoW if applicable
-        consensus_type = self.env.quark_chain_config.ROOT.CONSENSUS_TYPE
+        consensus_type = self.root_config.CONSENSUS_TYPE
         validate_seal(block_header, consensus_type, adjusted_diff=adjusted_diff)
 
         return block_hash

--- a/quarkchain/cluster/rpc.py
+++ b/quarkchain/cluster/rpc.py
@@ -553,6 +553,30 @@ class ShardStats(Serializable):
         self.last_block_time = last_block_time
 
 
+class RootBlockSychronizerStats(Serializable):
+    FIELDS = [
+        ("headers_downloaded", uint64),
+        ("blocks_downloaded", uint64),
+        ("blocks_added", uint64),
+        ("ancestor_not_found_count", uint64),
+        ("ancestor_lookup_requests", uint64),
+    ]
+
+    def __init__(
+        self,
+        headers_downloaded=0,
+        blocks_downloaded=0,
+        blocks_added=0,
+        ancestor_not_found_count=0,
+        ancestor_lookup_requests=0,
+    ):
+        self.headers_downloaded = headers_downloaded
+        self.blocks_downloaded = blocks_downloaded
+        self.blocks_added = blocks_added
+        self.ancestor_not_found_count = ancestor_not_found_count
+        self.ancestor_lookup_requests = ancestor_lookup_requests
+
+
 class SyncMinorBlockListRequest(Serializable):
     FIELDS = [
         ("minor_block_hash_list", PrependedSizeListSerializer(4, hash256)),

--- a/quarkchain/cluster/tests/test_cluster.py
+++ b/quarkchain/cluster/tests/test_cluster.py
@@ -950,3 +950,178 @@ class TestCluster(unittest.TestCase):
             self.assertEqual(resp.block_header_list[2], root_block_header_list[4])
             self.assertEqual(resp.block_header_list[3], root_block_header_list[2])
             self.assertEqual(resp.block_header_list[4], root_block_header_list[0])
+
+    def test_get_root_block_header_sync_from_genesis(self):
+        """ Test the broadcast is only done to the neighbors """
+        id1 = Identity.create_random_identity()
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+
+        with ClusterContext(2, acc1, connect=False) as clusters:
+            master = clusters[0].master
+            root_block_header_list = [master.root_state.tip]
+            for i in range(10):
+                root_block = call_async(
+                    master.get_next_block_to_mine(
+                        Address.create_empty_account(), branch_value=None
+                    )
+                )
+                call_async(master.add_root_block(root_block))
+                root_block_header_list.append(root_block.header)
+
+            # Connect and the synchronizer should automically download
+            call_async(clusters[1].network.connect(
+                "127.0.0.1",
+                clusters[0].network.env.cluster_config.P2P_PORT)
+            )
+            assert_true_with_timeout(lambda: clusters[1].master.root_state.tip == root_block_header_list[-1])
+            self.assertEqual(clusters[1].master.synchronizer.stats.blocks_downloaded, len(root_block_header_list) - 1)
+
+    def test_get_root_block_header_sync_from_height_3(self):
+        """ Test the broadcast is only done to the neighbors """
+        id1 = Identity.create_random_identity()
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+
+        with ClusterContext(2, acc1, connect=False) as clusters:
+            master0 = clusters[0].master
+            root_block_list = []
+            for i in range(10):
+                root_block = call_async(
+                    master0.get_next_block_to_mine(
+                        Address.create_empty_account(), branch_value=None
+                    )
+                )
+                call_async(master0.add_root_block(root_block))
+                root_block_list.append(root_block)
+
+            # Add 3 blocks to another cluster
+            master1 = clusters[1].master
+            for i in range(3):
+                call_async(master1.add_root_block(root_block_list[i]))
+            assert_true_with_timeout(lambda: master1.root_state.tip == root_block_list[2].header)
+
+            # Connect and the synchronizer should automically download
+            call_async(clusters[1].network.connect(
+                "127.0.0.1",
+                clusters[0].network.env.cluster_config.P2P_PORT)
+            )
+            assert_true_with_timeout(lambda: master1.root_state.tip == root_block_list[-1].header)
+            self.assertEqual(master1.synchronizer.stats.blocks_downloaded, len(root_block_list) - 3)
+            self.assertEqual(master1.synchronizer.stats.ancestor_lookup_requests, 1)
+
+    def test_get_root_block_header_sync_with_fork(self):
+        """ Test the broadcast is only done to the neighbors """
+        id1 = Identity.create_random_identity()
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+
+        with ClusterContext(2, acc1, connect=False) as clusters:
+            master0 = clusters[0].master
+            root_block_list = []
+            for i in range(10):
+                root_block = call_async(
+                    master0.get_next_block_to_mine(
+                        Address.create_empty_account(), branch_value=None
+                    )
+                )
+                call_async(master0.add_root_block(root_block))
+                root_block_list.append(root_block)
+
+            # Add 2+3 blocks to another cluster: 2 are the same as cluster 0, and 3 are the fork
+            master1 = clusters[1].master
+            for i in range(2):
+                call_async(master1.add_root_block(root_block_list[i]))
+            for i in range(3):
+                root_block = call_async(
+                    master1.get_next_block_to_mine(
+                        acc1, branch_value=None
+                    )
+                )
+                call_async(master1.add_root_block(root_block))
+
+            # Connect and the synchronizer should automically download
+            call_async(clusters[1].network.connect(
+                "127.0.0.1",
+                clusters[0].network.env.cluster_config.P2P_PORT)
+            )
+            assert_true_with_timeout(lambda: master1.root_state.tip == root_block_list[-1].header)
+            self.assertEqual(master1.synchronizer.stats.blocks_downloaded, len(root_block_list) - 2)
+            self.assertEqual(master1.synchronizer.stats.ancestor_lookup_requests, 1)
+
+    def test_get_root_block_header_sync_with_staleness(self):
+        """ Test the broadcast is only done to the neighbors """
+        id1 = Identity.create_random_identity()
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+
+        with ClusterContext(2, acc1, connect=False) as clusters:
+            master0 = clusters[0].master
+            root_block_list = []
+            for i in range(10):
+                root_block = call_async(
+                    master0.get_next_block_to_mine(
+                        Address.create_empty_account(), branch_value=None
+                    )
+                )
+                call_async(master0.add_root_block(root_block))
+                root_block_list.append(root_block)
+            assert_true_with_timeout(lambda: master0.root_state.tip == root_block_list[-1].header)
+
+            # Add 3 blocks to another cluster
+            master1 = clusters[1].master
+            for i in range(8):
+                root_block = call_async(
+                    master1.get_next_block_to_mine(
+                        acc1, branch_value=None
+                    )
+                )
+                call_async(master1.add_root_block(root_block))
+            master1.env.quark_chain_config.ROOT.MAX_STALE_ROOT_BLOCK_HEIGHT_DIFF = 5
+            assert_true_with_timeout(lambda: master1.root_state.tip == root_block.header)
+
+            # Connect and the synchronizer should automically download
+            call_async(clusters[1].network.connect(
+                "127.0.0.1",
+                clusters[0].network.env.cluster_config.P2P_PORT)
+            )
+            assert_true_with_timeout(lambda: master1.synchronizer.stats.ancestor_not_found_count == 1)
+            self.assertEqual(master1.synchronizer.stats.blocks_downloaded, 0)
+            self.assertEqual(master1.synchronizer.stats.ancestor_lookup_requests, 1)
+
+    def test_get_root_block_header_sync_with_multiple_lookup(self):
+        """ Test the broadcast is only done to the neighbors """
+        id1 = Identity.create_random_identity()
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+
+        with ClusterContext(2, acc1, connect=False) as clusters:
+            master0 = clusters[0].master
+            root_block_list = []
+            for i in range(12):
+                root_block = call_async(
+                    master0.get_next_block_to_mine(
+                        Address.create_empty_account(), branch_value=None
+                    )
+                )
+                call_async(master0.add_root_block(root_block))
+                root_block_list.append(root_block)
+            assert_true_with_timeout(lambda: master0.root_state.tip == root_block_list[-1].header)
+
+            # Add 4+4 blocks to another cluster
+            master1 = clusters[1].master
+            for i in range(4):
+                call_async(master1.add_root_block(root_block_list[i]))
+            for i in range(4):
+                root_block = call_async(
+                    master1.get_next_block_to_mine(
+                        acc1, branch_value=None
+                    )
+                )
+                call_async(master1.add_root_block(root_block))
+            master1.synchronizer.root_block_header_list_limit = 4
+
+            # Connect and the synchronizer should automically download
+            call_async(clusters[1].network.connect(
+                "127.0.0.1",
+                clusters[0].network.env.cluster_config.P2P_PORT)
+            )
+            assert_true_with_timeout(lambda: master1.root_state.tip == root_block_list[-1].header)
+            self.assertEqual(master1.synchronizer.stats.blocks_downloaded, 8)
+            self.assertEqual(master1.synchronizer.stats.headers_downloaded, 5 + 8)
+            self.assertEqual(master1.synchronizer.stats.ancestor_lookup_requests, 2)

--- a/quarkchain/cluster/tests/test_utils.py
+++ b/quarkchain/cluster/tests/test_utils.py
@@ -277,6 +277,7 @@ def create_test_clusters(
     remote_mining=False,
     small_coinbase=False,
     loadtest_accounts=None,
+    connect=True,               # connect the bootstrap node by default
 ):
     # so we can have lower minimum diff
     easy_diff_calc = EthDifficultyCalculator(
@@ -344,7 +345,7 @@ def create_test_clusters(
         # Start simple network and connect to seed host
         network = SimpleNetwork(env, master_server, loop)
         network.start_server()
-        if i != 0:
+        if connect and i != 0:
             peer = call_async(network.connect("127.0.0.1", bootstrap_port))
         else:
             peer = None
@@ -393,6 +394,7 @@ class ClusterContext(ContextDecorator):
         remote_mining=False,
         small_coinbase=False,
         loadtest_accounts=None,
+        connect=True,
     ):
         self.num_cluster = num_cluster
         self.genesis_account = genesis_account
@@ -403,6 +405,7 @@ class ClusterContext(ContextDecorator):
         self.remote_mining = remote_mining
         self.small_coinbase = small_coinbase
         self.loadtest_accounts = loadtest_accounts
+        self.connect = connect
 
         check(is_p2(self.num_slaves))
         check(is_p2(self.shard_size))
@@ -418,6 +421,7 @@ class ClusterContext(ContextDecorator):
             remote_mining=self.remote_mining,
             small_coinbase=self.small_coinbase,
             loadtest_accounts=self.loadtest_accounts,
+            connect=self.connect,
         )
         return self.cluster_list
 


### PR DESCRIPTION
Using n-ary method to lookup ancestor of local and remote chains with the following benefits:
- Should take about at most 2 RPCs to locate the best ancestor if we download 500 headers per RPC.  The first RPC will divide at most 22500 blocks to 499 bins with each bin has at most 46 elements.  The next RPC could local the ancestor directly.
- The code assumes the remote chain may be organized significantly.  Special handling is required (currently we just abort the sync)
- After locating ancestor, we will download the blocks from ancestor to the remote tip, and make incremental sync progress.