### PR TITLE
fix equal cmp for TokenBalanceMap

### DIFF
--- a/quarkchain/core.py
+++ b/quarkchain/core.py
@@ -587,6 +587,10 @@ class TokenBalanceMap(Serializable):
     def get_hash(self):
         return sha3_256(self.serialize())
 
+    def __eq__(self, other):
+        # TODO: Could implement in a more-efficient way, but make sure skip_func works.
+        return self.serialize() == other.serialize()
+
 
 def calculate_merkle_root(item_list):
     """ Using ETH2.0 SSZ style hash tree

--- a/quarkchain/core.py
+++ b/quarkchain/core.py
@@ -589,6 +589,8 @@ class TokenBalanceMap(Serializable):
 
     def __eq__(self, other):
         # TODO: Could implement in a more-efficient way, but make sure skip_func works.
+        if not isinstance(other, TokenBalanceMap):
+            return False
         return self.serialize() == other.serialize()
 
 

--- a/quarkchain/tests/test_core.py
+++ b/quarkchain/tests/test_core.py
@@ -320,6 +320,11 @@ class TestTokenBalanceMap(unittest.TestCase):
         m0.add(m2.balance_map)
         self.assertEqual(m0.balance_map, {0: 40, 1: 20, 2: 50})
 
+    def test_zero_balance(self):
+        m0 = TokenBalanceMap({3234: 10, 0: 0, 3567: 0})
+        m1 = TokenBalanceMap.deserialize(m0.serialize())
+        self.assertEqual(m0, m1)
+
 
 def calculate_merkle_root1(item_list):
     """ Same version as calculate_merkle_root(), but zpadding hashed vector to nearest p2


### PR DESCRIPTION
If the token map has a balance zero, reconstructing it from db will result in an empty map, which differs from a map with zero balance, and thus equal comparison will fail.

This fix uses a serialized version of the token map to compare, which could be implemented in a more efficient way, but it is sufficient at the moment (where the token balance map is mostly a single item).