### PR TITLE
Fix PoSW rolling window counting

### DIFF
--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -331,10 +331,9 @@ class ShardState:
         if self.shard_config.POSW_CONFIG.ENABLED and header_hash is not None:
             disallow_map = dict()
             length = self.shard_config.POSW_CONFIG.WINDOW_SIZE
+            total_stakes = self.shard_config.POSW_CONFIG.TOTAL_STAKE_PER_BLOCK
             for k, v in self._get_posw_coinbase_blockcnt(header_hash, length).items():
-                disallow_map[k] = (
-                    v * self.shard_config.POSW_CONFIG.TOTAL_STAKE_PER_BLOCK
-                )
+                disallow_map[k] = v * total_stakes
             state.sender_disallow_map = disallow_map
         return state
 
@@ -945,12 +944,10 @@ class ShardState:
             if self.shard_config.POSW_CONFIG.ENABLED:
                 disallow_map = dict()
                 length = self.shard_config.POSW_CONFIG.WINDOW_SIZE
-                for k, v in self._get_posw_coinbase_blockcnt(
-                    block_hash, length
-                ).items():
-                    disallow_map[k] = (
-                        v * self.shard_config.POSW_CONFIG.TOTAL_STAKE_PER_BLOCK
-                    )
+                total_stakes = self.shard_config.POSW_CONFIG.TOTAL_STAKE_PER_BLOCK
+                block_cnt = self._get_posw_coinbase_blockcnt(block_hash, length)
+                for k, v in block_cnt.items():
+                    disallow_map[k] = v * total_stakes
                 evm_state.sender_disallow_map = disallow_map
 
             self.__update_tip(block, evm_state=evm_state)

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -2,7 +2,7 @@ import asyncio
 import functools
 import json
 import time
-from collections import Counter, deque
+from collections import Counter, deque, defaultdict
 from fractions import Fraction
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -252,7 +252,9 @@ class ShardState:
         # new blocks that passed POW validation and should be made available to whole network
         self.new_block_header_pool = dict()
         # header hash -> (height, [coinbase address]) during previous blocks (ascending)
-        self.coinbase_addr_cache = dict()  # type: Dict[bytes, Tuple[int, Deque[bytes]]]
+        self.coinbase_addr_cache = defaultdict(
+            dict
+        )  # type: Dict[int, Dict[bytes, Tuple[int, Deque[bytes]]]]
         self.genesis_token_id = self.env.quark_chain_config.genesis_token
         self.local_fee_rate = (
             1 - self.env.quark_chain_config.reward_tax_rate
@@ -328,8 +330,11 @@ class ShardState:
 
         if self.shard_config.POSW_CONFIG.ENABLED and header_hash is not None:
             disallow_map = dict()
-            for k, v in self._get_posw_coinbase_blockcnt(header_hash).items():
-                disallow_map[k] = v * self.shard_config.POSW_CONFIG.TOTAL_STAKE_PER_BLOCK
+            length = self.shard_config.POSW_CONFIG.WINDOW_SIZE
+            for k, v in self._get_posw_coinbase_blockcnt(header_hash, length).items():
+                disallow_map[k] = (
+                    v * self.shard_config.POSW_CONFIG.TOTAL_STAKE_PER_BLOCK
+                )
             state.sender_disallow_map = disallow_map
         return state
 
@@ -939,8 +944,13 @@ class ShardState:
             # Safe to update PoSW blacklist here
             if self.shard_config.POSW_CONFIG.ENABLED:
                 disallow_map = dict()
-                for k, v in self._get_posw_coinbase_blockcnt(block_hash).items():
-                    disallow_map[k] = v * self.shard_config.POSW_CONFIG.TOTAL_STAKE_PER_BLOCK
+                length = self.shard_config.POSW_CONFIG.WINDOW_SIZE
+                for k, v in self._get_posw_coinbase_blockcnt(
+                    block_hash, length
+                ).items():
+                    disallow_map[k] = (
+                        v * self.shard_config.POSW_CONFIG.TOTAL_STAKE_PER_BLOCK
+                    )
                 evm_state.sender_disallow_map = disallow_map
 
             self.__update_tip(block, evm_state=evm_state)
@@ -1719,8 +1729,9 @@ class ShardState:
         header = curr_block.header
         height = header.height
         prev_hash = header.hash_prev_minor_block
-        if prev_hash in self.coinbase_addr_cache:  # mem cache hit
-            _, addrs = self.coinbase_addr_cache[prev_hash]
+        cache = self.coinbase_addr_cache[length]
+        if prev_hash in cache:  # mem cache hit
+            _, addrs = cache[prev_hash]
             addrs = addrs.copy()
             if len(addrs) == length:
                 addrs.popleft()
@@ -1735,27 +1746,27 @@ class ShardState:
                     header.hash_prev_minor_block
                 )
                 check(header is not None, "mysteriously missing block")
