### PR TITLE
Improve getTotalBalance JSONRPC

### DIFF
--- a/quarkchain/cluster/jsonrpc.py
+++ b/quarkchain/cluster/jsonrpc.py
@@ -1299,9 +1299,7 @@ class JSONRPCHttpServer:
         total_balance, next_starter = result
         return {
             "totalBalance": quantity_encoder(total_balance),
-            "next": data_encoder(
-                next_starter + full_shard_key.to_bytes(4, byteorder="big")
-            ),
+            "next": data_encoder(next_starter),
         }
 
     @private_methods.add

--- a/quarkchain/cluster/jsonrpc.py
+++ b/quarkchain/cluster/jsonrpc.py
@@ -1275,20 +1275,22 @@ class JSONRPCHttpServer:
         )
 
     @public_methods.add
-    @decode_arg("block_hash", hash_decoder)
-    @decode_arg("token_id", quantity_decoder)
-    @decode_arg("address", address_decoder)
+    @decode_arg("block_id", id_decoder)
+    @decode_arg("token_id", quantity_decoder)  # default: QKC
+    @decode_arg("recipient", recipient_decoder, allow_optional=True)
     @decode_arg("limit", quantity_decoder)
-    async def getTotalBalance(self, block_hash, token_id, address, limit="0x64"):
+    async def getTotalBalance(
+        self, block_id, token_id="0x8bb0", recipient=None, limit="0x64"
+    ):
         if limit > 10000:
             limit = 10000
-        starter = Address.create_from(address)
+        block_hash, full_shard_key = block_id
         full_shard_id = self.master.env.quark_chain_config.get_full_shard_id_by_full_shard_key(
-            starter.full_shard_key
+            full_shard_key
         )
         try:
             result = await self.master.get_total_balance(
-                Branch(full_shard_id), block_hash, token_id, starter.recipient, limit,
+                Branch(full_shard_id), block_hash, token_id, recipient, limit
             )
         except:
             raise ServerError
@@ -1298,7 +1300,7 @@ class JSONRPCHttpServer:
         return {
             "totalBalance": quantity_encoder(total_balance),
             "next": data_encoder(
-                next_starter + (starter.full_shard_key).to_bytes(4, byteorder="big")
+                next_starter + full_shard_key.to_bytes(4, byteorder="big")
             ),
         }
 

--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -1804,13 +1804,13 @@ class MasterServer:
         branch: Branch,
         block_hash: bytes,
         token_id: int,
-        starter: bytes,
+        starter: Optional[bytes],
         limit: int,
     ) -> Optional[Tuple[int, bytes]]:
         if branch.value not in self.branch_to_slaves:
             return None
         slave = self.branch_to_slaves[branch.value][0]
-        address = Address(starter, branch.value)
+        address = Address(starter or bytes(20), branch.value)
         return await slave.get_total_balance(address, block_hash, token_id, limit)
 
 


### PR DESCRIPTION
...update for better ergonomics where recipient can be none and full
shard key is included in block ID. a sample query will be like:

```bash
curl -s -X POST -d  '{"jsonrpc": "2.0", "method": "getTotalBalance", "params": ["0x1a1debffe5e5293467f1677d857343058916bab82caa661f8087ddcf4f3fcad400000001"], "id": 1}' localhost:38391
```

note default value for token is QKC, recipient is 0x0 and limit is 100