### PR TITLE
Fix contract address in xshard deployment

### DIFF
--- a/quarkchain/evm/messages.py
+++ b/quarkchain/evm/messages.py
@@ -390,7 +390,9 @@ def apply_transaction(state, tx: transactions.Transaction, tx_wrapper_hash):
                     ),
                     to_address=quarkchain.core.Address(
                         mk_contract_address(
-                            tx.sender, tx.to_full_shard_key, state.get_nonce(tx.sender)
+                            tx.sender,
+                            state.get_nonce(tx.sender),
+                            tx.from_full_shard_key,
                         ),
                         tx.to_full_shard_key,
                     ),

--- a/quarkchain/evm/specials.py
+++ b/quarkchain/evm/specials.py
@@ -1,5 +1,4 @@
 # -*- coding: utf8 -*-
-import collections
 from enum import Enum
 
 from py_ecc.secp256k1 import N as secp256k1n


### PR DESCRIPTION
fixes #760 

note we also changed to_full_shard_key to from_full_shard_key in case same account with same nonce from multiple shards want to xshard deploy different contracts 