### PR TITLE
add get minor block headers with skip p2p command

### DIFF
--- a/quarkchain/cluster/p2p_commands.py
+++ b/quarkchain/cluster/p2p_commands.py
@@ -166,6 +166,55 @@ class GetRootBlockHeaderListWithSkipRequest(Serializable):
         )
 
 
+class GetMinorBlockHeaderListWithSkipRequest(Serializable):
+    FIELDS = [
+        ("type", uint8),       # 0 block hash, 1 block height
+        ("data", hash256),
+        ("branch", Branch),
+        ("limit", uint32),
+        ("skip", uint32),
+        ("direction", uint8),  # 0 to genesis, 1 to tip
+    ]
+
+    def __init__(self, type, data, branch, limit, skip, direction):
+        self.type = type
+        self.data = data
+        self.branch = branch
+        self.limit = limit
+        self.skip = skip
+        self.direction = direction
+
+    def get_height(self):
+        check(self.type == 1)
+        return int.from_bytes(self.data, byteorder="big")
+
+    def get_hash(self):
+        check(self.type == 0)
+        return self.data
+
+    @staticmethod
+    def create_for_height(height, branch, limit, skip, direction):
+        return GetMinorBlockHeaderListWithSkipRequest(
+            1,
+            height.to_bytes(32, byteorder="big"),
+            branch,
+            limit,
+            skip,
+            direction
+        )
+
+    @staticmethod
+    def create_for_hash(hash, branch, limit, skip, direction):
+        return GetMinorBlockHeaderListWithSkipRequest(
+            0,
+            hash,
+            branch,
+            limit,
+            skip,
+            direction
+        )
+
+
 class GetRootBlockListRequest(Serializable):
     """ RPC to get a root block list.  The RPC should be only fired by root chain
     """
@@ -281,6 +330,8 @@ class CommandOp:
     GET_ROOT_BLOCK_HEADER_LIST_WITH_SKIP_REQUEST = 16
     GET_ROOT_BLOCK_HEADER_LIST_WITH_SKIP_RESPONSE = 17
     NEW_ROOT_BLOCK = 18
