### PR TITLE
Simplify get_transaction_by_address()

### DIFF
--- a/quarkchain/cluster/shard_db_operator.py
+++ b/quarkchain/cluster/shard_db_operator.py
@@ -143,7 +143,7 @@ class TransactionHistoryMixin:
 
         # only recipient addr needed to match
         # chain id can be ignored since no TX on other chains is stored here
-        end = b"index_addr_" + address.recipient[:-4]
+        end = b"index_addr_" + address.recipient
         original_start = (int.from_bytes(end, byteorder="big") + 1).to_bytes(
             len(end), byteorder="big"
         )

--- a/quarkchain/cluster/shard_db_operator.py
+++ b/quarkchain/cluster/shard_db_operator.py
@@ -141,8 +141,9 @@ class TransactionHistoryMixin:
         if not self.env.cluster_config.ENABLE_TRANSACTION_HISTORY:
             return [], b""
 
-        serialized_address = address.serialize()
-        end = b"index_addr_" + serialized_address[:-2]
+        # only recipient addr needed to match
+        # chain id can be ignored since no TX on other chains is stored here
+        end = b"index_addr_" + address.recipient[:-4]
         original_start = (int.from_bytes(end, byteorder="big") + 1).to_bytes(
             len(end), byteorder="big"
         )

--- a/quarkchain/cluster/shard_db_operator.py
+++ b/quarkchain/cluster/shard_db_operator.py
@@ -142,7 +142,7 @@ class TransactionHistoryMixin:
             return [], b""
 
         # only recipient addr needed to match
-        # chain id can be ignored since no TX on other chains is stored here
+        # full_shard_key can be ignored since no TX on other shards is stored here
         end = b"index_addr_" + address.recipient
         original_start = (int.from_bytes(end, byteorder="big") + 1).to_bytes(
             len(end), byteorder="big"


### PR DESCRIPTION
Chain id is unnecessary  for matching because no txs in other chains is stored.