### PR TITLE
increase rblock/mblock cache size and add mblock header cache

### DIFF
--- a/quarkchain/cluster/root_state.py
+++ b/quarkchain/cluster/root_state.py
@@ -54,7 +54,7 @@ class RootDb:
         self.tip_header = None
 
         self.__recover_from_db()
-        self.rblock_cache = LRUCache(maxsize=128)
+        self.rblock_cache = LRUCache(maxsize=1024)
 
     def __recover_from_db(self):
         """ Recover the best chain from local database.

--- a/quarkchain/cluster/shard_db_operator.py
+++ b/quarkchain/cluster/shard_db_operator.py
@@ -256,7 +256,6 @@ class ShardDbOperator(TransactionHistoryMixin):
         self.env = env
         self.db = db
         self.branch = branch
-        self.r_header_pool = dict()
 
         # height -> set(minor block hash) for counting wasted blocks
         self.height_to_minor_block_hashes = dict()
@@ -350,7 +349,8 @@ class ShardDbOperator(TransactionHistoryMixin):
         block = self.get_minor_block_by_hash(h)
         if block is not None:
             self.mblock_header_cache[h] = block.header
-        return block and block.header
+            return block.header
+        return None
 
     def get_minor_block_evm_root_hash_by_hash(self, h):
         meta = self.get_minor_block_meta_by_hash(h)


### PR DESCRIPTION
check db faces performance issue around rblock 15850, which takes several minutes per 10 blocks.  Adding the optimization will reduce the time to a few seconds.