### PR TITLE
add private jsonrpc for obtaining local peer routing table

### DIFF
--- a/quarkchain/cluster/jsonrpc.py
+++ b/quarkchain/cluster/jsonrpc.py
@@ -10,7 +10,7 @@ from async_armor import armor
 from decorator import decorator
 from jsonrpcserver import config
 from jsonrpcserver.async_methods import AsyncMethods
-from jsonrpcserver.exceptions import InvalidParams
+from jsonrpcserver.exceptions import InvalidParams, InvalidRequest
 
 from quarkchain.cluster.master import MasterServer
 from quarkchain.core import (
@@ -26,6 +26,7 @@ from quarkchain.core import (
 )
 from quarkchain.evm.transactions import Transaction as EvmTransaction
 from quarkchain.evm.utils import denoms, is_numeric
+from quarkchain.p2p.p2p_manager import P2PManager
 from quarkchain.utils import Logger, token_id_decode
 
 # defaults
@@ -1109,6 +1110,15 @@ class JSONRPCServer:
     @private_methods.add
     async def getJrpcCalls(self):
         return self.counters
+
+    @private_methods.add
+    async def getKadRoutingTable(self):
+        """ returns a list of nodes in the p2p discovery routing table, in the enode format
+        eg. "enode://PUBKEY@IP:PORT"
+        """
+        if not isinstance(self.master.network, P2PManager):
+            raise InvalidRequest("network is not P2P")
+        return [n.to_uri() for n in self.master.network.server.discovery.proto.routing]
 
     @staticmethod
     def _convert_eth_call_data(data, shard):

--- a/quarkchain/p2p/kademlia.py
+++ b/quarkchain/p2p/kademlia.py
@@ -123,6 +123,11 @@ class Node:
     def __hash__(self) -> int:
         return hash(self.pubkey)
 
+    def to_uri(self):
+        return "enode://{}@{}:{}".format(
+            self.pubkey.to_hex(), self.address.ip, self.address.tcp_port
+        )
+
 
 @total_ordering
 class KBucket(Sized):


### PR DESCRIPTION
test plan:
run `python cluster.py`, this only runs SimpleNetwork so the routing table is unavailable
with `python cluster.py --cluster_config /Users/dll/chain/pyquarkchain/testnet/2.5/cluster_config_template.json`:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"getKadRoutingTable","id":0}' http://127.0.0.1:38491
{"jsonrpc": "2.0", "result": ["enode://0x5eeaae0986bb6d7e36fd3a23ae15ca371ba9e88e8545825ed587a472b5ec417c3f757ee46e643d834a7ff454855cfc28b736b8b76f2eae3ebbe61028b777971c@35.155.213.180:38291",
...
```
looks good, use this and #512 to get the whole network
fixes #507 