-        self.coinbase_addr_cache[header_hash] = (height, addrs)
+        cache[header_hash] = (height, addrs)
         # in case cached too much, clean up
-        if len(self.coinbase_addr_cache) > 128:  # size around 640KB if window size 256
-            self.coinbase_addr_cache = {
+        if len(cache) > 128:  # size around 640KB if window size 256
+            self.coinbase_addr_cache[length] = {
                 k: (h, addrs)
-                for k, (h, addrs) in self.coinbase_addr_cache.items()
+                for k, (h, addrs) in cache.items()
                 if h > height - 16  # keep most recent ones
             }
+
+        check(len(addrs) <= length)
         return list(addrs)
 
     @functools.lru_cache(maxsize=16)
     def _get_posw_coinbase_blockcnt(
-        self, header_hash: bytes, length: int = None
+        self, header_hash: bytes, length: int
     ) -> Dict[bytes, int]:
         """ PoSW needed function: get coinbase addresses up until the given block
         hash (inclusive) along with block counts within the PoSW window.
 
         Raise ValueError if anything goes wrong.
         """
-        if length is None:
-            length = self.shard_config.POSW_CONFIG.WINDOW_SIZE
         coinbase_addrs = self.__get_coinbase_addresses_until_block(header_hash, length)
         return Counter(coinbase_addrs)
 

--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -2047,11 +2047,12 @@ class TestShardState(unittest.TestCase):
             Identity.create_random_identity(), full_shard_key=0
         )
         env = get_test_env(genesis_account=acc, genesis_minor_quarkash=0)
+        posw_window_len = 2
         state = create_default_shard_state(env=env, shard_id=0)
 
         m = state.get_tip().create_block_to_append(address=acc)
         coinbase_blockcnt = state._get_posw_coinbase_blockcnt(
-            m.header.hash_prev_minor_block
+            m.header.hash_prev_minor_block, length=posw_window_len
         )
         self.assertEqual(len(coinbase_blockcnt), 1)  # Genesis
         state.finalize_and_add_block(m)
@@ -2062,7 +2063,7 @@ class TestShardState(unittest.TestCase):
             random_acc = Address.create_random_account(full_shard_key=0)
             m = state.get_tip().create_block_to_append(address=random_acc)
             coinbase_blockcnt = state._get_posw_coinbase_blockcnt(
-                m.header.hash_prev_minor_block
+                m.header.hash_prev_minor_block, length=posw_window_len
             )
             self.assertEqual(len(coinbase_blockcnt), 2)
             # Count should all equal 1
@@ -2074,7 +2075,34 @@ class TestShardState(unittest.TestCase):
             prev_addr = random_acc.recipient
 
         # Cached should have certain items
-        self.assertEqual(len(state.coinbase_addr_cache), 5)
+        self.assertEqual(len(state.coinbase_addr_cache), 1)
+        self.assertEqual(len(state.coinbase_addr_cache[2]), 5)
+
+    def test_posw_coinbase_address_count_by_diff_length(self):
+        acc = Address.create_from_identity(
+            Identity.create_random_identity(), full_shard_key=0
+        )
+        env = get_test_env(genesis_account=acc, genesis_minor_quarkash=0)
+        state = create_default_shard_state(env=env, shard_id=0)
+
+        m = state.get_tip().create_block_to_append(address=acc)
+        state.finalize_and_add_block(m)
+
+        # Note PoSW window size is 2
+        for i in range(4):
+            random_acc = Address.create_random_account(full_shard_key=0)
+            m = state.get_tip().create_block_to_append(address=random_acc)
+            state.finalize_and_add_block(m)
+
+        sum_cnt = lambda d: sum(d.values())
+        for length in range(1, 5):
+            coinbase_blockcnt = state._get_posw_coinbase_blockcnt(
+                m.header.get_hash(), length
+            )
+            self.assertEqual(sum_cnt(coinbase_blockcnt), length)
+
+        # Make sure internal cache state is correct
+        self.assertEqual(len(state.coinbase_addr_cache), 4)
 
     def test_posw_coinbase_lockup(self):
         id1 = Identity.create_random_identity()
