### PR TITLE
Add grpc method for adding root block

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # QuarkChain
 
-![commit-build-test](https://github.com/QuarkChain/pyquarkchain/workflows/commit-build-test/badge.svg?branch=master)
+![commit-build-test](https://github.com/QuarkChain/pyquarkchain/workflows/commit-build-test/badge.svg?branch=dev)
 ![nightly-check-db](https://github.com/QuarkChain/pyquarkchain/workflows/nightly-check-db/badge.svg?branch=master)
 
 QuarkChain is a sharded blockchain protocol that employs a two-layer architecture - one extensible sharding layer consisting of multiple shard chains processing transactions and one root chain layer securing the network and coordinating cross-shard transactions among shard chains. The capacity of the network scales linearly as the number of shard chains increase while the root chain is always providing strong security guarantee regardless of the number of shards. QuarkChain testnet consistently hit [10,000+ TPS](https://youtu.be/dUldrq3zKwE?t=8m28s) with 256 shards run by 50 clusters consisting of 6450 servers with each loadtest submitting 3,000,000 transactions to the network.

--- a/quarkchain/cluster/grpc_client.py
+++ b/quarkchain/cluster/grpc_client.py
@@ -51,34 +51,6 @@ class GrpcClient:
             return False
 
         if response.status.code == 0:
-            if str(root_block.minor_block_header_list) == str(
-                request.minor_block_headers
-            ):
-                return True
-            else:
-                return False
+            return True
         else:
             return False
-
-
-if __name__ == "__main__":
-    logging.basicConfig()
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--host", type=str, default=HOST, help="server host")
-    parser.add_argument("--port", type=int, default=PORT, help="server port")
-
-    args = parser.parse_args()
-    HOST = args.host
-    PORT = args.port
-
-    client = GrpcClient(HOST, PORT)
-    minor_header_list = [
-        MinorBlockHeader(height=0, difficulty=5),
-        MinorBlockHeader(height=1, difficulty=5),
-    ]
-    block = RootBlock(
-        RootBlockHeader(create_time=42, difficulty=5),
-        tracking_data="{}".encode("utf-8"),
-        minor_block_header_list=minor_header_list,
-    )
-    client.add_root_block(block)

--- a/quarkchain/cluster/grpc_client.py
+++ b/quarkchain/cluster/grpc_client.py
@@ -51,7 +51,10 @@ class GrpcClient:
             return False
 
         if response.status.code == 0:
-            return True
+            if response.status.message == str(minor_block_header_list):
+                return True
+            else:
+                return False
         else:
             return False
 
@@ -74,6 +77,6 @@ if __name__ == "__main__":
     block = RootBlock(
         RootBlockHeader(create_time=42, difficulty=5),
         tracking_data="{}".encode("utf-8"),
-        minor_header_list=minor_header_list,
+        minor_block_header_list=minor_header_list,
     )
     client.add_root_block(block)

--- a/quarkchain/cluster/grpc_client.py
+++ b/quarkchain/cluster/grpc_client.py
@@ -15,7 +15,7 @@ class GrpcClient:
         self.client = grpc_pb2_grpc.ClusterSlaveStub(channel)
 
     def set_root_chain_confirmed_block(self) -> bool:
-        request = grpc_pb2.SetRootChainConfirmedBlock()
+        request = grpc_pb2_grpc.SetRootChainConfirmedBlock()
         try:
             response = self.client.SetRootChainConfirmedBlock(request)
         except Exception:

--- a/quarkchain/cluster/grpc_client.py
+++ b/quarkchain/cluster/grpc_client.py
@@ -14,7 +14,7 @@ class GrpcClient:
         channel = grpc.insecure_channel("{}:{}".format(host, str(port)))
         self.client = grpc_pb2_grpc.ClusterSlaveStub(channel)
 
-    def set_root_chain_confirmed_block(self) -> bool:
+    def set_rootchain_confirmed_block(self) -> bool:
         request = grpc_pb2.SetRootChainConfirmedBlockRequest()
         try:
             response = self.client.SetRootChainConfirmedBlock(request)
@@ -32,13 +32,12 @@ class GrpcClient:
             root_block.header.hash_prev_block,
             root_block.header.height,
         )
-        minor_block_header_list = []
-        for m_header in root_block.minor_block_header_list:
-            m_full_shard_id = m_header.branch.get_full_shard_id()
-            minor_block_header = grpc_pb2.MinorBlockHeader(
-                id=m_header.get_hash(), full_shard_id=m_full_shard_id,
+        minor_block_header_list = [
+            grpc_pb2.MinorBlockHeader(
+                id=mh.get_hash(), full_shard_id=mh.get_full_shard_id()
             )
-            minor_block_header_list.append(minor_block_header)
+            for mh in root_block.minor_block_header_list
+        ]
 
         request = grpc_pb2.AddRootBlockRequest(
             id=id,

--- a/quarkchain/cluster/grpc_client.py
+++ b/quarkchain/cluster/grpc_client.py
@@ -27,8 +27,8 @@ class GrpcClient:
 
     def add_root_block(self, root_block) -> bool:
         id, prev_id, height = (
-            b"rblock_" + root_block.header.get_hash(),
-            b"rblock_" + root_block.header.hash_prev_block,
+            root_block.header.get_hash(),
+            root_block.header.hash_prev_block,
             root_block.header.height,
         )
         minor_block_header_list = []
@@ -38,7 +38,7 @@ class GrpcClient:
                 4, byteorder="big"
             )
             minor_block_header = grpc_pb2.MinorBlockHeader(
-                id=b"m_r_" + m_block_id.id, full_shard_id=m_full_shard_id,
+                id=m_block_id.id, full_shard_id=m_full_shard_id,
             )
             minor_block_header_list.append(minor_block_header)
 

--- a/quarkchain/cluster/grpc_client.py
+++ b/quarkchain/cluster/grpc_client.py
@@ -27,14 +27,18 @@ class GrpcClient:
 
     def add_root_block(self, root_block) -> bool:
         id, prev_id, height = (
-            root_block.header.id,
-            root_block.header.prev_id,
+            b"rblock_" + root_block.header.get_hash(),
+            b"rblock_" + root_block.header.hash_prev_block,
             root_block.header.height,
         )
         minor_block_header_list = []
         for m_header in root_block.minor_block_header_list:
+            m_full_shard_id = m_header.branch.get_full_shard_id()
+            m_block_id = m_header.get_hash() + m_full_shard_id.to_bytes(
+                4, byteorder="big"
+            )
             minor_block_header = grpc_pb2.MinorBlockHeader(
-                id=m_header.id, full_shard_id=m_header.full_shard_id
+                id=b"m_r_" + m_block_id.id, full_shard_id=m_full_shard_id,
             )
             minor_block_header_list.append(minor_block_header)
 

--- a/quarkchain/cluster/grpc_client.py
+++ b/quarkchain/cluster/grpc_client.py
@@ -51,7 +51,9 @@ class GrpcClient:
             return False
 
         if response.status.code == 0:
-            if response.status.message == str(minor_block_header_list):
+            if str(root_block.minor_block_header_list) == str(
+                request.minor_block_headers
+            ):
                 return True
             else:
                 return False

--- a/quarkchain/cluster/grpc_client.py
+++ b/quarkchain/cluster/grpc_client.py
@@ -3,7 +3,7 @@ import argparse
 import grpc
 
 from quarkchain.generated import grpc_pb2, grpc_pb2_grpc
-from quarkchain.core import RootBlock, RootBlockHeader
+from quarkchain.core import RootBlock, RootBlockHeader, MinorBlockHeader
 
 HOST = "localhost"
 PORT = 50051
@@ -34,7 +34,7 @@ class GrpcClient:
         )
         minor_block_header_list = [
             grpc_pb2.MinorBlockHeader(
-                id=mh.get_hash(), full_shard_id=mh.get_full_shard_id()
+                id=mh.get_hash(), full_shard_id=mh.branch.get_full_shard_id()
             )
             for mh in root_block.minor_block_header_list
         ]
@@ -67,9 +67,13 @@ if __name__ == "__main__":
     PORT = args.port
 
     client = GrpcClient(HOST, PORT)
-
+    minor_header_list = [
+        MinorBlockHeader(height=0, difficulty=5),
+        MinorBlockHeader(height=1, difficulty=5),
+    ]
     block = RootBlock(
         RootBlockHeader(create_time=42, difficulty=5),
         tracking_data="{}".encode("utf-8"),
+        minor_header_list=minor_header_list,
     )
     client.add_root_block(block)

--- a/quarkchain/cluster/grpc_client.py
+++ b/quarkchain/cluster/grpc_client.py
@@ -15,7 +15,7 @@ class GrpcClient:
         self.client = grpc_pb2_grpc.ClusterSlaveStub(channel)
 
     def set_root_chain_confirmed_block(self) -> bool:
-        request = grpc_pb2_grpc.SetRootChainConfirmedBlock()
+        request = grpc_pb2.SetRootChainConfirmedBlockRequest()
         try:
             response = self.client.SetRootChainConfirmedBlock(request)
         except Exception:
@@ -40,7 +40,7 @@ class GrpcClient:
             )
             minor_block_header_list.append(minor_block_header)
 
-        request = grpc_pb2.AddRootBlock(
+        request = grpc_pb2.AddRootBlockRequest(
             id=id,
             prev_id=prev_id,
             height=height,

--- a/quarkchain/cluster/tests/test_grpc_client.py
+++ b/quarkchain/cluster/tests/test_grpc_client.py
@@ -13,12 +13,28 @@ class NormalServer(grpc_pb2_grpc.ClusterSlaveServicer):
             status=grpc_pb2.ClusterSlaveStatus(code=0, message="Confirmed")
         )
 
+    def SetRootChainConfirmedBlock(self, request, context):
+        return grpc_pb2.SetRootChainConfirmedBlockResponse(
+            status=grpc_pb2.ClusterSlaveStatus(code=0, message="Confirmed")
+        )
+
+    # def FinalizeMinorBlock(self, request, context):
+    #     return grpc_pb2.FinalizeMinorBlockResponse()
+
 
 class ErrorServer(grpc_pb2_grpc.ClusterSlaveServicer):
     def AddRootBlock(self, request, context):
         return grpc_pb2.AddRootBlockResponse(
             status=grpc_pb2.ClusterSlaveStatus(code=1, message="Confirmed")
         )
+
+    def SetRootChainConfirmedBlock(self, request, context):
+        return grpc_pb2.AddRootBlockResponse(
+            status=grpc_pb2.ClusterSlaveStatus(code=1, message="Confirmed")
+        )
+
+    # def FinalizeMinorBlock(self, request, context):
+    #     return grpc_pb2.FinalizeMinorBlockResponse()
 
 
 class TestGrpcClient(unittest.TestCase):

--- a/quarkchain/cluster/tests/test_grpc_client.py
+++ b/quarkchain/cluster/tests/test_grpc_client.py
@@ -5,12 +5,13 @@ from concurrent import futures
 from quarkchain.generated import grpc_pb2
 from quarkchain.generated import grpc_pb2_grpc
 from quarkchain.cluster.grpc_client import GrpcClient
+from quarkchain.core import RootBlockHeader, RootBlock
 
 
 class NormalServer(grpc_pb2_grpc.ClusterSlaveServicer):
     def AddRootBlock(self, request, context):
         return grpc_pb2.AddRootBlockResponse(
-            status=grpc_pb2.ClusterSlaveStatus(code=0, message="Confirmed")
+            status=grpc_pb2.ClusterSlaveStatus(code=0, message="Added")
         )
 
     def SetRootChainConfirmedBlock(self, request, context):
@@ -18,23 +19,17 @@ class NormalServer(grpc_pb2_grpc.ClusterSlaveServicer):
             status=grpc_pb2.ClusterSlaveStatus(code=0, message="Confirmed")
         )
 
-    # def FinalizeMinorBlock(self, request, context):
-    #     return grpc_pb2.FinalizeMinorBlockResponse()
-
 
 class ErrorServer(grpc_pb2_grpc.ClusterSlaveServicer):
     def AddRootBlock(self, request, context):
         return grpc_pb2.AddRootBlockResponse(
-            status=grpc_pb2.ClusterSlaveStatus(code=1, message="Confirmed")
+            status=grpc_pb2.ClusterSlaveStatus(code=1, message="Added")
         )
 
     def SetRootChainConfirmedBlock(self, request, context):
         return grpc_pb2.AddRootBlockResponse(
             status=grpc_pb2.ClusterSlaveStatus(code=1, message="Confirmed")
         )
-
-    # def FinalizeMinorBlock(self, request, context):
-    #     return grpc_pb2.FinalizeMinorBlockResponse()
 
 
 class TestGrpcClient(unittest.TestCase):
@@ -48,7 +43,7 @@ class TestGrpcClient(unittest.TestCase):
         # This test is used to check connection exception, if there is no server or inconsistent ports, return False
         client_host = "localhost"
         client_port = 50011
-        resp = GrpcClient(client_host, client_port).add_root_block()
+        resp = GrpcClient(client_host, client_port).set_root_chain_confirmed_block()
         self.assertFalse(resp)
 
     def test_status_code(self):
@@ -58,13 +53,22 @@ class TestGrpcClient(unittest.TestCase):
         server0 = self.build_test_server(NormalServer, server_port1)
         server0.start()
 
-        resp0 = GrpcClient(client_host, server_port1).add_root_block()
+        block = RootBlock(
+            RootBlockHeader(create_time=42, difficulty=5),
+            tracking_data="{}".encode("utf-8"),
+        )
+
+        resp0 = GrpcClient(client_host, server_port1).set_root_chain_confirmed_block()
+        resp1 = GrpcClient(client_host, server_port1).add_root_block(root_block=block)
         self.assertTrue(resp0)
+        self.assertTrue(resp1)
         server0.stop(None)
 
         server1 = self.build_test_server(ErrorServer, server_port2)
         server1.start()
 
-        resp1 = GrpcClient(client_host, server_port2).add_root_block()
-        self.assertFalse(resp1)
+        resp2 = GrpcClient(client_host, server_port2).set_root_chain_confirmed_block()
+        resp3 = GrpcClient(client_host, server_port2).add_root_block(root_block=block)
+        self.assertFalse(resp2)
+        self.assertFalse(resp3)
         server1.stop(None)

--- a/quarkchain/cluster/tests/test_grpc_client.py
+++ b/quarkchain/cluster/tests/test_grpc_client.py
@@ -8,15 +8,15 @@ from quarkchain.cluster.grpc_client import GrpcClient
 
 
 class NormalServer(grpc_pb2_grpc.ClusterSlaveServicer):
-    def SetRootChainConfirmedBlock(self, request, context):
-        return grpc_pb2.SetRootChainConfirmedBlockResponse(
+    def AddRootBlock(self, request, context):
+        return grpc_pb2.AddRootBlockResponse(
             status=grpc_pb2.ClusterSlaveStatus(code=0, message="Confirmed")
         )
 
 
 class ErrorServer(grpc_pb2_grpc.ClusterSlaveServicer):
-    def SetRootChainConfirmedBlock(self, request, context):
-        return grpc_pb2.SetRootChainConfirmedBlockResponse(
+    def AddRootBlock(self, request, context):
+        return grpc_pb2.AddRootBlockResponse(
             status=grpc_pb2.ClusterSlaveStatus(code=1, message="Confirmed")
         )
 
@@ -32,7 +32,7 @@ class TestGrpcClient(unittest.TestCase):
         # This test is used to check connection exception, if there is no server or inconsistent ports, return False
         client_host = "localhost"
         client_port = 50011
-        resp = GrpcClient(client_host, client_port).set_rootchain_confirmed_block()
+        resp = GrpcClient(client_host, client_port).add_root_block()
         self.assertFalse(resp)
 
     def test_status_code(self):
@@ -42,13 +42,13 @@ class TestGrpcClient(unittest.TestCase):
         server0 = self.build_test_server(NormalServer, server_port1)
         server0.start()
 
-        resp0 = GrpcClient(client_host, server_port1).set_rootchain_confirmed_block()
+        resp0 = GrpcClient(client_host, server_port1).add_root_block()
         self.assertTrue(resp0)
         server0.stop(None)
 
         server1 = self.build_test_server(ErrorServer, server_port2)
         server1.start()
 
-        resp1 = GrpcClient(client_host, server_port2).set_rootchain_confirmed_block()
+        resp1 = GrpcClient(client_host, server_port2).add_root_block()
         self.assertFalse(resp1)
         server1.stop(None)

--- a/quarkchain/cluster/tests/test_grpc_client.py
+++ b/quarkchain/cluster/tests/test_grpc_client.py
@@ -5,14 +5,21 @@ from concurrent import futures
 from quarkchain.generated import grpc_pb2
 from quarkchain.generated import grpc_pb2_grpc
 from quarkchain.cluster.grpc_client import GrpcClient
-from quarkchain.core import RootBlockHeader, RootBlock
+from quarkchain.core import RootBlockHeader, RootBlock, MinorBlockHeader
 
 
 class NormalServer(grpc_pb2_grpc.ClusterSlaveServicer):
     def AddRootBlock(self, request, context):
-        return grpc_pb2.AddRootBlockResponse(
-            status=grpc_pb2.ClusterSlaveStatus(code=0, message="Added")
+        grpc_request = grpc_pb2.AddRootBlockRequest(
+            id=request.id,
+            prev_id=request.prev_id,
+            height=request.height,
+            minor_block_headers=request.minor_block_headers,
         )
+        if request.minor_block_headers == grpc_request.minor_block_headers:
+            return grpc_pb2.AddRootBlockResponse(
+                status=grpc_pb2.ClusterSlaveStatus(code=0, message="Added")
+            )
 
     def SetRootChainConfirmedBlock(self, request, context):
         return grpc_pb2.SetRootChainConfirmedBlockResponse(
@@ -22,9 +29,16 @@ class NormalServer(grpc_pb2_grpc.ClusterSlaveServicer):
 
 class ErrorServer(grpc_pb2_grpc.ClusterSlaveServicer):
     def AddRootBlock(self, request, context):
-        return grpc_pb2.AddRootBlockResponse(
-            status=grpc_pb2.ClusterSlaveStatus(code=1, message="Added")
+        grpc_request = grpc_pb2.AddRootBlockRequest(
+            id=request.id,
+            prev_id=request.prev_id,
+            height=request.height,
+            minor_block_headers=request.minor_block_headers,
         )
+        if request.minor_block_headers != grpc_request.minor_block_headers:
+            return grpc_pb2.AddRootBlockResponse(
+                status=grpc_pb2.ClusterSlaveStatus(code=1, message="Added")
+            )
 
     def SetRootChainConfirmedBlock(self, request, context):
         return grpc_pb2.AddRootBlockResponse(
@@ -53,15 +67,20 @@ class TestGrpcClient(unittest.TestCase):
         server0 = self.build_test_server(NormalServer, server_port1)
         server0.start()
 
+        minor_header_list = [
+            MinorBlockHeader(height=0, difficulty=5),
+            MinorBlockHeader(height=1, difficulty=5),
+        ]
         block = RootBlock(
             RootBlockHeader(create_time=42, difficulty=5),
             tracking_data="{}".encode("utf-8"),
+            minor_block_header_list=minor_header_list,
         )
 
         client1 = GrpcClient(client_host, server_port1)
         resp0 = client1.set_rootchain_confirmed_block()
-        resp1 = client1.add_root_block(root_block=block)
         self.assertTrue(resp0)
+        resp1 = client1.add_root_block(root_block=block)
         self.assertTrue(resp1)
         server0.stop(None)
 
@@ -70,7 +89,7 @@ class TestGrpcClient(unittest.TestCase):
 
         client2 = GrpcClient(client_host, server_port2)
         resp2 = client2.set_rootchain_confirmed_block()
-        resp3 = client2.add_root_block(root_block=block)
         self.assertFalse(resp2)
+        resp3 = client2.add_root_block(root_block=block)
         self.assertFalse(resp3)
         server1.stop(None)

--- a/quarkchain/cluster/tests/test_grpc_client.py
+++ b/quarkchain/cluster/tests/test_grpc_client.py
@@ -43,7 +43,7 @@ class TestGrpcClient(unittest.TestCase):
         # This test is used to check connection exception, if there is no server or inconsistent ports, return False
         client_host = "localhost"
         client_port = 50011
-        resp = GrpcClient(client_host, client_port).set_root_chain_confirmed_block()
+        resp = GrpcClient(client_host, client_port).set_rootchain_confirmed_block()
         self.assertFalse(resp)
 
     def test_status_code(self):
@@ -58,8 +58,9 @@ class TestGrpcClient(unittest.TestCase):
             tracking_data="{}".encode("utf-8"),
         )
 
-        resp0 = GrpcClient(client_host, server_port1).set_root_chain_confirmed_block()
-        resp1 = GrpcClient(client_host, server_port1).add_root_block(root_block=block)
+        client1 = GrpcClient(client_host, server_port1)
+        resp0 = client1.set_rootchain_confirmed_block()
+        resp1 = client1.add_root_block(root_block=block)
         self.assertTrue(resp0)
         self.assertTrue(resp1)
         server0.stop(None)
@@ -67,8 +68,9 @@ class TestGrpcClient(unittest.TestCase):
         server1 = self.build_test_server(ErrorServer, server_port2)
         server1.start()
 
-        resp2 = GrpcClient(client_host, server_port2).set_root_chain_confirmed_block()
-        resp3 = GrpcClient(client_host, server_port2).add_root_block(root_block=block)
+        client2 = GrpcClient(client_host, server_port2)
+        resp2 = client2.set_rootchain_confirmed_block()
+        resp3 = client2.add_root_block(root_block=block)
         self.assertFalse(resp2)
         self.assertFalse(resp3)
         server1.stop(None)

--- a/quarkchain/proto/grpc.proto
+++ b/quarkchain/proto/grpc.proto
@@ -1,32 +1,57 @@
 // SPDX-License-Identifier: Apache-2.0
+
 syntax = "proto3";
+
 package cluster;
 
-message RootBlockHeader {
-  bytes id = 1;
-  uint32 height = 2;
-  bytes prev_id = 3;
+
+message SetRootChainConfirmedBlockRequest {
 }
-message MinorBlockHeader {
-  bytes id = 1;
-  uint32 full_shard_id = 2;
+
+message FinalizeMinorBlockRequest {
 }
-message AddRootBlockRequest {
-  RootBlockHeader root_block_header = 1;
-  repeated MinorBlockHeader minor_block_headers = 2;
-}
+
 message ClusterSlaveStatus {
   int32 code = 1;
   string message = 2;
 }
+
+message MinorBlockHeader {
+    bytes id = 1;
+    uint32 full_shard_id = 2;
+}
+
+message AddRootBlockRequest {
+  bytes id = 1;
+  bytes prev_id = 2;
+  uint64 height = 3;
+  repeated MinorBlockHeader minor_block_headers = 4;
+}
+
+
+message SetRootChainConfirmedBlockResponse {
+  ClusterSlaveStatus status = 1;
+}
+
+message FinalizeMinorBlockResponse {
+}
+
 message AddRootBlockResponse {
   ClusterSlaveStatus status = 1;
 }
+
 // -----------------------------------------------------------------------------
 // ---------------- Service definition
 // -----------------------------------------------------------------------------
 service ClusterSlave {
   // Master's command for setting rootchain-confirmed block.
+  rpc SetRootChainConfirmedBlock(SetRootChainConfirmedBlockRequest)
+      returns (SetRootChainConfirmedBlockResponse) {}
+
+  // Commit a minor block from root chain.
+  rpc FinalizeMinorBlock(FinalizeMinorBlockRequest)
+      returns (FinalizeMinorBlockResponse) {}
+
   rpc AddRootBlock(AddRootBlockRequest)
       returns (AddRootBlockResponse) {}
 }

--- a/quarkchain/proto/grpc.proto
+++ b/quarkchain/proto/grpc.proto
@@ -1,23 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 syntax = "proto3";
 package cluster;
+
 message RootBlockHeader {
   bytes id = 1;
   uint32 height = 2;
-  bytes prev_hash = 3;
-  bytes merkle_hash = 4;
-  bytes evm_hash = 5;
-  bytes mix_hash = 6;
-  bytes sig = 7;
+  bytes prev_id = 3;
 }
 message MinorBlockHeader {
   bytes id = 1;
   uint32 full_shard_id = 2;
-  bytes hash_prev_minor_block = 3;
-  bytes hash_prev_root_block = 4;
-  bytes mix_hash = 5;
 }
-message SetRootChainConfirmedBlockRequest {
+message AddRootBlockRequest {
   RootBlockHeader root_block_header = 1;
   repeated MinorBlockHeader minor_block_headers = 2;
 }
@@ -25,7 +19,7 @@ message ClusterSlaveStatus {
   int32 code = 1;
   string message = 2;
 }
-message SetRootChainConfirmedBlockResponse {
+message AddRootBlockResponse {
   ClusterSlaveStatus status = 1;
 }
 // -----------------------------------------------------------------------------
@@ -33,6 +27,6 @@ message SetRootChainConfirmedBlockResponse {
 // -----------------------------------------------------------------------------
 service ClusterSlave {
   // Master's command for setting rootchain-confirmed block.
-  rpc SetRootChainConfirmedBlock(SetRootChainConfirmedBlockRequest)
-      returns (SetRootChainConfirmedBlockResponse) {}
+  rpc AddRootBlock(AddRootBlockRequest)
+      returns (AddRootBlockResponse) {}
 }

--- a/quarkchain/proto/grpc.proto
+++ b/quarkchain/proto/grpc.proto
@@ -1,22 +1,33 @@
 // SPDX-License-Identifier: Apache-2.0
-
 syntax = "proto3";
-
 package cluster;
-
-message SetRootChainConfirmedBlockRequest {
+message RootBlockHeader {
+  bytes id = 1;
+  uint32 height = 2;
+  bytes prev_hash = 3;
+  bytes merkle_hash = 4;
+  bytes evm_hash = 5;
+  bytes mix_hash = 6;
+  bytes sig = 7;
 }
-
+message MinorBlockHeader {
+  bytes id = 1;
+  uint32 full_shard_id = 2;
+  bytes hash_prev_minor_block = 3;
+  bytes hash_prev_root_block = 4;
+  bytes mix_hash = 5;
+}
+message SetRootChainConfirmedBlockRequest {
+  RootBlockHeader root_block_header = 1;
+  repeated MinorBlockHeader minor_block_headers = 2;
+}
 message ClusterSlaveStatus {
   int32 code = 1;
   string message = 2;
 }
-
-
 message SetRootChainConfirmedBlockResponse {
   ClusterSlaveStatus status = 1;
 }
-
 // -----------------------------------------------------------------------------
 // ---------------- Service definition
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Add simplified libra root block structure to grpc_client.proto. The draft structure of libra root block mainly includes the root block id, block height, hashes, signature and minor block headers. More adjustments of proto and grpc_client.py will be made accordingly. 