### PR TITLE
support x-shard smart contract call

### DIFF
--- a/quarkchain/cluster/shard_db_operator.py
+++ b/quarkchain/cluster/shard_db_operator.py
@@ -52,7 +52,7 @@ class TransactionHistoryMixin:
         data = self.db.get(b"xr_" + minor_block_hash, None)
         if not data:
             return []
-        return CrossShardTransactionList.deserialize(data).tx_list
+        return CrossShardTransactionList.from_data(data).tx_list
 
     def __update_transaction_history_index(self, tx, block_height, index, func):
         evm_tx = tx.tx.to_evm_tx()
@@ -454,7 +454,7 @@ class ShardDbOperator(TransactionHistoryMixin):
         key = b"xShard_" + h
         if key not in self.db:
             return None
-        return CrossShardTransactionList.deserialize(self.db.get(key))
+        return CrossShardTransactionList.from_data(self.db.get(key))
 
     def contain_remote_minor_block_hash(self, h):
         key = b"xShard_" + h

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -1472,18 +1472,11 @@ class ShardState:
             evm_state.delta_token_balance(
                 tx.to_address.recipient, tx.transfer_token_id, tx.value
             )
-            if check_is_from_root_chain:
-                evm_state.gas_used = evm_state.gas_used + (
-                    opcodes.GTXXSHARDCOST if not tx.is_from_root_chain else 0
-                )
-            else:
-                evm_state.gas_used = evm_state.gas_used + (
-                    opcodes.GTXXSHARDCOST if tx.gas_price != 0 else 0
-                )
+            evm_state.gas_used = evm_state.gas_used + gas_used_start
             check(evm_state.gas_used <= evm_state.gas_limit)
 
             xshard_fee = (
-                opcodes.GTXXSHARDCOST
+                gas_used_start
                 * tx.gas_price
                 * self.local_fee_rate.numerator
                 // self.local_fee_rate.denominator

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -1465,7 +1465,7 @@ class ShardState:
 
         if (
             self.env.quark_chain_config.ENABLE_EVM_TIMESTAMP is not None
-            and evm_state.timestamp <= self.env.quark_chain_config.ENABLE_EVM_TIMESTAMP
+            and evm_state.timestamp < self.env.quark_chain_config.ENABLE_EVM_TIMESTAMP
         ):
             tx = deposit
             # FIXME: full_shard_key is not set
@@ -1473,10 +1473,9 @@ class ShardState:
                 tx.to_address.recipient, tx.transfer_token_id, tx.value
             )
             evm_state.gas_used = evm_state.gas_used + gas_used_start
