### PR TITLE
Add batch processing for check db

### DIFF
--- a/quarkchain/cluster/cluster.py
+++ b/quarkchain/cluster/cluster.py
@@ -82,8 +82,10 @@ class Cluster:
     async def run_master(self):
         extra_cmd = ""
         if self.check_db_only:
-            extra_cmd += " --check_db=true --check_db_rblock_from={0} --check_db_rblock_to={1}".format(
-                self.args.check_db_rblock_from, self.args.check_db_rblock_to
+            extra_cmd += " --check_db=true --check_db_rblock_from={0} --check_db_rblock_to={1} --check_db_rblock_batch={2}".format(
+                self.args.check_db_rblock_from,
+                self.args.check_db_rblock_to,
+                self.args.check_db_rblock_batch,
             )
         if "MASTER" in self.args.profile.split(","):
             extra_cmd += " --enable_profiler=true"
@@ -138,6 +140,7 @@ def main():
     parser.add_argument("--profile", default="", type=str)
     parser.add_argument("--check_db_rblock_from", default=-1, type=int)
     parser.add_argument("--check_db_rblock_to", default=0, type=int)
+    parser.add_argument("--check_db_rblock_batch", default=1, type=int)
     args = parser.parse_args()
 
     config = ClusterConfig.create_from_args(args)

--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -908,54 +908,71 @@ class MasterServer:
         check_db_rblock_to = self.env.arguments.check_db_rblock_to
         if check_db_rblock_from >= 0 and check_db_rblock_from < rb.header.height:
             rb = self.root_state.get_root_block_by_height(check_db_rblock_from)
-        Logger.info("Starting from root block height: {}".format(rb.header.height))
+        Logger.info(
+            "Starting from root block height: {0}, batch size: {1}".format(
+                rb.header.height, self.env.arguments.check_db_rblock_batch
+            )
+        )
         while rb.header.height >= max(check_db_rblock_to, 1):
             if rb.header.height % 10 == 0:
                 Logger.info("Checking root block height: {}".format(rb.header.height))
-            prev_rb = self.root_state.db.get_root_block_by_hash(
-                rb.header.hash_prev_block
-            )
-            if prev_rb.header.height != rb.header.height - 1:
-                log_error_and_exit(
-                    "Root block height {} mismatches previous block".format(
-                        rb.header.height
-                    )
+            rb_list = []
+            for i in range(self.env.arguments.check_db_rblock_batch):
+                if rb.header.height < max(check_db_rblock_to, 1):
+                    break
+                rb_list.append(rb)
+                prev_rb = self.root_state.db.get_root_block_by_hash(
+                    rb.header.hash_prev_block
                 )
+                if prev_rb.header.height != rb.header.height - 1:
+                    log_error_and_exit(
+                        "Root block height {} mismatches previous block".format(
+                            rb.header.height
+                        )
+                    )
 
-            if prev_rb.header.get_hash() != rb.header.hash_prev_block:
-                log_error_and_exit(
-                    "Root block height {} mismatches previous block hash".format(
-                        rb.header.height
+                if prev_rb.header.get_hash() != rb.header.hash_prev_block:
+                    log_error_and_exit(
+                        "Root block height {} mismatches previous block hash".format(
+                            rb.header.height
+                        )
                     )
-                )
+                rb = prev_rb
 
             future_list = []
-            for mheader in rb.minor_block_header_list:
-                conn = self.get_slave_connection(mheader.branch)
-                request = CheckMinorBlockRequest(mheader)
-                future_list.append(
-                    conn.write_rpc_request(ClusterOp.CHECK_MINOR_BLOCK_REQUEST, request)
-                )
+            header_list = []
+            for crb in rb_list:
+                header_list.extend(crb.minor_block_header_list)
+                for mheader in crb.minor_block_header_list:
+                    conn = self.get_slave_connection(mheader.branch)
+                    request = CheckMinorBlockRequest(mheader)
+                    future_list.append(
+                        conn.write_rpc_request(
+                            ClusterOp.CHECK_MINOR_BLOCK_REQUEST, request
+                        )
+                    )
 
-            try:
-                self.root_state.add_block(rb, write_db=False, skip_if_too_old=False)
-            except Exception as e:
-                Logger.log_exception()
-                log_error_and_exit(
-                    "Failed to check root block height {}".format(rb.header.height)
-                )
+            for crb in rb_list:
+                try:
+                    self.root_state.add_block(
+                        crb, write_db=False, skip_if_too_old=False
+                    )
+                except Exception as e:
+                    Logger.log_exception()
+                    log_error_and_exit(
+                        "Failed to check root block height {}".format(crb.header.height)
+                    )
 
             response_list = await asyncio.gather(*future_list)
             for idx, (_, resp, _) in enumerate(response_list):
                 if resp.error_code != 0:
-                    header = rb.minor_block_header_list[idx]
+                    header = header_list[idx]
                     log_error_and_exit(
                         "Failed to check minor block branch {} height {}".format(
                             header.branch.value, header.height
                         )
                     )
 
-            rb = prev_rb
         Logger.info("Integrity check completed!")
         self.shutdown()
 
@@ -1602,6 +1619,7 @@ def parse_args():
     parser.add_argument("--enable_profiler", default=False, type=bool)
     parser.add_argument("--check_db_rblock_from", default=-1, type=int)
     parser.add_argument("--check_db_rblock_to", default=0, type=int)
+    parser.add_argument("--check_db_rblock_batch", default=10, type=int)
     args = parser.parse_args()
 
     env = DEFAULT_ENV.copy()


### PR DESCRIPTION
check db will submit the check tasks to a slave by collecting mheaders from multiple rblocks.  This reduces time that slaves maybe idle while master is still checking rblock.

Performance improvement (109295 rblocks)
Before:  4566.5641s
After:  3676.9211s 