### PR TITLE
Fix process hanging during log stream reading

### DIFF
--- a/quarkchain/cluster/cluster.py
+++ b/quarkchain/cluster/cluster.py
@@ -49,10 +49,13 @@ async def run_slave(config_file, id):
 
 async def print_output(prefix, stream):
     while True:
-        line = await stream.readline()
-        if not line:
-            break
-        print("{}: {}".format(prefix, line.decode("ascii").strip()))
+        try:
+            line = await stream.readline()
+            if not line:
+                break
+            print("{}: {}".format(prefix, line.decode("ascii").strip()))
+        except Exception as e:
+            print("{}: reading line exception {}".format(prefix, e))
 
 
 class Cluster:


### PR DESCRIPTION
1. When writing logs using `Logger.info` (say, logging JSONRPC
   requests)
2. Master or slave process calls `asyncio.StreamReader.readline` to get
   the log out
3. However the stream has a buffer limit 64k and will throw exception if
   reached, hence the printing coroutine will crash
4. As a result, the process's pipe may get full because no one is
   consuming, leading the process hang

Fixes #208

******

Many thanks to [Chaitin Tech | 长亭科技](https://www.chaitin.cn/en/) for bringing up this issue and analyzing the root cause. Following is the discussion verbatim

> 关于“恶意request导致RPC模块失效”这个洞，发送超长的request，可以让RPC模块失效，这个问题我们深入研究了一下，定位到了真正的漏洞位置：在jsonrpc.py的__handle函数里有一个Logger.info(request)，master子进程把超长request写入stdout，也就是subprocess.PIPE，然后主进程有print_out任务用asyncio.streams从里面读数据再输出，但asyncio.streams buffer上限是64k，（https://github.com/python/cpython/blob/0afada163c7ef25c3a9d46ed445481fb69f2ecaf/Lib/asyncio/streams.py#L19） ，超过的时候会抛异常LimitOverrunError(‘Separator is found, but chunk is longer than limit’)，这个异常在print_out里没有try住，所以这个task会退出，于是后续master进程的Logger继续向pipe里写，但没有read来清理，写满后（测了一下约2**18bytes）master就hang住了，导致RPC模块无响应。
所以这个问题实际是pipe挂掉了，这个机制引入的攻击面有以下几个：
第一点，产生的危害其实不止rpc失效，应该是master里所有涉及log/print的地方都有可能卡住
第二点，能使print_out抛异常退出的除了readline以外还可以通过line.decode("ascii”)这里来报错，比如log里提供一个中文字符
第三点，能使print_out抛异常的地方除了RPC以外，任何一个可控的log点其实都可以触发print_out异常退出
第四点，危害不限于master，可能可以通过P2P数据包转发给slave，通过slave的log来触发异常退掉slave的print_out
第五点，如果先后把所有slave和master的print_out的任务都抛异常退掉，理论上主进程会执行结束，可能使节点退出
总结：关闭rpc可能无法修复这个漏洞，因为理论上通过P2P和其他方式也可以触发，可以使master/slave不退出只是无响应，或异常退出