### PR TITLE
Fix transfer failure return result

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,4 +160,3 @@ workflows:
       - check-db:
           requires:
             - build
-            - download-snapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,16 +147,16 @@ workflows:
           requires:
             - build
   nightly:
-    # triggers:
-      # - schedule:
-          # cron: "0 3 * * *"
-          # filters:
-            # branches:
-              # only:
-                # - master
+    triggers:
+      - schedule:
+          cron: "0 3 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - build
-      # - download-snapshot
+      - download-snapshot
       - check-db:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,16 +147,16 @@ workflows:
           requires:
             - build
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 3 * * *"
-          filters:
-            branches:
-              only:
-                - master
+    # triggers:
+      # - schedule:
+          # cron: "0 3 * * *"
+          # filters:
+            # branches:
+              # only:
+                # - master
     jobs:
       - build
-      - download-snapshot
+      # - download-snapshot
       - check-db:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,3 +160,4 @@ workflows:
       - check-db:
           requires:
             - build
+            - download-snapshot

--- a/fixtures/QuarkChainStateTests/stContractCallMnt/contractTransferMntNotEnoughBalance.json
+++ b/fixtures/QuarkChainStateTests/stContractCallMnt/contractTransferMntNotEnoughBalance.json
@@ -1,0 +1,77 @@
+{
+  "contractTransferMntNotEnoughBalance": {
+    "_info": {
+      "comment": "deployed contract: https://gist.github.com/hanyunx/b758b44b4c866a4c175acf5017761b13",
+      "filledwith": "byhand",
+      "lllcversion": "byhand",
+      "source": "NA",
+      "sourceHash": "NA"
+    },
+    "env": {
+      "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+      "currentDifficulty": "0x020000",
+      "currentGasLimit": "0xf5f5e100",
+      "currentNumber": "0x01",
+      "currentTimestamp": "0x03e8",
+      "previousHash": "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+    },
+    "post": {
+      "ConstantinopleFix": [
+        {
+          "hash": "0xf5811632e06923cfbbd8b8d2fc8dcd13dd0c583f96d385f203d423fd73bee80c",
+          "indexes": {
+            "data": 0,
+            "gas": 0,
+            "value": 0,
+            "transferTokenId": 0
+          },
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+        },
+        {
+          "hash": "0xf5811632e06923cfbbd8b8d2fc8dcd13dd0c583f96d385f203d423fd73bee80c",
+          "indexes": {
+            "data": 0,
+            "gas": 0,
+            "value": 0,
+            "transferTokenId": 0
+          },
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+        }
+      ]
+    },
+    "pre": {
+      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+        "balances": {
+          "0x8bb0": "0x0de0b6b3a7640000",
+          "0x3de": "0x0de0b6b3a7640000"
+        },
+        "code": "",
+        "nonce": "0x00",
+        "storage": {
+        }
+      },
+      "0x692a70D2e424a56D2C6C27aA97D1a86395877b3A": {
+        "balance": "0x00",
+        "code": "0x608060405260043610601c5760003560e01c8063c19d93fb1460a2575b602260d0565b3373ffffffffffffffffffffffffffffffffffffffff1681600060038110604557fe5b6020020181815250506103de81600160038110605d57fe5b602002018181525050600181600260038110607457fe5b602002018181525050600080606083600064514b430002600019f1609757600080fd5b600160008190555050005b34801560ad57600080fd5b5060b460ca565b6040518082815260200191505060405180910390f35b60005481565b604051806060016040528060039060208202803883398082019150509050509056fea265627a7a7231582000b4f7b5bc79e4d23adb9406e42c4099a4defa2fd3d41ed76b263f4cddac6d1564736f6c634300050b0032",
+        "nonce": "0x00",
+        "storage": {
+        }
+      }
+    },
+    "transaction": {
+      "data": [
+        "0x"
+      ],
+      "gasLimit": [
+        "0xf4c4b40"
+      ],
+      "gasPrice": "0x01",
+      "nonce": "0x00",
+      "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+      "to": "0x692a70D2e424a56D2C6C27aA97D1a86395877b3A",
+      "value": [
+        "0x00"
+      ]
+    }
+  }
+}

--- a/fixtures/QuarkChainStateTests/stContractCallMnt/contractTransferMntNotEnoughBalance.json
+++ b/fixtures/QuarkChainStateTests/stContractCallMnt/contractTransferMntNotEnoughBalance.json
@@ -24,18 +24,7 @@
             "gas": 0,
             "value": 0,
             "transferTokenId": 0
-          },
-          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
-        },
-        {
-          "hash": "0xf5811632e06923cfbbd8b8d2fc8dcd13dd0c583f96d385f203d423fd73bee80c",
-          "indexes": {
-            "data": 0,
-            "gas": 0,
-            "value": 0,
-            "transferTokenId": 0
-          },
-          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+          }
         }
       ]
     },

--- a/quarkchain/evm/messages.py
+++ b/quarkchain/evm/messages.py
@@ -560,8 +560,7 @@ def _apply_msg(ext, msg, code):
                 have=ext.get_balance(msg.sender, token_id=msg.transfer_token_id),
                 want=msg.value,
             )
-            # TODO: Why return success if the transfer failed?
-            return 1, msg.gas, []
+            return 0, 0, []
 
     # Main loop
     if msg.code_address in ext.specials:


### PR DESCRIPTION
in normal case this code path won't be touched because:

1. normal transfer tx will be guarded by validation
2. transfer / calls in smart contract will be guarded by VM checking QKC balance

thus there are two ways to break the execution rule:

1. indirectly make a CALL msg (outside the VM) such as calling transfer_mnt precompiled contract (fixed by this PR)
~2. make a CALL message with value transfer but in non-default token~