### PR TITLE
ignore a new minor block if its root block is not found

### DIFF
--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -640,6 +640,15 @@ class Shard:
         ):
             return
 
+        # There is a race that the root block may not be processed at the moment.
+        # Ignore it if its root block is not found.
+        # Otherwise, validate_block() will fail and we will disconnect the peer.
+        if (
+            self.state.get_root_block_header_by_hash(block.header.hash_prev_root_block)
+            is None
+        ):
+            return
+
         try:
             self.state.validate_block(block)
         except Exception as e:

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -1441,6 +1441,9 @@ class ShardState:
 
         return True
 
+    def get_root_block_header_by_hash(self, h):
+        return self.db.get_root_block_header_by_hash(h)
+
     def _is_neighbor(self, remote_branch: Branch, root_height=None):
         root_height = self.root_tip.height if root_height is None else root_height
         shard_size = len(


### PR DESCRIPTION
The issues I observed is that a peer connection can be disconnected if handle_new_block receives a block while its dependent root block is not yet processed.   This disconnection is unintended since disconnection should happen only for malicious peers.  We should treat it similar to missing previous minor block and we should follow the same logic by just ignoring broadcasting the block.