### PR TITLE
Change response format of syncing subscription

### DIFF
--- a/fixtures/QuarkChainStateTests/stContractCallMnt/contractTransferMntQKCOnly.json
+++ b/fixtures/QuarkChainStateTests/stContractCallMnt/contractTransferMntQKCOnly.json
@@ -1,7 +1,7 @@
 {
   "contractTransferMntQKCOnly": {
     "_info": {
-      "comment": "deployed contract: https://gist.github.com/hanyunxu/4c1e33b59c6f67bb9c6d0ebed9e6b0d1",
+      "comment": "deployed contract: https://gist.github.com/hanyunx/4c1e33b59c6f67bb9c6d0ebed9e6b0d1",
       "filledwith": "byhand",
       "lllcversion": "byhand",
       "source": "NA",

--- a/fixtures/QuarkChainStateTests/stContractCallMnt/currentMntId.json
+++ b/fixtures/QuarkChainStateTests/stContractCallMnt/currentMntId.json
@@ -1,7 +1,7 @@
 {
   "currentMntId": {
     "_info": {
-      "comment": "deployed contract: https://gist.github.com/hanyunxu/2288b72872721a4901d6bf7768c5fb88",
+      "comment": "deployed contract: https://gist.github.com/hanyunx/2288b72872721a4901d6bf7768c5fb88",
       "filledwith": "byhand",
       "lllcversion": "byhand",
       "source": "NA",


### PR DESCRIPTION
Normalize the response format of four subscription types.
Also minor fix on test contract link