### PR TITLE
adding tx to queue needs to check gasprice in QKC

### DIFF
--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -1205,8 +1205,6 @@ class MasterServer:
     async def add_transaction(self, tx: TypedTransaction, from_peer=None):
         """ Add transaction to the cluster and broadcast to peers """
         evm_tx = tx.tx.to_evm_tx()  # type: EvmTransaction
-        if evm_tx.gasprice < self.env.quark_chain_config.MIN_TX_POOL_GAS_PRICE:
-            return False
         evm_tx.set_quark_chain_config(self.env.quark_chain_config)
         branch = Branch(evm_tx.from_full_shard_id)
         if branch.value not in self.branch_to_slaves:

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -39,7 +39,7 @@ from quarkchain.evm.messages import (
     apply_transaction,
     validate_transaction,
     apply_xshard_deposit,
-    get_genesis_gasprice,
+    convert_to_default_chain_token_gasprice,
 )
 from quarkchain.evm.specials import SystemContract
 from quarkchain.evm.state import State as EvmState
@@ -543,10 +543,10 @@ class ShardState:
             # Don't add the tx if the gasprice in QKC is too low.
             # Note that this is not enforced by consensus,
             # but miners will likely discard the tx if the gasprice is too low.
-            genesis_gasprice = get_genesis_gasprice(
+            default_gasprice = convert_to_default_chain_token_gasprice(
                 evm_state, evm_tx.gas_token_id, evm_tx.gasprice
             )
-            if genesis_gasprice < self.env.quark_chain_config.MIN_TX_POOL_GAS_PRICE:
+            if default_gasprice < self.env.quark_chain_config.MIN_TX_POOL_GAS_PRICE:
                 return False
 
             self.tx_queue.add_transaction(tx)
@@ -1202,11 +1202,11 @@ class ShardState:
             evm_tx = tx.tx.to_evm_tx()
             evm_tx.set_quark_chain_config(self.env.quark_chain_config)
 
-            genesis_gasprice = get_genesis_gasprice(
+            default_gasprice = convert_to_default_chain_token_gasprice(
                 evm_state, evm_tx.gas_token_id, evm_tx.gasprice
             )
             # simply ignore tx with lower gas price than specified
-            if genesis_gasprice < self.env.quark_chain_config.MIN_MINING_GAS_PRICE:
+            if default_gasprice < self.env.quark_chain_config.MIN_MINING_GAS_PRICE:
                 continue
 
             # check if TX is disabled

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -39,6 +39,7 @@ from quarkchain.evm.messages import (
     apply_transaction,
     validate_transaction,
     apply_xshard_deposit,
+    get_genesis_gasprice,
 )
 from quarkchain.evm.specials import SystemContract
 from quarkchain.evm.state import State as EvmState
@@ -538,6 +539,16 @@ class ShardState:
             evm_tx = self.__validate_tx(
                 tx, evm_state, xshard_gas_limit=xshard_gas_limit
             )
+
+            # Don't add the tx if the gasprice in QKC is too low.
+            # Note that this is not enforced by consensus,
+            # but miners will likely discard the tx if the gasprice is too low.
+            genesis_gasprice = get_genesis_gasprice(
+                evm_state, evm_tx.gas_token_id, evm_tx.gasprice
+            )
+            if genesis_gasprice < self.env.quark_chain_config.MIN_TX_POOL_GAS_PRICE:
+                return False
+
             self.tx_queue.add_transaction(tx)
             asyncio.ensure_future(
                 self.subscription_manager.notify_new_pending_tx(
@@ -1189,12 +1200,14 @@ class ShardState:
                 break
 
             evm_tx = tx.tx.to_evm_tx()
-
-            # simply ignore tx with lower gas price than specified
-            if evm_tx.gasprice < self.env.quark_chain_config.MIN_MINING_GAS_PRICE:
-                continue
-
             evm_tx.set_quark_chain_config(self.env.quark_chain_config)
+
+            genesis_gasprice = get_genesis_gasprice(
+                evm_state, evm_tx.gas_token_id, evm_tx.gasprice
+            )
+            # simply ignore tx with lower gas price than specified
+            if genesis_gasprice < self.env.quark_chain_config.MIN_MINING_GAS_PRICE:
+                continue
 
             # check if TX is disabled
             if (

--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -28,7 +28,7 @@ from quarkchain.evm.messages import (
     get_gas_utility_info,
     pay_native_token_as_gas,
     validate_transaction,
-    get_genesis_gasprice,
+    convert_to_default_chain_token_gasprice,
 )
 from quarkchain.evm.specials import SystemContract
 from quarkchain.evm.state import State as EvmState
@@ -3275,7 +3275,9 @@ class TestShardState(unittest.TestCase):
         # get the gas utility information by calling the get_gas_utility_info function
         refund_percentage, gas_price = get_gas_utility_info(evm_state, token_id, 60000)
         self.assertEqual((refund_percentage, gas_price), (60, 2))
-        self.assertEqual(get_genesis_gasprice(evm_state, token_id, 60000), 2)
+        self.assertEqual(
+            convert_to_default_chain_token_gasprice(evm_state, token_id, 60000), 2
+        )
         # exchange the Qkc with the native token
         refund_percentage, gas_price = pay_native_token_as_gas(
             evm_state, token_id, 1, 60000

--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -28,6 +28,7 @@ from quarkchain.evm.messages import (
     get_gas_utility_info,
     pay_native_token_as_gas,
     validate_transaction,
+    get_genesis_gasprice,
 )
 from quarkchain.evm.specials import SystemContract
 from quarkchain.evm.state import State as EvmState
@@ -3274,6 +3275,7 @@ class TestShardState(unittest.TestCase):
         # get the gas utility information by calling the get_gas_utility_info function
         refund_percentage, gas_price = get_gas_utility_info(evm_state, token_id, 60000)
         self.assertEqual((refund_percentage, gas_price), (60, 2))
+        self.assertEqual(get_genesis_gasprice(evm_state, token_id, 60000), 2)
         # exchange the Qkc with the native token
         refund_percentage, gas_price = pay_native_token_as_gas(
             evm_state, token_id, 1, 60000

--- a/quarkchain/evm/messages.py
+++ b/quarkchain/evm/messages.py
@@ -114,7 +114,7 @@ def mk_receipt(state, success, logs, contract_address, contract_full_shard_key):
     return o
 
 
-def get_genesis_gasprice(state, token_id, gas_price):
+def convert_to_default_chain_token_gasprice(state, token_id, gas_price):
     if token_id == state.shard_config.default_chain_token:
         return gas_price
     snapshot = state.snapshot()

--- a/quarkchain/evm/messages.py
+++ b/quarkchain/evm/messages.py
@@ -114,6 +114,15 @@ def mk_receipt(state, success, logs, contract_address, contract_full_shard_key):
     return o
 
 
+def get_genesis_gasprice(state, token_id, gas_price):
+    if token_id == state.shard_config.default_chain_token:
+        return gas_price
+    snapshot = state.snapshot()
+    _, genesis_token_gas_price = get_gas_utility_info(state, token_id, gas_price)
+    state.revert(snapshot)
+    return genesis_token_gas_price
+
+
 def validate_transaction(state, tx):
     # (1) The transaction signature is valid;
     if not tx.sender:  # sender is set and validated on Transaction initialization


### PR DESCRIPTION
This diff will enforce the minimum gasprice in QKC using converted QKC gasprice instead of gasprice of a native token directly.  This avoids that a tx of a non-native token may be discarded since its gasprice is too small.

Following the fix, a couple of following things should be done:
- More cluster tests with mnt
- The transaction queue will order the txs by their gasprice in QKC instead of gasprice in their native token.
