### PR TITLE
Fully validate block when handling new block before broadcast

### DIFF
--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -572,9 +572,7 @@ class ShardState:
             header = self.db.get_root_block_header_by_hash(header.hash_prev_block)
         return header == shorter_block_header
 
-    def __validate_block(
-        self, block: MinorBlock, gas_limit=None, xshard_gas_limit=None
-    ):
+    def validate_block(self, block: MinorBlock, gas_limit=None, xshard_gas_limit=None):
         """ Validate a block before running evm transactions
         """
         if block.header.version != 0:
@@ -854,7 +852,7 @@ class ShardState:
 
         x_shard_receive_tx_list = []
         # Throw exception if fail to run
-        self.__validate_block(
+        self.validate_block(
             block, gas_limit=gas_limit, xshard_gas_limit=xshard_gas_limit
         )
         evm_state = self.run_block(


### PR DESCRIPTION
fix QuarkChain/quarkchain-dev#381

note that full block validation doesn't take as long as expected

```
In [0]: db = ShardDbOperator(PersistentDb(path), env, b)
In [1]: mb = db.get_minor_block_by_height(100)
In [2]: ss = ShardState(env, 458753, db=db.db)
In [3]: timeit ss.validate_block(mb)
6.34 ms ± 801 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```