### PR TITLE
Increase weekly checkdb timeout

### DIFF
--- a/.github/workflows/nightly-check-db.yml
+++ b/.github/workflows/nightly-check-db.yml
@@ -11,7 +11,7 @@ jobs:
   download-snapshot-and-checkdb:
     runs-on: self-hosted
     container: quarkchaindocker/pyquarkchain:mainnet1.1.1
-    timeout-minutes: 1440
+    timeout-minutes: 2880
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
recently we are seeing timeouts for weekly check-db job which runs through the whole dataset (like this [run](https://github.com/QuarkChain/pyquarkchain/runs/838287334)). this PR increases the timeout from 1 day to 2 days