### PR TITLE
Remove pending tx with lower nonce

### DIFF
--- a/quarkchain/evm/tests/test_transaction_queue.py
+++ b/quarkchain/evm/tests/test_transaction_queue.py
@@ -137,7 +137,7 @@ class TestTransactionQueue(unittest.TestCase):
         # Verify internal state, still have remaining txs with nonce == 1
         self.assertEqual(len(q), 4)
         # Stale tx will be cleaned up in the future
-        res = q.pop_transaction(nonce_getter_maker(100))
+        res = q.pop_transaction(nonce_getter_maker(2))
         self.assertIsNone(res)
         self.assertEqual(len(q), 0)
 

--- a/quarkchain/evm/transaction_queue.py
+++ b/quarkchain/evm/transaction_queue.py
@@ -4,9 +4,6 @@ from functools import total_ordering
 from typing import Callable
 
 
-MAX_STALE_TX_NONCE = 32
-
-
 @total_ordering
 class OrderableTx(object):
     def __init__(self, prio, counter, tx):
@@ -51,7 +48,7 @@ class TransactionQueue(object):
             item = self.txs[i]
             tx = item.tx
             # discard old tx
-            if tx.nonce < req_nonce_getter(tx.sender) - MAX_STALE_TX_NONCE:
+            if tx.nonce < req_nonce_getter(tx.sender):
                 self.txs.pop(i)
                 continue
             # target found


### PR DESCRIPTION
discard tx in queue if already finalized one with lower nonce. in case of chain reorg, the new tx will be added by including the new block, which has nothing to do with tx queue, so safe to remove lower nonce tx