### PR TITLE
Fix mock paying native token as gas

### DIFF
--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -126,7 +126,7 @@ class TestShardState(unittest.TestCase):
         shard_block.header.version = 0
         state.finalize_and_add_block(shard_block)
 
-    @mock_pay_native_token_as_gas
+    @mock_pay_native_token_as_gas()
     def test_gas_price(self):
         id_list = [Identity.create_random_identity() for _ in range(5)]
         acc_list = [Address.create_from_identity(i, full_shard_key=0) for i in id_list]
@@ -138,6 +138,7 @@ class TestShardState(unittest.TestCase):
                 "QI": 100000000,
                 "BTC": 100000000,
             },
+            charge_gas_reserve=True,
         )
 
         qkc_token = token_id_encode("QKC")
@@ -210,9 +211,9 @@ class TestShardState(unittest.TestCase):
         gas_price = state.gas_price(token_id=btc_token)
         self.assertEqual(gas_price, 0)
 
-        # unrecognized token id
+        # unrecognized token id should return 0
         gas_price = state.gas_price(token_id=1)
-        self.assertIsNone(gas_price)
+        self.assertEqual(gas_price, 0)
 
     def test_estimate_gas(self):
         id1 = Identity.create_random_identity()

--- a/quarkchain/cluster/tests/test_utils.py
+++ b/quarkchain/cluster/tests/test_utils.py
@@ -25,6 +25,7 @@ from quarkchain.db import InMemoryDb
 from quarkchain.diff import EthDifficultyCalculator
 from quarkchain.env import DEFAULT_ENV
 from quarkchain.evm.messages import pay_native_token_as_gas, get_gas_utility_info
+from quarkchain.evm.specials import SystemContract
 from quarkchain.evm.transactions import Transaction as EvmTransaction
 from quarkchain.protocol import AbstractConnection
 from quarkchain.utils import call_async, check, is_p2
@@ -38,6 +39,7 @@ def get_test_env(
     genesis_root_heights=None,  # dict(full_shard_id, genesis_root_height)
     remote_mining=False,
     genesis_minor_token_balances=None,
+    charge_gas_reserve=False,
 ):
     check(is_p2(shard_size))
     env = DEFAULT_ENV.copy()
@@ -76,6 +78,13 @@ def get_test_env(
         else:
             shard.GENESIS.ALLOC[addr] = {
                 env.quark_chain_config.GENESIS_TOKEN: genesis_minor_quarkash
+            }
+        if charge_gas_reserve:
+            gas_reserve_addr = (
+                SystemContract.GENERAL_NATIVE_TOKEN.addr().hex() + addr[-8:]
+            )
+            shard.GENESIS.ALLOC[gas_reserve_addr] = {
+                env.quark_chain_config.GENESIS_TOKEN: int(1e18)
             }
         shard.CONSENSUS_CONFIG.REMOTE_MINE = remote_mining
         shard.DIFFICULTY_ADJUSTMENT_CUTOFF_TIME = 7


### PR DESCRIPTION
the meta decorator needs to be invoked to have the desired effect. thanks to it, I've identified other failed test cases