### PR TITLE
Support AddRootBlock GRPC

### DIFF
--- a/quarkchain/cluster/grpc_client.py
+++ b/quarkchain/cluster/grpc_client.py
@@ -51,12 +51,12 @@ class GrpcClient:
             Logger.log_exception()
             return False
 
-        if response.status.code == 0:
-            return True
-        else:
-            Logger.warning(
+        if response.status.code != 0:
+            Logger.error(
                 "GRPC failure: {}, {}".format(
                     response.status.code, response.status.message
                 )
             )
             return False
+
+        return True

--- a/quarkchain/cluster/grpc_client.py
+++ b/quarkchain/cluster/grpc_client.py
@@ -3,6 +3,7 @@ import argparse
 import grpc
 from quarkchain.generated import grpc_pb2, grpc_pb2_grpc
 from quarkchain.core import RootBlock, RootBlockHeader, MinorBlockHeader
+from quarkchain.utils import Logger
 
 HOST = "localhost"
 PORT = 50051
@@ -46,10 +47,16 @@ class GrpcClient:
         )
         try:
             response = self.client.AddRootBlock(request)
-        except Exception:
+        except grpc.RpcError as e:
+            Logger.log_exception()
             return False
 
         if response.status.code == 0:
             return True
         else:
+            Logger.warning(
+                "GRPC failure: {}, {}".format(
+                    response.status.code, response.status.message
+                )
+            )
             return False

--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -1293,6 +1293,7 @@ class MasterServer:
 
         for grpc_client in self.grpc_slave_pool:
             grpc_client.set_rootchain_confirmed_block()
+            grpc_client.add_root_block(r_block)
 
         result_list = await asyncio.gather(*future_list)
         check(all([resp.error_code == 0 for _, resp, _ in result_list]))

--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -1292,7 +1292,6 @@ class MasterServer:
         )
 
         for grpc_client in self.grpc_slave_pool:
-            grpc_client.set_rootchain_confirmed_block()
             grpc_client.add_root_block(r_block)
 
         result_list = await asyncio.gather(*future_list)

--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -1292,7 +1292,7 @@ class MasterServer:
         )
 
         for grpc_client in self.grpc_slave_pool:
-            grpc_client.add_root_block(r_block)
+            check(grpc_client.add_root_block(r_block), "Fail to call GRPC slave")
 
         result_list = await asyncio.gather(*future_list)
         check(all([resp.error_code == 0 for _, resp, _ in result_list]))

--- a/quarkchain/cluster/tests/test_cluster.py
+++ b/quarkchain/cluster/tests/test_cluster.py
@@ -50,28 +50,16 @@ def _tip_gen(shard_state):
 class MockGrpcServer(grpc_pb2_grpc.ClusterSlaveServicer):
     def __init__(self, expected_minor_block_headers):
         self.request_num = 0
-        self.expected_minor_block_headers = (
-            expected_minor_block_headers
-        )  # type: List[MinorBlockHeader]
 
     def SetRootChainConfirmedBlock(self, request, context):
-        self.request_num += 1
         return grpc_pb2.SetRootChainConfirmedBlockResponse(
             status=grpc_pb2.ClusterSlaveStatus(code=0, message="Test")
         )
 
     def AddRootBlock(self, request, context):
-        assert len(self.expected_minor_block_headers) == len(
-            request.minor_block_headers
-        )
-        for expected_mh, mh in zip(
-            self.expected_minor_block_headers, request.minor_block_headers
-        ):
-            assert expected_mh.get_hash() == mh.id
-            assert expected_mh.branch.get_full_shard_id() == mh.full_shard_id
-
+        self.request_num += 1
         return grpc_pb2.AddRootBlockResponse(
-            status=grpc_pb2.ClusterSlaveStatus(code=0, message="Confirmed")
+            status=grpc_pb2.ClusterSlaveStatus(code=0, message="Test")
         )
 
 

--- a/quarkchain/cluster/tests/test_cluster.py
+++ b/quarkchain/cluster/tests/test_cluster.py
@@ -48,7 +48,7 @@ def _tip_gen(shard_state):
 
 
 class MockGrpcServer(grpc_pb2_grpc.ClusterSlaveServicer):
-    def __init__(self, expected_minor_block_headers):
+    def __init__(self):
         self.request_num = 0
 
     def SetRootChainConfirmedBlock(self, request, context):
@@ -2466,7 +2466,7 @@ class TestCluster(unittest.TestCase):
             # This case tests the correct connection
             root_block = clusters[0].master.root_state.create_block_to_mine([])
             grpc_slaves = clusters[0].master.env.cluster_config.GRPC_SLAVE_LIST
-            server = MockGrpcServer(root_block.minor_block_header_list)
+            server = MockGrpcServer()
             grpc_server1 = self.build_test_server(
                 server, grpc_slaves[0].HOST, grpc_slaves[0].PORT,
             )


### PR DESCRIPTION
(Open this new pull request to prevent from picking up unnecessary histories.)
In this pr, we add call to methods of GRPC client in add_root_block() function of master.py. This method is to  broadcast root blocks to all shards. Tests are also added in test_cluster.py.
For network failure, we first considered different types of errors such as connection lost and timeout error. However, under these conditions, we are unable to retry to connect GRPC slave again, nor could we get a timeout error if we don't specify a timeout for the operations.  As a result, we simply conclude all failures as network error and application error and describe what kind of failure it is with an error message.