### PR TITLE
Fix eth_getBalance legacy JSONRPC endpoint

### DIFF
--- a/quarkchain/cluster/jsonrpc.py
+++ b/quarkchain/cluster/jsonrpc.py
@@ -427,11 +427,7 @@ def eth_address_to_quarkchain_address_decoder(hex_str):
     eth_hex = hex_str[2:]
     if len(eth_hex) != 40:
         raise InvalidParams("Addresses must be 40 or 0 bytes long")
-    full_shard_key_hex = ""
-    for i in range(4):
-        index = i * 10
-        full_shard_key_hex += eth_hex[index : index + 2]
-    return address_decoder("0x" + eth_hex + full_shard_key_hex)
+    return address_decoder("0x" + eth_hex + "00000001")
 
 
 def _parse_log_request(
@@ -1104,7 +1100,7 @@ class JSONRPCHttpServer:
         if shard is not None:
             address = Address(address.recipient, shard)
         account_branch_data = await self.master.get_primary_account_data(address)
-        balance = account_branch_data.balance
+        balance = account_branch_data.token_balances.balance_map[token_id_encode("QKC")]
         return balance
 
     @public_methods.add

--- a/quarkchain/cluster/tests/test_jsonrpc.py
+++ b/quarkchain/cluster/tests/test_jsonrpc.py
@@ -121,6 +121,22 @@ class TestJSONRPCHttp(unittest.TestCase):
                 )
                 self.assertEqual(response, hex(i + 1))
 
+    def test_getBalance(self):
+        id1 = Identity.create_random_identity()
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+
+        with ClusterContext(
+            1, acc1, small_coinbase=True
+        ) as clusters, jrpc_http_server_context(clusters[0].master):
+            response = send_request("getBalances", ["0x" + acc1.serialize().hex()])
+            self.assertListEqual(
+                response["balances"],
+                [{"tokenId": "0x8bb0", "tokenStr": "QKC", "balance": "0xf4240"}],
+            )
+
+            response = send_request("eth_getBalance", ["0x" + acc1.recipient.hex()])
+            self.assertEqual(response, "0xf4240")
+
     def test_sendTransaction(self):
         id1 = Identity.create_random_identity()
         acc1 = Address.create_from_identity(id1, full_shard_key=0)


### PR DESCRIPTION
for compatibility with quarkchain-web3.js

default to chain 0 shard 0

fixes #732