### PR TITLE
better accounting for xshard local gas use

### DIFF
--- a/quarkchain/cluster/tests/test_jsonrpc.py
+++ b/quarkchain/cluster/tests/test_jsonrpc.py
@@ -780,7 +780,7 @@ class TestJSONRPCHttp(unittest.TestCase):
                 resp = send_request(endpoint, ["0x" + tx.get_hash().hex() + "00000002"])
                 self.assertEqual(resp["transactionHash"], "0x" + tx.get_hash().hex())
                 self.assertEqual(resp["status"], "0x1")
-                self.assertEqual(resp["cumulativeGasUsed"], "0x1369c")
+                self.assertEqual(resp["cumulativeGasUsed"], "0x11374")
                 self.assertIsNone(resp["contractAddress"])
 
             # x-shard contract creation should succeed. check target shard

--- a/quarkchain/cluster/tests/test_native_token.py
+++ b/quarkchain/cluster/tests/test_native_token.py
@@ -293,9 +293,7 @@ class TestNativeTokenShardState(unittest.TestCase):
         self.assertEqual(state.get_token_balance(id1.recipient, QETH), 999999 - 888888)
 
         # Make sure the xshard gas is not used by local block
-        self.assertEqual(
-            state.evm_state.gas_used, opcodes.GTXCOST + opcodes.GTXXSHARDCOST
-        )
+        self.assertEqual(state.evm_state.gas_used, opcodes.GTXCOST)
         # GTXXSHARDCOST is consumed by remote shard
         self.assertEqual(
             state.get_token_balance(acc3.recipient, self.genesis_token),
@@ -465,9 +463,7 @@ class TestNativeTokenShardState(unittest.TestCase):
         )
 
         # Make sure the xshard gas is not used by local block
-        self.assertEqual(
-            state.evm_state.gas_used, opcodes.GTXCOST + opcodes.GTXXSHARDCOST
-        )
+        self.assertEqual(state.evm_state.gas_used, opcodes.GTXCOST)
         # block coinbase for mining is still in genesis_token
         self.assertEqual(
             state.get_token_balance(acc3.recipient, self.genesis_token),


### PR DESCRIPTION
For an x-shard tx:
- local gas used will be intrinsic gas - 9000
- remote gas used will be 9000 + remained gas for smart contract call

This makes sure the fee calculation is the same as gas used.