### PR TITLE
Update allowed native token and tx validation handling

### DIFF
--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -1775,9 +1775,6 @@ class ShardState:
         return hi
 
     def gas_price(self, token_id: int) -> Optional[int]:
-        if token_id not in self.env.quark_chain_config.allowed_token_ids:
-            Logger.error("Unrecognized token id {} ".format(token_id))
-            return
         curr_head = self.header_tip.get_hash()
         if (curr_head, token_id) in self.gas_price_suggestion_oracle.cache:
             return self.gas_price_suggestion_oracle.cache[(curr_head, token_id)]

--- a/quarkchain/cluster/tests/test_native_token.py
+++ b/quarkchain/cluster/tests/test_native_token.py
@@ -114,26 +114,7 @@ class TestNativeTokenShardState(unittest.TestCase):
             gas_token_id=self.genesis_token,
             transfer_token_id=MALICIOUS0,
         )
-        self.assertTrue(state.add_tx(tx))
-
-        b1 = state.create_block_to_mine(address=acc3)
-        self.assertEqual(len(b1.tx_list), 1)
-        state.finalize_and_add_block(b1)
-        self.assertEqual(state.header_tip, b1.header)
-        self.assertEqual(
-            state.get_token_balance(id1.recipient, self.genesis_token),
-            10000000 - opcodes.GTXCOST,
-        )
-        self.assertEqual(state.get_token_balance(acc1.recipient, MALICIOUS0), 0)
-        # MALICIOUS0 shall not be in the dict
-        self.assertNotEqual(
-            state.get_balances(acc1.recipient),
-            {self.genesis_token: 10000000 - opcodes.GTXCOST, MALICIOUS0: 0},
-        )
-        self.assertEqual(
-            state.get_balances(acc1.recipient),
-            {self.genesis_token: 10000000 - opcodes.GTXCOST},
-        )
+        self.assertFalse(state.add_tx(tx))
 
     def test_disallowed_unknown_token(self):
         """do not allow tx with unknown token id

--- a/quarkchain/cluster/tests/test_native_token.py
+++ b/quarkchain/cluster/tests/test_native_token.py
@@ -94,7 +94,6 @@ class TestNativeTokenShardState(unittest.TestCase):
         MALICIOUS0 = token_id_encode("MALICIOUS0")
         id1 = Identity.create_random_identity()
         acc1 = Address.create_from_identity(id1, full_shard_key=0)
-        acc3 = Address.create_random_account(full_shard_key=0)
 
         env = get_test_env(
             genesis_account=acc1,
@@ -123,7 +122,6 @@ class TestNativeTokenShardState(unittest.TestCase):
         MALICIOUS1 = token_id_encode("MALICIOUS1")
         id1 = Identity.create_random_identity()
         acc1 = Address.create_from_identity(id1, full_shard_key=0)
-        acc3 = Address.create_random_account(full_shard_key=0)
 
         env = get_test_env(
             genesis_account=acc1,

--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -3176,6 +3176,26 @@ class TestShardState(unittest.TestCase):
         state.finalize_and_add_block(b0)
         self.assertEqual(len(state.tx_queue), 0)
 
+    @staticmethod
+    def __prepare_gas_reserve_contract(evm_state, supervisor) -> bytes:
+        runtime_bytecode = GENERAL_NATIVE_TOKEN_CONTRACT_BYTECODE
+        runtime_start = runtime_bytecode.find(bytes.fromhex("608060405260"), 1)
+        # get rid of the constructor argument
+        runtime_bytecode = runtime_bytecode[runtime_start:-32]
+
+        contract_addr = SystemContract.GENERAL_NATIVE_TOKEN.addr()
+        evm_state.set_code(contract_addr, runtime_bytecode)
+        # Set caller
+        evm_state.set_storage_data(contract_addr, 0, contract_addr)
+        # Set supervisor
+        evm_state.set_storage_data(contract_addr, 1, supervisor)
+        # Set min gas reserve for maintenance
+        evm_state.set_storage_data(contract_addr, 3, 30000)
+        # Set min starting gas for use as gas
+        evm_state.set_storage_data(contract_addr, 4, 1)
+        evm_state.commit()
+        return contract_addr
+
     def test_pay_native_token_as_gas_contract_api(self):
         id1 = Identity.create_random_identity()
         acc1 = Address.create_from_identity(id1, full_shard_key=0)
@@ -3187,22 +3207,7 @@ class TestShardState(unittest.TestCase):
         refund_percentage, gas_price = get_gas_utility_info(evm_state, 123, 1)
         self.assertEqual((refund_percentage, gas_price), (0, 0))
 
-        runtime_bytecode = GENERAL_NATIVE_TOKEN_CONTRACT_BYTECODE
-        runtime_start = runtime_bytecode.find(bytes.fromhex("608060405260"), 1)
-        # get rid of the constructor argument
-        runtime_bytecode = runtime_bytecode[runtime_start:-32]
-
-        contract_addr = SystemContract.GENERAL_NATIVE_TOKEN.addr()
-        evm_state.set_code(contract_addr, runtime_bytecode)
-        # Set caller
-        evm_state.set_storage_data(contract_addr, 0, contract_addr)
-        # Set supervisor
-        evm_state.set_storage_data(contract_addr, 1, acc1.recipient)
-        # Set min gas reserve for maintenance
-        evm_state.set_storage_data(contract_addr, 3, 1)
-        # Set min starting gas for use as gas
-        evm_state.set_storage_data(contract_addr, 4, 1)
-        evm_state.commit()
+        contract_addr = self.__prepare_gas_reserve_contract(evm_state, acc1.recipient)
 
         nonce = 0
 
@@ -3242,26 +3247,27 @@ class TestShardState(unittest.TestCase):
         )
 
         # propose a new exchange rate
-        tx1 = propose_new_exchange_rate(10000)
+        tx1 = propose_new_exchange_rate(100000)
         success, _ = apply_transaction(evm_state, tx1, bytes(32))
         self.assertTrue(success)
         # set the refund rate
         tx2 = set_refund_rate()
         success, _ = apply_transaction(evm_state, tx2, bytes(32))
-        # should be able to use the gas utility
-        evm_state.commit()
+        self.assertTrue(success)
 
         # get the gas utility information by calling the get_gas_utility_info function
-        refund_percentage, gas_price = get_gas_utility_info(evm_state, 123, 60000)
+        refund_percentage, gas_price = get_gas_utility_info(evm_state, token_id, 60000)
         self.assertEqual((refund_percentage, gas_price), (60, 2))
         # exchange the Qkc with the native token
-        refund_percentage, gas_price = pay_native_token_as_gas(evm_state, 123, 1, 60000)
+        refund_percentage, gas_price = pay_native_token_as_gas(
+            evm_state, token_id, 1, 60000
+        )
         self.assertEqual((refund_percentage, gas_price), (60, 2))
         # check the balance of the gas reserve. amount of native token (60000) * exchange rate (1 / 30000) = 2 QKC
         tx3 = query_gas_reserve_balance(acc1)
         success, output = apply_transaction(evm_state, tx3, bytes(32))
         self.assertTrue(success)
-        self.assertEqual(int.from_bytes(output, byteorder="big"), 9998)
+        self.assertEqual(int.from_bytes(output, byteorder="big"), 99998)
         # check the balance of native token.
         tx4 = query_native_token_balance(acc1)
         success, output = apply_transaction(evm_state, tx4, bytes(32))
@@ -3278,7 +3284,6 @@ class TestShardState(unittest.TestCase):
 
         env = get_test_env(
             genesis_account=acc1,
-            genesis_minor_quarkash=10000000,
             genesis_minor_token_balances={"QKC": 100000000, "QI": 100000000},
         )
         state = create_default_shard_state(env=env)
@@ -3338,3 +3343,124 @@ class TestShardState(unittest.TestCase):
             evm_state.get_balance(bytes(20), token_id=qkc_token),
             979000 * 10 + 21000 * 10,
         )
+
+    def test_pay_native_token_as_gas_end_to_end(self):
+        id1 = Identity.create_random_identity()
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        # genesis balance: 100 ether for both QKC and QI
+        env = get_test_env(
+            genesis_account=acc1,
+            genesis_minor_token_balances={"QKC": int(1e20), "QI": int(1e20)},
+        )
+        state = create_default_shard_state(env=env)
+        evm_state = state.evm_state
+        evm_state.block_coinbase = Address.create_random_account(0).recipient
+
+        contract_addr = self.__prepare_gas_reserve_contract(evm_state, acc1.recipient)
+
+        nonce = 0
+        token_id = token_id_encode("QI")
+        gaslimit = 1000000
+
+        def tx_gen(
+            data: str,
+            value: Optional[int] = None,
+            addr: bytes = contract_addr,
+            use_native_token: bool = False,
+            gas_price: int = 0,
+            increment_nonce=True,
+        ):
+            nonlocal nonce
+            ret = create_transfer_transaction(
+                nonce=nonce,
+                shard_state=state,
+                key=id1.get_key(),
+                from_address=acc1,
+                to_address=Address(addr, 0),
+                value=value or 0,
+                gas=gaslimit,
+                gas_price=gas_price,
+                data=bytes.fromhex(data),
+                gas_token_id=token_id if use_native_token else None,
+            ).tx.to_evm_tx()
+            if increment_nonce:
+                nonce += 1
+            ret.set_quark_chain_config(env.quark_chain_config)
+            return ret
+
+        # propose a new exchange rate for native token with ratio 1 / 2
+        parsed_hex = lambda i: i.to_bytes(32, byteorder="big").hex()
+        propose_new_exchange_rate = lambda v: tx_gen(
+            "735e0e19" + parsed_hex(token_id) + parsed_hex(1) + parsed_hex(2), v
+        )
+        # set the refund rate to 80
+        set_refund_rate = lambda: tx_gen(
+            "6d27af8c" + parsed_hex(token_id) + parsed_hex(80)
+        )
+        query_gas_reserve_balance = lambda a: tx_gen(
+            "13dee215" + parsed_hex(token_id) + "0" * 24 + a.recipient.hex()
+        )
+        query_native_token_balance = lambda a: tx_gen(
+            "21a2b36e" + parsed_hex(token_id) + "0" * 24 + a.recipient.hex()
+        )
+
+        # propose a new exchange rate with 1 ether of QKC as reserve
+        tx = propose_new_exchange_rate(int(1e18))
+        success, _ = apply_transaction(evm_state, tx, bytes(32))
+        self.assertTrue(success)
+        # set the refund rate
+        tx = set_refund_rate()
+        success, _ = apply_transaction(evm_state, tx, bytes(32))
+        self.assertTrue(success)
+        evm_state.commit()
+
+        # 1) craft a tx using native token for gas, with gas price as 10
+        tx_w_native_token = tx_gen(
+            "", 0, acc1.recipient, use_native_token=True, gas_price=10
+        )
+        success, _ = apply_transaction(evm_state, tx_w_native_token, bytes(32))
+        self.assertTrue(success)
+
+        # native token balance should update accordingly
+        self.assertEqual(
+            evm_state.get_balance(acc1.recipient, token_id), int(1e20) - gaslimit * 10
+        )
+        self.assertEqual(evm_state.get_balance(contract_addr, token_id), gaslimit * 10)
+        query_tx = query_native_token_balance(acc1)
+        success, output = apply_transaction(evm_state, query_tx, bytes(32))
+        self.assertTrue(success)
+        self.assertEqual(int.from_bytes(output, byteorder="big"), gaslimit * 10)
+        # qkc balance should update accordingly:
+        # should have 100 ether - 1 ether + refund
+        sender_balance = (
+            int(1e20) - int(1e18) + (gaslimit - 21000) * (10 // 2) * 8 // 10
+        )
+        self.assertEqual(evm_state.get_balance(acc1.recipient), sender_balance)
+        contract_remaining_qkc = int(1e18) - gaslimit * 10 // 2
+        self.assertEqual(evm_state.get_balance(contract_addr), contract_remaining_qkc)
+        query_tx = query_gas_reserve_balance(acc1)
+        success, output = apply_transaction(evm_state, query_tx, bytes(32))
+        self.assertTrue(success)
+        self.assertEqual(
+            int.from_bytes(output, byteorder="big"), contract_remaining_qkc
+        )
+        # burned QKC for gas conversion
+        self.assertEqual(
+            evm_state.get_balance(bytes(20)), (gaslimit - 21000) * (10 // 2) * 2 // 10
+        )
+        # miner fee with 50% tax
+        self.assertEqual(
+            evm_state.get_balance(evm_state.block_coinbase), 21000 * (10 // 2) // 2
+        )
+
+        # 2) craft a tx that will use up gas reserve, should fail validation
+        tx_use_up_reserve = tx_gen(
+            "",
+            0,
+            acc1.recipient,
+            use_native_token=True,
+            gas_price=int(1e12) * 2,
+            increment_nonce=False,
+        )
+        with self.assertRaises(InvalidNativeToken):
+            apply_transaction(evm_state, tx_use_up_reserve, bytes(32))

--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -126,7 +126,7 @@ class TestShardState(unittest.TestCase):
         shard_block.header.version = 0
         state.finalize_and_add_block(shard_block)
 
-    @mock_pay_native_token_as_gas
+    @mock_pay_native_token_as_gas()
     def test_gas_price(self):
         id_list = [Identity.create_random_identity() for _ in range(5)]
         acc_list = [Address.create_from_identity(i, full_shard_key=0) for i in id_list]
@@ -138,6 +138,7 @@ class TestShardState(unittest.TestCase):
                 "QI": 100000000,
                 "BTC": 100000000,
             },
+            charge_gas_reserve=True,
         )
 
         qkc_token = token_id_encode("QKC")
@@ -210,9 +211,9 @@ class TestShardState(unittest.TestCase):
         gas_price = state.gas_price(token_id=btc_token)
         self.assertEqual(gas_price, 0)
 
-        # unrecognized token id
+        # unrecognized token id should return 0
         gas_price = state.gas_price(token_id=1)
-        self.assertIsNone(gas_price)
+        self.assertEqual(gas_price, 0)
 
     def test_estimate_gas(self):
         id1 = Identity.create_random_identity()

--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -3269,8 +3269,6 @@ class TestShardState(unittest.TestCase):
     # mock refund rate 50% with 2x gas price
     @mock_pay_native_token_as_gas(lambda *x: (50, x[-1] * 2))
     def test_native_token_as_gas_in_shard(self):
-        # import quarkchain.evm.messages
-
         id1 = Identity.create_random_identity()
         id2 = Identity.create_random_identity()
         acc1 = Address.create_from_identity(id1, full_shard_key=0)
@@ -3286,6 +3284,11 @@ class TestShardState(unittest.TestCase):
 
         qkc_token = token_id_encode("QKC")
         qi_token = token_id_encode("QI")
+
+        # need to give gas reserve enough QKC to pay for gas conversion
+        evm_state.delta_token_balance(
+            SystemContract.GENERAL_NATIVE_TOKEN.addr(), qkc_token, int(1e18)
+        )
 
         nonce = 0
 

--- a/quarkchain/cluster/tests/test_utils.py
+++ b/quarkchain/cluster/tests/test_utils.py
@@ -25,6 +25,7 @@ from quarkchain.db import InMemoryDb
 from quarkchain.diff import EthDifficultyCalculator
 from quarkchain.env import DEFAULT_ENV
 from quarkchain.evm.messages import pay_native_token_as_gas, get_gas_utility_info
+from quarkchain.evm.specials import SystemContract
 from quarkchain.evm.transactions import Transaction as EvmTransaction
 from quarkchain.protocol import AbstractConnection
 from quarkchain.utils import call_async, check, is_p2
@@ -38,6 +39,7 @@ def get_test_env(
     genesis_root_heights=None,  # dict(full_shard_id, genesis_root_height)
     remote_mining=False,
     genesis_minor_token_balances=None,
+    charge_gas_reserve=False,
 ):
     check(is_p2(shard_size))
     env = DEFAULT_ENV.copy()
@@ -76,6 +78,13 @@ def get_test_env(
         else:
             shard.GENESIS.ALLOC[addr] = {
                 env.quark_chain_config.GENESIS_TOKEN: genesis_minor_quarkash
+            }
+        if charge_gas_reserve:
+            gas_reserve_addr = (
+                SystemContract.GENERAL_NATIVE_TOKEN.addr().hex() + addr[-8:]
+            )
+            shard.GENESIS.ALLOC[gas_reserve_addr] = {
+                env.quark_chain_config.GENESIS_TOKEN: int(1e18)
             }
         shard.CONSENSUS_CONFIG.REMOTE_MINE = remote_mining
         shard.DIFFICULTY_ADJUSTMENT_CUTOFF_TIME = 7

--- a/quarkchain/cluster/tests/test_utils.py
+++ b/quarkchain/cluster/tests/test_utils.py
@@ -24,7 +24,7 @@ from quarkchain.core import (
 from quarkchain.db import InMemoryDb
 from quarkchain.diff import EthDifficultyCalculator
 from quarkchain.env import DEFAULT_ENV
-from quarkchain.evm.messages import pay_native_token_as_gas
+from quarkchain.evm.messages import pay_native_token_as_gas, get_gas_utility_info
 from quarkchain.evm.transactions import Transaction as EvmTransaction
 from quarkchain.protocol import AbstractConnection
 from quarkchain.utils import call_async, check, is_p2
@@ -482,16 +482,18 @@ class ClusterContext(ContextDecorator):
         shutdown_clusters(self.cluster_list)
 
 
-def mock_pay_native_token_as_gas(mock_pay=None):
+def mock_pay_native_token_as_gas(mock=None):
     # default mock: refund rate 100%, gas price unchanged
-    mock_pay = mock_pay or (lambda *x: (100, x[-1]))
+    mock = mock or (lambda *x: (100, x[-1]))
 
     def decorator(f):
         def wrapper(*args, **kwargs):
             import quarkchain.evm.messages as m
 
-            m.pay_native_token_as_gas = mock_pay
+            m.get_gas_utility_info = mock
+            m.pay_native_token_as_gas = mock
             ret = f(*args, **kwargs)
+            m.get_gas_utility_info = get_gas_utility_info
             m.pay_native_token_as_gas = pay_native_token_as_gas
             return ret
 

--- a/quarkchain/config.py
+++ b/quarkchain/config.py
@@ -351,8 +351,6 @@ class QuarkChainConfig(BaseConfig):
         self.init_and_validate()
 
         self._genesis_token = None  # genesis token id
-        self._allowed_token_ids = None  # set of allowed token ids based on config
-
         self._tx_whitelist_senders = None
 
     def init_and_validate(self):
@@ -540,32 +538,6 @@ class QuarkChainConfig(BaseConfig):
         if self._genesis_token is None:
             self._genesis_token = token_id_encode(self.GENESIS_TOKEN)
         return self._genesis_token
-
-    @property
-    def allowed_token_ids(self):
-        if self._allowed_token_ids is None:
-            self._allowed_token_ids = {self.genesis_token}
-            for _, shard in self.shards.items():
-                for _, alloc_data in shard.GENESIS.ALLOC.items():
-                    # genesis config is backward compatible:
-                    # v1: {addr: {QKC: 1234}}
-                    # v2: {addr: {balances: {QKC: 1234}, code: 0x, storage: {0x12: 0x34}}}
-                    balances = alloc_data
-                    if "balances" in alloc_data:
-                        balances = alloc_data["balances"]
-                    for k in balances:
-                        if k in ("code", "storage"):
-                            continue
-                        self._allowed_token_ids.add(token_id_encode(k))
-        return self._allowed_token_ids
-
-    @property
-    def allowed_transfer_token_ids(self):
-        return self.allowed_token_ids
-
-    @property
-    def allowed_gas_token_ids(self):
-        return self.allowed_token_ids
 
     @property
     def tx_whitelist_senders(self):

--- a/quarkchain/evm/exceptions.py
+++ b/quarkchain/evm/exceptions.py
@@ -32,3 +32,7 @@ class BlockGasLimitReached(InvalidTransaction):
 
 class GasPriceTooLow(InvalidTransaction):
     pass
+
+
+class InvalidNativeToken(InvalidTransaction):
+    pass

--- a/quarkchain/evm/messages.py
+++ b/quarkchain/evm/messages.py
@@ -152,17 +152,22 @@ def validate_transaction(state, tx):
     for token_id, b in bal.items():
         if b < cost[token_id]:
             raise InsufficientBalance(
-                rp(tx, "token %d balance" % token_id, b, cost[token_id])
+                rp(
+                    tx,
+                    "token %s balance" % token_id_decode(token_id),
+                    b,
+                    cost[token_id],
+                )
             )
 
-    # (6) if gas token non default, need to check system contract for gas conversion
+    # (6) if gas token non-default, need to check system contract for gas conversion
     if tx.gas_token_id != default_chain_token:
         _, genesis_token_gas_price = get_gas_utility_info(
             state, tx.gas_token_id, tx.gasprice
         )
         if genesis_token_gas_price == 0:
             raise InvalidNativeToken(
-                "{}: non-default gas token not ready for being used to pay gas".format(
+                "{}: non-default gas token {} not ready for being used to pay gas".format(
                     tx.__repr__(), token_id_decode(tx.gas_token_id)
                 )
             )
@@ -171,7 +176,7 @@ def validate_transaction(state, tx):
         )
         if bal_gas_reserve < genesis_token_gas_price * tx.startgas:
             raise InvalidNativeToken(
-                "{}: non-default gas token doesn't have enough balance in reserve for conversion".format(
+                "{}: non-default gas token {} not enough reserve balance for conversion".format(
                     tx.__repr__(), token_id_decode(tx.gas_token_id)
                 )
             )

--- a/quarkchain/evm/messages.py
+++ b/quarkchain/evm/messages.py
@@ -371,9 +371,11 @@ def apply_transaction(state, tx: transactions.Transaction, tx_wrapper_hash):
         refund_rate, converted_genesis_token_gas_price = pay_native_token_as_gas(
             state, tx.gas_token_id, tx.startgas, tx.gasprice
         )
+        # guaranteed by validation
         assert converted_genesis_token_gas_price > 0
         gasprice = converted_genesis_token_gas_price
         contract_addr = SystemContract.GENERAL_NATIVE_TOKEN.addr()
+        # guaranteed by validation
         assert (
             state.get_balance(contract_addr, token_id=state.genesis_token)
             >= tx.startgas * converted_genesis_token_gas_price

--- a/quarkchain/evm/messages.py
+++ b/quarkchain/evm/messages.py
@@ -374,10 +374,10 @@ def apply_transaction(state, tx: transactions.Transaction, tx_wrapper_hash):
         assert converted_genesis_token_gas_price > 0
         gasprice = converted_genesis_token_gas_price
         contract_addr = SystemContract.GENERAL_NATIVE_TOKEN.addr()
-        # assert (
-        #    state.get_balance(contract_addr, token_id=state.genesis_token)
-        #    >= tx.startgas * converted_genesis_token_gas_price
-        # )
+        assert (
+            state.get_balance(contract_addr, token_id=state.genesis_token)
+            >= tx.startgas * converted_genesis_token_gas_price
+        )
         state.delta_token_balance(
             contract_addr,
             state.genesis_token,

--- a/quarkchain/evm/messages.py
+++ b/quarkchain/evm/messages.py
@@ -143,21 +143,19 @@ def validate_transaction(state, tx):
         (tx.transfer_token_id, bal_transfer),
         (tx.gas_token_id, bal_gas),
     ]:
-        if token_id != state.shard_config.default_chain_token:
-            if bal == 0:
-                raise InvalidNativeToken(
-                    "{}: non-default token {} has zero balance".format(
-                        tx.__repr__(), token_id_decode(token_id)
-                    )
+        if token_id != state.shard_config.default_chain_token and bal == 0:
+            raise InvalidNativeToken(
+                "{}: non-default token {} has zero balance".format(
+                    tx.__repr__(), token_id_decode(token_id)
                 )
+            )
 
     # (5) the sender account balance contains at least the cost required in up-front payment
     cost = Counter({tx.transfer_token_id: tx.value}) + Counter(
         {tx.gas_token_id: tx.gasprice * tx.startgas}
     )
-    bal = Counter({tx.transfer_token_id: bal_transfer}) + Counter(
-        {tx.gas_token_id: bal_gas}
-    )
+    # key will override if the same
+    bal = Counter({tx.transfer_token_id: bal_transfer, tx.gas_token_id: bal_gas})
     for token_id, b in bal.items():
         if b < cost[token_id]:
             raise InsufficientBalance(

--- a/quarkchain/evm/messages.py
+++ b/quarkchain/evm/messages.py
@@ -16,7 +16,7 @@ from quarkchain.evm import bloom  # FIXME: use eth_bloom
 from quarkchain.evm import transactions
 from quarkchain.evm import opcodes
 from quarkchain.evm import vm
-from quarkchain.evm.specials import specials as default_specials, SystemContract
+from quarkchain.evm.specials import specials as default_specials
 from quarkchain.evm.exceptions import (
     InvalidNonce,
     InsufficientStartGas,


### PR DESCRIPTION
resolves #797 

1. removed allowed token checks
2. do not allow non-default token transaction if balance is zero
3. add validation steps when using non-default token for paying gas: the gas reserve should be ready and have enough default tokens to cover the gas
