### PR TITLE
Discard underpriced tx in queue

### DIFF
--- a/quarkchain/evm/tests/test_transaction_queue.py
+++ b/quarkchain/evm/tests/test_transaction_queue.py
@@ -119,7 +119,7 @@ class TestTransactionQueue(unittest.TestCase):
         res = q.pop_transaction(nonce_getter_maker(0))
         self.assertIsNone(res)
         # Internal state: total tx size == 5
-        self.assertEqual(len(q.txs) + len(q.aside), 5)
+        self.assertEqual(len(q), 5)
         # Add first valid tx
         q.add_transaction(make_test_tx(nonce=0))
         res = q.pop_transaction(nonce_getter_maker(0))
@@ -129,8 +129,8 @@ class TestTransactionQueue(unittest.TestCase):
         self.assertEqual(res.nonce, 1)
         self.assertEqual(res.gasprice, 5)
         # Verify internal state, still have remaining txs with nonce == 1
-        self.assertEqual(len(q.txs) + len(q.aside), 4)
+        self.assertEqual(len(q), 4)
         # Stale tx will be cleaned up in the future
         res = q.pop_transaction(nonce_getter_maker(100))
         self.assertIsNone(res)
-        self.assertEqual(len(q.txs) + len(q.aside), 0)
+        self.assertEqual(len(q), 0)

--- a/quarkchain/evm/tests/test_transaction_queue.py
+++ b/quarkchain/evm/tests/test_transaction_queue.py
@@ -18,6 +18,10 @@ def make_test_tx(s=100000, g=50, data=b"", nonce=0):
 
 
 class TestTransactionQueue(unittest.TestCase):
+    @staticmethod
+    def _gasprices(q: TransactionQueue):
+        return [i.tx.gasprice for i in q.txs]
+
     def test(self):
         q = TransactionQueue()
         # (startgas, gasprice) pairs
@@ -50,7 +54,6 @@ class TestTransactionQueue(unittest.TestCase):
                 assert (tx.startgas, tx.gasprice) == (expected_s, expected_g)
             else:
                 assert expected_s is expected_g is None
-        print("Test successful")
 
     def test_diff(self):
         tx1 = make_test_tx(data=b"foo")
@@ -134,3 +137,29 @@ class TestTransactionQueue(unittest.TestCase):
         res = q.pop_transaction(nonce_getter_maker(100))
         self.assertIsNone(res)
         self.assertEqual(len(q), 0)
+
+    def test_discard_underpriced_tx(self):
+        q = TransactionQueue(limit=6)
+        # (startgas, gasprice) pairs
+        params = [
+            (100000, 81),
+            (50000, 74),
+            (40000, 65),
+            (60000, 39),
+            (30000, 50),
+            (30000, 80),
+        ]
+        # Add transactions to queue
+        for param in params:
+            q.add_transaction(make_test_tx(s=param[0], g=param[1]))
+
+        prices = self._gasprices(q)
+        self.assertListEqual(prices, [81, 80, 74, 65, 50, 39])
+
+        # Add a lower priced tx is a no-op
+        q.add_transaction(make_test_tx(s=100000, g=38))
+        self.assertListEqual(self._gasprices(q), prices)
+
+        # Add a higher priced tx, should be placed inside the queue
+        q.add_transaction(make_test_tx(s=100000, g=70))
+        self.assertListEqual(self._gasprices(q), [81, 80, 74, 70, 65, 50])

--- a/quarkchain/evm/transaction_queue.py
+++ b/quarkchain/evm/transaction_queue.py
@@ -1,6 +1,4 @@
 import bisect
-import heapq
-import queue
 from functools import total_ordering
 
 from typing import Callable

--- a/quarkchain/evm/transaction_queue.py
+++ b/quarkchain/evm/transaction_queue.py
@@ -39,6 +39,7 @@ class TransactionQueue(object):
             self.txs.pop(-1)
         prio = -tx.gasprice
         ordered_tx = OrderableTx(prio, self.counter, tx)
+        # amortized O(n) cost, ~9x slower than heapq push, may need optimization if becoming a bottleneck
         bisect.insort(self.txs, ordered_tx)
         self.counter += 1
 


### PR DESCRIPTION
closes #573 

note `bisect.insort` has amortized O(n) cost, ~9x slower than heapq push, may need optimization if becoming a bottleneck