### PR TITLE
Enforce order of inited shard IDs

### DIFF
--- a/quarkchain/config.py
+++ b/quarkchain/config.py
@@ -406,7 +406,7 @@ class QuarkChainConfig(BaseConfig):
         for full_shard_id, config in self.shards.items():
             if config.GENESIS.ROOT_HEIGHT < root_height:
                 ids.append(full_shard_id)
-        return ids
+        return sorted(ids)
 
     @property
     def guardian_public_key(self) -> KeyAPI.PublicKey:


### PR DESCRIPTION
we actually rely on the order such that full shard ID is monotonically increasing during validation while python dict won't guarantee the order.

we are just being [lucky](https://stackoverflow.com/a/40007169) that the insertion order is preserved.