### PR TITLE
Update mining for testnet26

### DIFF
--- a/quarkchain/tools/external_miner.py
+++ b/quarkchain/tools/external_miner.py
@@ -1,9 +1,7 @@
 import argparse
 import copy
 import functools
-import json
 import logging
-import os
 import random
 import signal
 import threading

--- a/quarkchain/tools/external_miner_manager.sh
+++ b/quarkchain/tools/external_miner_manager.sh
@@ -30,12 +30,10 @@ done
 shift $((OPTIND -1))
 
 # TODO: following full shard key encoding only works for testnet2.4
-shards=(1 65537 131073 196609 262146 262147 327682 327683)
 shards_by_process=()
-i=0
-for shard in "${shards[@]}"; do
-	shards_by_process[$(( i % $process ))]+=" $shard"
-	i=$(( $i + 1 ))
+for chain_id in $(seq 0 7); do
+    shard=16#${chain_id}0001
+	shards_by_process[$(( chain_id % $process ))]+=" $(($shard))"
 done
 
 miner_py_path="$( cd "$(dirname "$0")" ; pwd -P )/external_miner.py"


### PR DESCRIPTION
verified it works
```bash
quarkchain/tools/external_miner_manager.sh -c ~/Documents/config-26.json -p 8 -h localhost
~/pyquarkchain/quarkchain/tools/external_miner.py --host localhost --config ~/Documents/config-26.json --worker 1 --shards 1
~/pyquarkchain/quarkchain/tools/external_miner.py --host localhost --config ~/Documents/config-26.json --worker 1 --shards 65537
~/pyquarkchain/quarkchain/tools/external_miner.py --host localhost --config ~/Documents/config-26.json --worker 1 --shards 131073
~/pyquarkchain/quarkchain/tools/external_miner.py --host localhost --config ~/Documents/config-26.json --worker 1 --shards 196609
~/pyquarkchain/quarkchain/tools/external_miner.py --host localhost --config ~/Documents/config-26.json --worker 1 --shards 262145
~/pyquarkchain/quarkchain/tools/external_miner.py --host localhost --config ~/Documents/config-26.json --worker 1 --shards 327681
~/pyquarkchain/quarkchain/tools/external_miner.py --host localhost --config ~/Documents/config-26.json --worker 1 --shards 393217
~/pyquarkchain/quarkchain/tools/external_miner.py --host localhost --config ~/Documents/config-26.json --worker 1 --shards 458753
```