### PR TITLE
Misc: fix p2p client version & docker

### DIFF
--- a/mainnet/singularity/Dockerfile
+++ b/mainnet/singularity/Dockerfile
@@ -1,31 +1,27 @@
 FROM python:3.7-buster
-
 LABEL maintainer="quarkchain"
-
 # install rocksdb
-RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get -y install libsnappy-dev zlib1g-dev libbz2-dev libgflags-dev liblz4-dev libzstd-dev librocksdb-dev \
-  && apt-get clean \
+RUN apt-get update && apt-get install -y \
+    libbz2-dev \
+    libgflags-dev \
+    liblz4-dev \
+    librocksdb-dev \
+    libsnappy-dev \
+    libzstd-dev \
+    zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
-
 # set up code
 RUN mkdir /code
 WORKDIR /code
-
-# docker build --build-arg CACHEBUST=$(date +%s) .
-ARG CACHEBUST=1
-RUN git clone https://github.com/QuarkChain/pyquarkchain.git
+RUN git clone --branch mainnet1.1.0 https://github.com/QuarkChain/pyquarkchain.git
 
 # py dep
 RUN pip install -r pyquarkchain/requirements.txt
 
-# build qkchash c++ lib
-WORKDIR /code/pyquarkchain/qkchash
-RUN make
+# add qkchash c++ lib
+ADD https://s3-us-west-2.amazonaws.com/qkcmainnet/libqkchash.so /code/pyquarkchain/qkchash/
 
 EXPOSE 22 38291 38391 38491
-
 ENV PYTHONPATH /code/pyquarkchain
 ENV QKCHASHLIB /code/pyquarkchain/qkchash/libqkchash.so
-
 WORKDIR /code/pyquarkchain

--- a/quarkchain/tools/client_version_poll.py
+++ b/quarkchain/tools/client_version_poll.py
@@ -5,7 +5,12 @@ from typing import Any, cast, Dict
 
 from quarkchain.p2p import auth
 from quarkchain.p2p import ecies
-from quarkchain.p2p.exceptions import HandshakeFailure, HandshakeDisconnectedFailure
+from quarkchain.p2p.exceptions import (
+    HandshakeFailure,
+    HandshakeDisconnectedFailure,
+    UnreachablePeer,
+    MalformedMessage,
+)
 from quarkchain.p2p.kademlia import Node
 from quarkchain.p2p.p2p_manager import QuarkServer
 from quarkchain.p2p.p2p_proto import Disconnect, DisconnectReason, Hello


### PR DESCRIPTION
1. fix missing imports in `client_version_poll.py` (not being used for now)
1. improve docker file, remove dependency on `make` (and hopefully get rid of `git` as well in the future and use `python:3.7-slim-buster` or alpine to reduce image size, which currently is ~1.1GB)