-            check(evm_state.gas_used <= evm_state.gas_limit)
 
             xshard_fee = (
-                gas_used_start
+                opcodes.GTXXSHARDCOST
                 * tx.gas_price
                 * self.local_fee_rate.numerator
                 // self.local_fee_rate.denominator

--- a/quarkchain/config.py
+++ b/quarkchain/config.py
@@ -304,6 +304,7 @@ class QuarkChainConfig(BaseConfig):
     MIN_MINING_GAS_PRICE = 10 ** 9  # lowest gas price to pack tx for mining, 1 Gwei
     XSHARD_GAS_DDOS_FIX_ROOT_HEIGHT = 90000
     DISABLE_POW_CHECK = False
+    XSHARD_ADD_RECIEPT_TIMESTAMP = None
 
     def __init__(self):
         self.loadtest_accounts = (

--- a/quarkchain/core.py
+++ b/quarkchain/core.py
@@ -1029,12 +1029,12 @@ class RootBlock(Serializable):
         )
 
 
-CROSS_SHARD_TRANSACTION_DEPOSIT_SIZE = (
+CROSS_SHARD_TRANSACTION_DEPOSIT_DEPRECATED_SIZE = (
     Constant.HASH_LENGTH + Constant.ADDRESS_LENGTH * 2 + 32 * 2 + 8 * 2 + 1
 )
 
 
-class CrossShardTransactionDepositOld(Serializable):
+class CrossShardTransactionDepositDeprecated(Serializable):
     """ Destination of x-shard tx
     """
 
@@ -1115,9 +1115,12 @@ class CrossShardTransactionDeposit(Serializable):
         self.is_from_root_chain = is_from_root_chain
 
 
-class CrossShardTransactionOldList(Serializable):
+class CrossShardTransactionDeprecatedList(Serializable):
     FIELDS = [
-        ("tx_list", PrependedSizeListSerializer(4, CrossShardTransactionDepositOld))
+        (
+            "tx_list",
+            PrependedSizeListSerializer(4, CrossShardTransactionDepositDeprecated),
+        )
     ]
 
     def __init__(self, tx_list):
@@ -1140,14 +1143,14 @@ class CrossShardTransactionList(Serializable):
         size = bb.get_uint(4)
         if size == 0:
             return True
-        return (len(data) - 4) // size == CROSS_SHARD_TRANSACTION_DEPOSIT_SIZE
+        return (len(data) - 4) == CROSS_SHARD_TRANSACTION_DEPOSIT_DEPRECATED_SIZE * size
 
     @staticmethod
     def from_data(data):
         if not CrossShardTransactionList.is_old_list(data):
             return CrossShardTransactionList.deserialize(data)
 
-        old_list = CrossShardTransactionOldList.deserialize(data)
+        old_list = CrossShardTransactionDeprecatedList.deserialize(data)
         return CrossShardTransactionList(
             [
                 CrossShardTransactionDeposit(

--- a/quarkchain/evm/messages.py
+++ b/quarkchain/evm/messages.py
@@ -196,14 +196,124 @@ def validate_transaction(state, tx):
     return True
 
 
-def apply_message(state, msg=None, **kwargs):
-    if msg is None:
-        msg = vm.Message(**kwargs)
+def apply_transaction_message(
+    state, message, ext, should_create_contract, gas_used_start, add_receipt=True
+):
+    local_fee_rate = (
+        1 - state.qkc_config.reward_tax_rate if state.qkc_config else Fraction(1)
+    )
+
+    contract_address = b""
+
+    evm_gas_start = message.gas
+    if not should_create_contract:
+        result, gas_remained, data = apply_msg(ext, message)
+    else:  # CREATE
+        result, gas_remained, data = create_contract(ext, message)
+        contract_address = (
+            data if data else b""
+        )  # data could be [] when vm failed execution
+
+    assert gas_remained >= 0
+
+    log_tx.debug("TX APPLIED", result=result, gas_remained=gas_remained, data=data)
+
+    gas_used = evm_gas_start - gas_remained + gas_used_start
+
+    if not result:
+        log_tx.debug("TX FAILED", reason="out of gas", gas_remained=gas_remained)
+        output = b""
+        success = 0
+    # Transaction success
     else:
-        assert not kwargs
-    ext = VMExt(state, transactions.Transaction(0, 0, 21000, b"", 0, b""))
-    result, gas_remained, data = apply_msg(ext, msg)
-    return bytearray_to_bytestr(data) if result else None
+        log_tx.debug("TX SUCCESS", data=data)
+        state.refunds += len(set(state.suicides)) * opcodes.GSUICIDEREFUND
+        if state.refunds > 0:
+            log_tx.debug("Refunding", gas_refunded=min(state.refunds, gas_used // 2))
+            gas_remained += min(state.refunds, gas_used // 2)
+            gas_used -= min(state.refunds, gas_used // 2)
+            state.refunds = 0
+        if not should_create_contract:
+            output = bytearray_to_bytestr(data)
+        else:
+            output = data
+        success = 1
+
+    # sell remaining gas
+    state.delta_token_balance(
+        message.sender, message.gas_token_id, ext.tx_gasprice * gas_remained
+    )
+    fee = (
+        ext.tx_gasprice
+        * gas_used
+        * local_fee_rate.numerator
+        // local_fee_rate.denominator
+    )
+    state.delta_token_balance(state.block_coinbase, message.gas_token_id, fee)
+    add_dict(state.block_fee_tokens, {message.gas_token_id: fee})
+
+    state.gas_used += gas_used
+
+    # Clear suicides
+    suicides = state.suicides
+    state.suicides = []
+    for s in suicides:
+        state.set_balances(s, {})
+        state.del_account(s)
+
+    if add_receipt:
+        # Construct a receipt
+        r = mk_receipt(
+            state, success, state.logs, contract_address, state.full_shard_key
+        )
+        state.logs = []
+        state.add_receipt(r)
+
+    return success, output
+
+
+def apply_xshard_desposit(state, deposit, gas_used_start):
+    state.logs = []
+    state.suicides = []
+    state.refunds = 0
+    state.full_shard_key = deposit.to_address.full_shard_key
+
+    state.delta_token_balance(
+        deposit.from_address.recipient, deposit.transfer_token_id, deposit.value
+    )
+
+    message_data = vm.CallData(
+        [safe_ord(x) for x in deposit.message_data], 0, len(deposit.message_data)
+    )
+    message = vm.Message(
+        deposit.from_address.recipient,
+        deposit.to_address.recipient,
+        deposit.value,
+        deposit.gas_remained,
+        message_data,
+        code_address=deposit.to_address.recipient,
+        is_cross_shard=False,
+        from_full_shard_key=deposit.from_address.full_shard_key,
+        to_full_shard_key=deposit.to_address.full_shard_key,
+        tx_hash=deposit.tx_hash,
+        transfer_token_id=deposit.transfer_token_id,
+        gas_token_id=deposit.gas_token_id,
+    )
+
+    # MESSAGE
+    ext = VMExt(
+        state, sender=deposit.from_address.recipient, gas_price=deposit.gas_price
+    )
+
+    return apply_transaction_message(
+        state,
+        message,
+        ext,
+        should_create_contract=deposit.create_contract,
+        gas_used_start=gas_used_start,
+        add_receipt=state.qkc_config.XSHARD_ADD_RECIEPT_TIMESTAMP is not None
+        and state.timestamp >= state.qkc_config.XSHARD_ADD_RECIEPT_TIMESTAMP,
+    )
 
 
 def apply_transaction(state, tx: transactions.Transaction, tx_wrapper_hash):
@@ -253,127 +363,76 @@ def apply_transaction(state, tx: transactions.Transaction, tx_wrapper_hash):
     )
 
     # MESSAGE
-    ext = VMExt(state, tx)
+    ext = VMExt(state, tx.sender, tx.gasprice)
 
     contract_address = b""
     if tx.is_cross_shard:
+        local_gas_used = intrinsic_gas
+        remote_gas_reserved = 0
         if transfer_failure_by_posw_balance_check(ext, message):
-            result = 0
-            gas_remained = 0
-            data = []
+            success = 0
         elif tx.to == b"":
             # TODO: support x-shard tx creation
-            result = 0
-            gas_remained = message.gas
-            data = []
+            success = 0
         else:
             state.delta_token_balance(tx.sender, tx.transfer_token_id, -tx.value)
-            result = 1  # success
-            # TODO: gas_remained should be calcualted in target shard
-            gas_remained = tx.startgas - intrinsic_gas
-            data = []
+            if (
+                state.qkc_config.ENABLE_EVM_TIMESTAMP is None
+                or state.timestamp >= state.qkc_config.ENABLE_EVM_TIMESTAMP
+            ):
+                remote_gas_reserved = tx.startgas - intrinsic_gas
             ext.add_cross_shard_transaction_deposit(
                 quarkchain.core.CrossShardTransactionDeposit(
-                    tx_hash=message.tx_hash,
+                    tx_hash=tx_wrapper_hash,
                     from_address=quarkchain.core.Address(
-                        message.sender, message.from_full_shard_key
+                        tx.sender, tx.from_full_shard_key
                     ),
-                    to_address=quarkchain.core.Address(
-                        message.to, message.to_full_shard_key
-                    ),
-                    value=message.value,
-                    gas_price=ext.tx_gasprice,
-                    gas_token_id=message.gas_token_id,
-                    transfer_token_id=message.transfer_token_id,
+                    to_address=quarkchain.core.Address(tx.to, tx.to_full_shard_key),
+                    value=tx.value,
+                    gas_price=tx.gasprice,
+                    gas_token_id=tx.gas_token_id,
+                    transfer_token_id=tx.transfer_token_id,
+                    message_data=tx.data,
+                    create_contract=False,
+                    gas_remained=remote_gas_reserved,
                 )
             )
-    elif tx.to != b"":
-        result, gas_remained, data = apply_msg(ext, message)
-    else:  # CREATE
-        result, gas_remained, data = create_contract(ext, message)
-        contract_address = (
-            data if data else b""
-        )  # data could be [] when vm failed execution
+            success = 1
+        gas_remained = tx.startgas - local_gas_used - remote_gas_reserved
 
-    assert gas_remained >= 0
-
-    log_tx.debug("TX APPLIED", result=result, gas_remained=gas_remained, data=data)
-
-    gas_used = tx.startgas - gas_remained
-
-    # pay CORRECT tx fee (after tax) to coinbase so that each step of state is accurate
-    # Transaction failed
-    if not result:
-        log_tx.debug(
-            "TX FAILED",
-            reason="out of gas",
-            startgas=tx.startgas,
-            gas_remained=gas_remained,
-        )
+        # Refund
         state.delta_token_balance(
-            tx.sender, tx.gas_token_id, tx.gasprice * gas_remained
+            message.sender, message.gas_token_id, ext.tx_gasprice * gas_remained
         )
+
+        # if x-shard, reserve part of the gas for the target shard miner for fee
         fee = (
             tx.gasprice
-            * gas_used
+            * (local_gas_used - (opcodes.GTXXSHARDCOST if success else 0))
             * local_fee_rate.numerator
             // local_fee_rate.denominator
         )
         state.delta_token_balance(state.block_coinbase, tx.gas_token_id, fee)
-        add_dict(state.block_fee_tokens, {tx.gas_token_id: fee})
-        output = b""
-        success = 0
-    # Transaction success
-    else:
-        log_tx.debug("TX SUCCESS", data=data)
-        state.refunds += len(set(state.suicides)) * opcodes.GSUICIDEREFUND
-        if state.refunds > 0:
-            log_tx.debug("Refunding", gas_refunded=min(state.refunds, gas_used // 2))
-            gas_remained += min(state.refunds, gas_used // 2)
-            gas_used -= min(state.refunds, gas_used // 2)
-            state.refunds = 0
-        # sell remaining gas
-        state.delta_token_balance(
-            tx.sender, tx.gas_token_id, tx.gasprice * gas_remained
+        add_dict(state.block_fee_tokens, {message.gas_token_id: fee})
+
+        output = []
+
+        state.gas_used += local_gas_used
+
+        # Construct a receipt
+        r = mk_receipt(
+            state, success, state.logs, contract_address, state.full_shard_key
         )
-        # if x-shard, reserve part of the gas for the target shard miner
-        fee = (
-            tx.gasprice
-            * (gas_used - (opcodes.GTXXSHARDCOST if tx.is_cross_shard else 0))
-            * local_fee_rate.numerator
-            // local_fee_rate.denominator
-        )
-        state.delta_token_balance(state.block_coinbase, tx.gas_token_id, fee)
-        add_dict(state.block_fee_tokens, {tx.gas_token_id: fee})
-        if tx.to:
-            output = bytearray_to_bytestr(data)
-        else:
-            output = data
-        success = 1
+        state.logs = []
+        state.add_receipt(r)
+        return success, output
 
-        # TODO: check if the destination address is correct, and consume xshard gas of the state
-        # the xshard gas and fee is consumed by destination shard block
-
-    state.gas_used += gas_used
-
-    # Clear suicides
-    suicides = state.suicides
-    state.suicides = []
-    for s in suicides:
-        state.set_balances(s, {})
-        state.del_account(s)
-
-    # Construct a receipt
-    r = mk_receipt(state, success, state.logs, contract_address, state.full_shard_key)
-    state.logs = []
-    state.add_receipt(r)
-
-    return success, output
+    return apply_transaction_message(state, message, ext, tx.to == b"", intrinsic_gas)
 
 
 # VM interface
 class VMExt:
-    def __init__(self, state, tx):
+    def __init__(self, state, sender, gas_price):
         self.specials = {k: v for k, v in default_specials.items()}
         for k, v in state.config["CUSTOM_SPECIALS"]:
             self.specials[k] = v
@@ -418,8 +477,8 @@ class VMExt:
             deposit
         )
         self.reset_storage = state.reset_storage
-        self.tx_origin = tx.sender if tx else b"\x00" * 20
-        self.tx_gasprice = tx.gasprice if tx else 0
+        self.tx_origin = sender
+        self.tx_gasprice = gas_price
         self.sender_disallow_map = state.sender_disallow_map
         self.default_state_token = state.shard_config.default_chain_token
 

--- a/quarkchain/evm/messages.py
+++ b/quarkchain/evm/messages.py
@@ -371,6 +371,8 @@ def apply_transaction(state, tx: transactions.Transaction, tx_wrapper_hash):
         remote_gas_reserved = 0
         if transfer_failure_by_posw_balance_check(ext, message):
             success = 0
+            # Currently, burn all gas
+            local_gas_used = tx.startgas
         elif tx.to == b"":
             # TODO: support x-shard tx creation
             success = 0

--- a/quarkchain/tests/test_config.py
+++ b/quarkchain/tests/test_config.py
@@ -186,7 +186,8 @@ class TestQuarkChainConfig(unittest.TestCase):
     "MIN_TX_POOL_GAS_PRICE": 1000000000,
     "MIN_MINING_GAS_PRICE": 1000000000,
     "XSHARD_GAS_DDOS_FIX_ROOT_HEIGHT": 90000,
-    "DISABLE_POW_CHECK": false
+    "DISABLE_POW_CHECK": false,
+    "XSHARD_ADD_RECIEPT_TIMESTAMP": null
 }
     """
         expected_json = expected_json.strip()


### PR DESCRIPTION
Initial code to enable x-shard smart contract call (and should support also creation).   The major changes are:
- New version of xshard deposit.  Xshard deposit now includes more information such as message_data (from tx.data), is_create_contract (tx.to is empty), and gas_remained (for smart contract call).  The db operator could automatically read the old version and convert it to new version lol.
- Reuse existing apply_transaction code to perform the call (including transfer)
- The receipt for the smart contract call is not persisted yet, and I put a future timestamp to enable it.  However, it breaks the assumption that a), a transaction has only one receipt (now xshard has two); and b), the number of receipts can be greater than number of transactions in a block, and txindex in a receipt doesn't mean the reciept of the txindex'th transaction in the block.

A future improvement may put the receipts in xshard_deposit receipt and retrieve it separately (to maintain maximum backward-compatibility)

Note that the test for x-shard smart contract call is not included yet.