### PR TITLE
Fix receipt contract address in failure 

### DIFF
--- a/quarkchain/evm/messages.py
+++ b/quarkchain/evm/messages.py
@@ -254,7 +254,7 @@ def apply_transaction_message(
     else:  # CREATE
         result, gas_remained, data = create_contract(ext, message, contract_address)
         contract_address = (
-            data if data else b""
+            data if (data and result) else b""
         )  # data could be [] when vm failed execution
 
     assert gas_remained >= 0


### PR DESCRIPTION
~tests to be added.~

if the contract cstor failed but returns data (such as `require`), the
data field will be written into the receipt's `contract_address` which
may not be an actual address, thus leading to rlp encoding failure.

cc @516108736 