### PR TITLE
Add timestamp when creating EVM state

### DIFF
--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -317,7 +317,7 @@ class ShardState:
         self.confirmed_header_tip = confirmed_header_tip
         sender_disallow_map = self._get_sender_disallow_map(header_tip)
         self.evm_state = self.__create_evm_state(
-            self.meta_tip.hash_evm_state_root, sender_disallow_map, time.time()
+            self.meta_tip.hash_evm_state_root, sender_disallow_map, int(time.time())
         )
         check(
             self.db.get_minor_block_evm_root_hash_by_hash(header_tip_hash)
@@ -1478,7 +1478,7 @@ class ShardState:
             b = self.db.get_minor_block_by_hash(h)
             sender_disallow_map = self._get_sender_disallow_map(b.header)
             evm_state = self.__create_evm_state(
-                b.meta.hash_evm_state_root, sender_disallow_map, time.time()
+                b.meta.hash_evm_state_root, sender_disallow_map, int(time.time())
             )
             self.__update_tip(b, evm_state)
             Logger.info(

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -565,7 +565,6 @@ class ShardState:
         )
         if ephemeral:
             state = state.ephemeral_clone()
-        state.timestamp = block.header.create_time
         state.gas_limit = block.header.evm_gas_limit
         state.block_number = block.header.height
         state.recent_uncles[

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -317,7 +317,9 @@ class ShardState:
         self.confirmed_header_tip = confirmed_header_tip
         sender_disallow_map = self._get_sender_disallow_map(header_tip)
         self.evm_state = self.__create_evm_state(
-            self.meta_tip.hash_evm_state_root, sender_disallow_map
+            self.meta_tip.hash_evm_state_root,
+            sender_disallow_map,
+            header_tip.create_time + 1,
         )
         check(
             self.db.get_minor_block_evm_root_hash_by_hash(header_tip_hash)
@@ -329,7 +331,10 @@ class ShardState:
         )
 
     def __create_evm_state(
-        self, trie_root_hash: Optional[bytes], sender_disallow_map: Dict[bytes, int]
+        self,
+        trie_root_hash: Optional[bytes],
+        sender_disallow_map: Dict[bytes, int],
+        timestamp: Optional[int] = None,
     ):
         """EVM state with given root hash and block hash AFTER which being evaluated."""
         state = EvmState(
@@ -339,6 +344,8 @@ class ShardState:
         if trie_root_hash:
             state.trie.root_hash = trie_root_hash
         state.sender_disallow_map = sender_disallow_map
+        if timestamp:
+            state.timestamp = timestamp
         return state
 
     def init_genesis_state(self, root_block):
@@ -553,7 +560,9 @@ class ShardState:
             prev_minor_header, recipient=coinbase_recipient
         )
 
-        state = self.__create_evm_state(root_hash, sender_disallow_map)
+        state = self.__create_evm_state(
+            root_hash, sender_disallow_map, block.header.create_time
+        )
         if ephemeral:
             state = state.ephemeral_clone()
         state.timestamp = block.header.create_time
@@ -1472,7 +1481,9 @@ class ShardState:
             b = self.db.get_minor_block_by_hash(h)
             sender_disallow_map = self._get_sender_disallow_map(b.header)
             evm_state = self.__create_evm_state(
-                b.meta.hash_evm_state_root, sender_disallow_map
+                b.meta.hash_evm_state_root,
+                sender_disallow_map,
+                b.header.create_time + 1,
             )
             self.__update_tip(b, evm_state)
             Logger.info(

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -317,9 +317,7 @@ class ShardState:
         self.confirmed_header_tip = confirmed_header_tip
         sender_disallow_map = self._get_sender_disallow_map(header_tip)
         self.evm_state = self.__create_evm_state(
-            self.meta_tip.hash_evm_state_root,
-            sender_disallow_map,
-            header_tip.create_time + 1,
+            self.meta_tip.hash_evm_state_root, sender_disallow_map, time.time()
         )
         check(
             self.db.get_minor_block_evm_root_hash_by_hash(header_tip_hash)
@@ -564,7 +562,7 @@ class ShardState:
             root_hash, sender_disallow_map, block.header.create_time
         )
         if ephemeral:
-            state = state.ephemeral_clone(block.header.create_time)
+            state = state.ephemeral_clone()
         state.gas_limit = block.header.evm_gas_limit
         state.block_number = block.header.height
         state.recent_uncles[
@@ -1480,9 +1478,7 @@ class ShardState:
             b = self.db.get_minor_block_by_hash(h)
             sender_disallow_map = self._get_sender_disallow_map(b.header)
             evm_state = self.__create_evm_state(
-                b.meta.hash_evm_state_root,
-                sender_disallow_map,
-                b.header.create_time + 1,
+                b.meta.hash_evm_state_root, sender_disallow_map, time.time()
             )
             self.__update_tip(b, evm_state)
             Logger.info(

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -564,7 +564,7 @@ class ShardState:
             root_hash, sender_disallow_map, block.header.create_time
         )
         if ephemeral:
-            state = state.ephemeral_clone()
+            state = state.ephemeral_clone(block.header.create_time)
         state.gas_limit = block.header.evm_gas_limit
         state.block_number = block.header.height
         state.recent_uncles[

--- a/quarkchain/evm/state.py
+++ b/quarkchain/evm/state.py
@@ -691,7 +691,7 @@ class State:
         state.changed = {}
         return state
 
-    def ephemeral_clone(self, timestamp: Optional[int] = None):
+    def ephemeral_clone(self):
         snapshot = self.to_snapshot(root_only=True, no_prevblocks=True)
         env2 = Env(OverlayDb(self.db), self.env.config)
         s = State.from_snapshot(snapshot, env2)
@@ -704,8 +704,6 @@ class State:
         s.journal = copy.copy(self.journal)
         s.cache = {}
         s.qkc_config = self.qkc_config
-        if timestamp:
-            s.timestamp = timestamp
         s.sender_disallow_map = self.sender_disallow_map
         return s
 

--- a/quarkchain/evm/state.py
+++ b/quarkchain/evm/state.py
@@ -1,6 +1,5 @@
 # Modified based on pyethereum under MIT license
 import copy
-from typing import Optional
 import rlp
 from rlp.sedes.lists import CountableList
 from rlp.sedes import binary

--- a/quarkchain/evm/state.py
+++ b/quarkchain/evm/state.py
@@ -1,5 +1,6 @@
 # Modified based on pyethereum under MIT license
 import copy
+from typing import Optional
 import rlp
 from rlp.sedes.lists import CountableList
 from rlp.sedes import binary
@@ -690,7 +691,7 @@ class State:
         state.changed = {}
         return state
 
-    def ephemeral_clone(self):
+    def ephemeral_clone(self, timestamp: Optional[int] = None):
         snapshot = self.to_snapshot(root_only=True, no_prevblocks=True)
         env2 = Env(OverlayDb(self.db), self.env.config)
         s = State.from_snapshot(snapshot, env2)
@@ -703,6 +704,8 @@ class State:
         s.journal = copy.copy(self.journal)
         s.cache = {}
         s.qkc_config = self.qkc_config
+        if timestamp:
+            s.timestamp = timestamp
         s.sender_disallow_map = self.sender_disallow_map
         return s
 


### PR DESCRIPTION
Before this PR, a transaction would fail if a user attempts to send a transaction at the moment of starting a cluster and not any peers has been connected. This is because the timestamp of EVM state is set as 0 by default, in which case tx is disabled except for whitelist senders.

As a potential solution, the timestamp is updated when creating the EVM state such that a transaction can be applied successfully, though it will not be broadcasted to other nodes and will eventually be discarded.