@@ -2161,15 +2189,11 @@ class TestShardState(unittest.TestCase):
         self.assertEqual(len(state.evm_state.sender_disallow_map), 2)
         self.assertEqual(
             state.get_token_balance(acc1.recipient, self.genesis_token),
-            state.shard_config.COINBASE_AMOUNT // 2         # tax rate is 0.5
+            state.shard_config.COINBASE_AMOUNT // 2,  # tax rate is 0.5
         )
 
         self.assertEqual(
-            state.evm_state.sender_disallow_map,
-            {
-                bytes(20): 2,
-                acc1.recipient: 2,
-            }
+            state.evm_state.sender_disallow_map, {bytes(20): 2, acc1.recipient: 2}
         )
 
         # Try to send money from that account
@@ -2191,15 +2215,11 @@ class TestShardState(unittest.TestCase):
         state.finalize_and_add_block(m)
         self.assertEqual(
             state.get_token_balance(acc1.recipient, self.genesis_token),
-            state.shard_config.COINBASE_AMOUNT // 2 - 1         # tax rate is 0.5
+            state.shard_config.COINBASE_AMOUNT // 2 - 1,  # tax rate is 0.5
         )
         self.assertEqual(
             state.evm_state.sender_disallow_map,
-            {
-                bytes(20): 2,
-                acc1.recipient: 2,
-                acc2.recipient: 2,
-            }
+            {bytes(20): 2, acc1.recipient: 2, acc2.recipient: 2},
         )
 
         tx1 = create_transfer_transaction(
@@ -2220,19 +2240,15 @@ class TestShardState(unittest.TestCase):
         state.finalize_and_add_block(m)
         self.assertEqual(
             state.get_token_balance(acc1.recipient, self.genesis_token),
-            state.shard_config.COINBASE_AMOUNT // 2 - 1         # tax rate is 0.5
+            state.shard_config.COINBASE_AMOUNT // 2 - 1,  # tax rate is 0.5
         )
         self.assertEqual(
             state.get_token_balance(acc2.recipient, self.genesis_token),
-            state.shard_config.COINBASE_AMOUNT          # tax rate is 0.5
+            state.shard_config.COINBASE_AMOUNT,  # tax rate is 0.5
         )
         self.assertEqual(
             state.evm_state.sender_disallow_map,
-            {
-                bytes(20): 2,
-                acc1.recipient: 2,
-                acc2.recipient: 4,
-            }
+            {bytes(20): 2, acc1.recipient: 2, acc2.recipient: 4},
         )
 
         tx2 = create_transfer_transaction(

--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -2085,10 +2085,6 @@ class TestShardState(unittest.TestCase):
         env = get_test_env(genesis_account=acc, genesis_minor_quarkash=0)
         state = create_default_shard_state(env=env, shard_id=0)
 
-        m = state.get_tip().create_block_to_append(address=acc)
-        state.finalize_and_add_block(m)
-
-        # Note PoSW window size is 2
         for i in range(4):
             random_acc = Address.create_random_account(full_shard_key=0)
             m = state.get_tip().create_block_to_append(address=random_acc)


### PR DESCRIPTION
fixes #539 

**symptom**

nodes fail to validate minor blocks, because some think the difficulty should be lowered by PoSW while the rest don't.

**surface**

function `_get_posw_coinbase_blockcnt` should always return a dictionary of total counts less than given param `length`. but in problematic situations we are finding the contrary. 

**root cause**

when calculating how many blocks have been mined by a coinbase address, we use a rolling window cache to avoid duplicate counting. 

however we actually need 2 kinds of such counting with **different lengths** (they are off-by-1), while the cache is being shared. hence the rolling logic could break.

**fix**

make the rolling window cache dependent also on the `length` param so they rolling logic won't interfere.