+    GET_MINOR_BLOCK_HEADER_LIST_WITH_SKIP_REQUEST = 19
+    GET_MINOR_BLOCK_HEADER_LIST_WITH_SKIP_RESPONSE = 20
 
 
 OP_SERIALIZER_MAP = {
@@ -303,4 +354,6 @@ OP_SERIALIZER_MAP = {
     CommandOp.GET_ROOT_BLOCK_HEADER_LIST_WITH_SKIP_REQUEST: GetRootBlockHeaderListWithSkipRequest,
     CommandOp.GET_ROOT_BLOCK_HEADER_LIST_WITH_SKIP_RESPONSE: GetRootBlockHeaderListResponse,
     CommandOp.NEW_ROOT_BLOCK: NewRootBlockCommand,
+    CommandOp.GET_MINOR_BLOCK_HEADER_LIST_WITH_SKIP_REQUEST: GetMinorBlockHeaderListWithSkipRequest,
+    CommandOp.GET_MINOR_BLOCK_HEADER_LIST_WITH_SKIP_RESPONSE: GetMinorBlockHeaderListResponse,
 }

--- a/quarkchain/cluster/shard_db_operator.py
+++ b/quarkchain/cluster/shard_db_operator.py
@@ -344,6 +344,13 @@ class ShardDbOperator(TransactionHistoryMixin):
         block_hash = self.db.get(key)
         return self.get_minor_block_by_hash(block_hash)
 
+    def get_minor_block_header_by_height(self, height) -> Optional[MinorBlock]:
+        key = b"mi_%d" % height
+        if key not in self.db:
+            return None
+        block_hash = self.db.get(key)
+        return self.get_minor_block_header_by_hash(block_hash)
+
     def get_block_count_by_height(self, height):
         """ Return the total number of blocks with the given height"""
         return len(self.height_to_minor_block_hashes.setdefault(height, set()))

--- a/quarkchain/cluster/tests/test_cluster.py
+++ b/quarkchain/cluster/tests/test_cluster.py
@@ -1122,15 +1122,15 @@ class TestCluster(unittest.TestCase):
             # Add a root block first so that later minor blocks referring to this root
             # can be broadcasted to other shards
             minor_block_header_list = [shard.state.header_tip]
+            branch = shard.state.header_tip.branch
             for i in range(10):
                 b = shard.state.create_block_to_mine()
                 call_async(master.add_raw_minor_block(b.header.branch, b.serialize()))
-                branch = b.header.branch
                 minor_block_header_list.append(b.header)
 
             self.assertEqual(minor_block_header_list[-1].height, 10)
 
-            peer = next(iter(next(iter(clusters[1].slave_list[0].shards.values())).peers.values()))
+            peer = next(iter(clusters[1].slave_list[0].shards[branch].peers.values()))
 
             # Test Case 1 ###################################################
             op, resp, rpc_id = call_async(

--- a/quarkchain/cluster/tests/test_cluster.py
+++ b/quarkchain/cluster/tests/test_cluster.py
@@ -15,6 +15,7 @@ from quarkchain.utils import call_async, assert_true_with_timeout
 from quarkchain.cluster.p2p_commands import (
     CommandOp,
     GetRootBlockHeaderListWithSkipRequest,
+    GetMinorBlockHeaderListWithSkipRequest,
     Direction,
 )
 
@@ -1108,3 +1109,204 @@ class TestCluster(unittest.TestCase):
             self.assertEqual(master1.synchronizer.stats.blocks_downloaded, 8)
             self.assertEqual(master1.synchronizer.stats.headers_downloaded, 5 + 8)
             self.assertEqual(master1.synchronizer.stats.ancestor_lookup_requests, 2)
+
+    def test_get_minor_block_headers_with_skip(self):
+        """ Test the broadcast is only done to the neighbors """
+        id1 = Identity.create_random_identity()
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+
+        with ClusterContext(2, acc1) as clusters:
+            master = clusters[0].master
+            shard = next(iter(clusters[0].slave_list[0].shards.values()))
+
+            # Add a root block first so that later minor blocks referring to this root
+            # can be broadcasted to other shards
+            minor_block_header_list = [shard.state.header_tip]
+            for i in range(10):
+                b = shard.state.create_block_to_mine()
+                call_async(master.add_raw_minor_block(b.header.branch, b.serialize()))
+                branch = b.header.branch
+                minor_block_header_list.append(b.header)
+
+            self.assertEqual(minor_block_header_list[-1].height, 10)
+
+            peer = next(iter(next(iter(clusters[1].slave_list[0].shards.values())).peers.values()))
+
+            # Test Case 1 ###################################################
+            op, resp, rpc_id = call_async(
+                peer.write_rpc_request(
+                    op=CommandOp.GET_MINOR_BLOCK_HEADER_LIST_WITH_SKIP_REQUEST,
+                    cmd=GetMinorBlockHeaderListWithSkipRequest.create_for_height(
+                        height=1, branch=branch, skip=1, limit=3, direction=Direction.TIP
+                    ),
+                )
+            )
+            self.assertEqual(len(resp.block_header_list), 3)
+            self.assertEqual(resp.block_header_list[0], minor_block_header_list[1])
+            self.assertEqual(resp.block_header_list[1], minor_block_header_list[3])
+            self.assertEqual(resp.block_header_list[2], minor_block_header_list[5])
+
+            op, resp, rpc_id = call_async(
+                peer.write_rpc_request(
+                    op=CommandOp.GET_MINOR_BLOCK_HEADER_LIST_WITH_SKIP_REQUEST,
+                    cmd=GetMinorBlockHeaderListWithSkipRequest.create_for_hash(
+                        hash=minor_block_header_list[1].get_hash(),
+                        branch=branch,
+                        skip=1,
+                        limit=3,
+                        direction=Direction.TIP,
+                    ),
+                )
+            )
+            self.assertEqual(len(resp.block_header_list), 3)
+            self.assertEqual(resp.block_header_list[0], minor_block_header_list[1])
+            self.assertEqual(resp.block_header_list[1], minor_block_header_list[3])
+            self.assertEqual(resp.block_header_list[2], minor_block_header_list[5])
+
+            # Test Case 2 ###################################################
+            op, resp, rpc_id = call_async(
+                peer.write_rpc_request(
+                    op=CommandOp.GET_MINOR_BLOCK_HEADER_LIST_WITH_SKIP_REQUEST,
+                    cmd=GetMinorBlockHeaderListWithSkipRequest.create_for_height(
+                        height=2, branch=branch, skip=2, limit=4, direction=Direction.TIP
+                    ),
+                )
+            )
+            self.assertEqual(len(resp.block_header_list), 3)
+            self.assertEqual(resp.block_header_list[0], minor_block_header_list[2])
+            self.assertEqual(resp.block_header_list[1], minor_block_header_list[5])
+            self.assertEqual(resp.block_header_list[2], minor_block_header_list[8])
+
+            op, resp, rpc_id = call_async(
+                peer.write_rpc_request(
+                    op=CommandOp.GET_MINOR_BLOCK_HEADER_LIST_WITH_SKIP_REQUEST,
+                    cmd=GetMinorBlockHeaderListWithSkipRequest.create_for_hash(
+                        hash=minor_block_header_list[2].get_hash(),
+                        branch=branch,
+                        skip=2,
+                        limit=4,
+                        direction=Direction.TIP,
+                    ),
+                )
+            )
+            self.assertEqual(len(resp.block_header_list), 3)
+            self.assertEqual(resp.block_header_list[0], minor_block_header_list[2])
+            self.assertEqual(resp.block_header_list[1], minor_block_header_list[5])
+            self.assertEqual(resp.block_header_list[2], minor_block_header_list[8])
+
+            # Test Case 3 ###################################################
+            op, resp, rpc_id = call_async(
+                peer.write_rpc_request(
+                    op=CommandOp.GET_MINOR_BLOCK_HEADER_LIST_WITH_SKIP_REQUEST,
+                    cmd=GetMinorBlockHeaderListWithSkipRequest.create_for_height(
+                        height=6, branch=branch, skip=0, limit=100, direction=Direction.TIP
+                    ),
+                )
+            )
+            self.assertEqual(len(resp.block_header_list), 5)
+            self.assertEqual(resp.block_header_list[0], minor_block_header_list[6])
+            self.assertEqual(resp.block_header_list[1], minor_block_header_list[7])
+            self.assertEqual(resp.block_header_list[2], minor_block_header_list[8])
+            self.assertEqual(resp.block_header_list[3], minor_block_header_list[9])
+            self.assertEqual(resp.block_header_list[4], minor_block_header_list[10])
+
+            op, resp, rpc_id = call_async(
+                peer.write_rpc_request(
+                    op=CommandOp.GET_MINOR_BLOCK_HEADER_LIST_WITH_SKIP_REQUEST,
+                    cmd=GetMinorBlockHeaderListWithSkipRequest.create_for_hash(
+                        hash=minor_block_header_list[6].get_hash(),
+                        branch=branch,
+                        skip=0,
+                        limit=100,
+                        direction=Direction.TIP,
+                    ),
+                )
+            )
+            self.assertEqual(len(resp.block_header_list), 5)
+            self.assertEqual(resp.block_header_list[0], minor_block_header_list[6])
+            self.assertEqual(resp.block_header_list[1], minor_block_header_list[7])
+            self.assertEqual(resp.block_header_list[2], minor_block_header_list[8])
+            self.assertEqual(resp.block_header_list[3], minor_block_header_list[9])
+            self.assertEqual(resp.block_header_list[4], minor_block_header_list[10])
+
+            # Test Case 4 ###################################################
+            op, resp, rpc_id = call_async(
+                peer.write_rpc_request(
+                    op=CommandOp.GET_MINOR_BLOCK_HEADER_LIST_WITH_SKIP_REQUEST,
+                    cmd=GetMinorBlockHeaderListWithSkipRequest.create_for_height(
+                        height=2, branch=branch, skip=2, limit=4, direction=Direction.GENESIS
+                    ),
+                )
+            )
+            self.assertEqual(len(resp.block_header_list), 1)
+            self.assertEqual(resp.block_header_list[0], minor_block_header_list[2])
+            op, resp, rpc_id = call_async(
+                peer.write_rpc_request(
+                    op=CommandOp.GET_MINOR_BLOCK_HEADER_LIST_WITH_SKIP_REQUEST,
+                    cmd=GetMinorBlockHeaderListWithSkipRequest.create_for_hash(
+                        hash=minor_block_header_list[2].get_hash(),
+                        branch=branch,
+                        skip=2,
+                        limit=4,
+                        direction=Direction.GENESIS,
+                    ),
+                )
+            )
+            self.assertEqual(len(resp.block_header_list), 1)
+            self.assertEqual(resp.block_header_list[0], minor_block_header_list[2])
+
+            # Test Case 5 ###################################################
+            op, resp, rpc_id = call_async(
+                peer.write_rpc_request(
+                    op=CommandOp.GET_MINOR_BLOCK_HEADER_LIST_WITH_SKIP_REQUEST,
+                    cmd=GetMinorBlockHeaderListWithSkipRequest.create_for_height(
+                        height=11, branch=branch, skip=2, limit=4, direction=Direction.GENESIS
+                    ),
+                )
+            )
+            self.assertEqual(len(resp.block_header_list), 0)
+
+            op, resp, rpc_id = call_async(
+                peer.write_rpc_request(
+                    op=CommandOp.GET_MINOR_BLOCK_HEADER_LIST_WITH_SKIP_REQUEST,
+                    cmd=GetMinorBlockHeaderListWithSkipRequest.create_for_hash(
+                        hash=bytes(32), branch=branch, skip=2, limit=4, direction=Direction.GENESIS
+                    ),
+                )
+            )
+            self.assertEqual(len(resp.block_header_list), 0)
+
+            # Test Case 6 ###################################################
+            op, resp, rpc_id = call_async(
+                peer.write_rpc_request(
+                    op=CommandOp.GET_MINOR_BLOCK_HEADER_LIST_WITH_SKIP_REQUEST,
+                    cmd=GetMinorBlockHeaderListWithSkipRequest.create_for_height(
+                        height=8, branch=branch, skip=1, limit=5, direction=Direction.GENESIS
+                    ),
+                )
+            )
+            self.assertEqual(len(resp.block_header_list), 5)
+            self.assertEqual(resp.block_header_list[0], minor_block_header_list[8])
+            self.assertEqual(resp.block_header_list[1], minor_block_header_list[6])
+            self.assertEqual(resp.block_header_list[2], minor_block_header_list[4])
+            self.assertEqual(resp.block_header_list[3], minor_block_header_list[2])
+            self.assertEqual(resp.block_header_list[4], minor_block_header_list[0])
+
+            op, resp, rpc_id = call_async(
+                peer.write_rpc_request(
+                    op=CommandOp.GET_MINOR_BLOCK_HEADER_LIST_WITH_SKIP_REQUEST,
+                    cmd=GetMinorBlockHeaderListWithSkipRequest.create_for_hash(
+                        hash=minor_block_header_list[8].get_hash(),
+                        branch=branch,
+                        skip=1,
+                        limit=5,
+                        direction=Direction.GENESIS,
+                    ),
+                )
+            )
+            self.assertEqual(len(resp.block_header_list), 5)
+            self.assertEqual(resp.block_header_list[0], minor_block_header_list[8])
+            self.assertEqual(resp.block_header_list[1], minor_block_header_list[6])
+            self.assertEqual(resp.block_header_list[2], minor_block_header_list[4])
+            self.assertEqual(resp.block_header_list[3], minor_block_header_list[2])
+            self.assertEqual(resp.block_header_list[4], minor_block_header_list[0])


### PR DESCRIPTION
Implement server-side command to get minor block headers from the canonical chain - either by height and hash.  May replace existing minor block synchronizer logic in future (not the plan for mainnet launch).