### PR TITLE
Include xshard deposit when counting total balance

### DIFF
--- a/quarkchain/cluster/cluster_config.py
+++ b/quarkchain/cluster/cluster_config.py
@@ -170,6 +170,7 @@ class MonitoringConfig(BaseConfig):
 class PrometheusConfig(BaseConfig):
     INTERVAL = 30  # Interval between two total_balance queries
     TOKENS = "QKC"  # comma-separated string of tokens
+    MONITOR_XSHARD_DEPOSIT = False
     PORT = 8000  # Prometheus client expose port
 
 
@@ -207,6 +208,7 @@ class ClusterConfig(BaseConfig):
         self._json_filepath = None
         self.MONITORING = MonitoringConfig()
         self.kafka_logger = KafkaSampleLogger(self)
+        self.PROMETHEUS = PrometheusConfig()
 
         slave_config = SlaveConfig()
         slave_config.PORT = 38000

--- a/quarkchain/cluster/jsonrpc.py
+++ b/quarkchain/cluster/jsonrpc.py
@@ -1279,11 +1279,12 @@ class JSONRPCHttpServer:
 
     @public_methods.add
     @decode_arg("block_id", id_decoder)
+    @decode_arg("root_block_id", data_decoder, allow_optional=True)
     @decode_arg("token_id", quantity_decoder)  # default: QKC
     @decode_arg("start", data_decoder, allow_optional=True)
     @decode_arg("limit", quantity_decoder)
     async def getTotalBalance(
-        self, block_id, token_id="0x8bb0", start=None, limit="0x64"
+        self, block_id, root_block_id=None, token_id="0x8bb0", start=None, limit="0x64"
     ):
         if limit > 10000:
             limit = 10000
@@ -1293,7 +1294,7 @@ class JSONRPCHttpServer:
         )
         try:
             result = await self.master.get_total_balance(
-                Branch(full_shard_id), block_hash, token_id, start, limit
+                Branch(full_shard_id), block_hash, root_block_id, token_id, start, limit
             )
         except:
             raise ServerError

--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -728,11 +728,12 @@ class SlaveConnection(ClusterConnection):
         branch: Branch,
         start: Optional[bytes],
         minor_block_hash: bytes,
+        root_block_hash: Optional[bytes],
         token_id: int,
         limit: int,
     ) -> Optional[Tuple[int, bytes]]:
         request = GetTotalBalanceRequest(
-            branch, start, token_id, limit, minor_block_hash
+            branch, start, token_id, limit, minor_block_hash, root_block_hash
         )
         _, resp, _ = await self.write_rpc_request(
             ClusterOp.GET_TOTAL_BALANCE_REQUEST, request
@@ -1810,6 +1811,7 @@ class MasterServer:
         self,
         branch: Branch,
         block_hash: bytes,
+        root_block_hash: Optional[bytes],
         token_id: int,
         start: Optional[bytes],
         limit: int,
@@ -1817,7 +1819,9 @@ class MasterServer:
         if branch.value not in self.branch_to_slaves:
             return None
         slave = self.branch_to_slaves[branch.value][0]
-        return await slave.get_total_balance(branch, start, block_hash, token_id, limit)
+        return await slave.get_total_balance(
+            branch, start, block_hash, root_block_hash, token_id, limit
+        )
 
 
 def parse_args():

--- a/quarkchain/cluster/prom.py
+++ b/quarkchain/cluster/prom.py
@@ -41,7 +41,9 @@ def get_time_and_balance(
         shard = "0x" + block_id[-8:]
         total, start = 0, None
         while start != "0x" + "0" * 64:
-            balance, start = fetcher.count_total_balance(block_id, token_id, start)
+            balance, start = fetcher.count_total_balance(
+                block_id, rb["hash"], token_id, start
+            )
             # TODO: add gap to avoid spam.
             total += balance
         total_balances[shard] = total

--- a/quarkchain/cluster/rpc.py
+++ b/quarkchain/cluster/rpc.py
@@ -998,6 +998,7 @@ class GetTotalBalanceRequest(Serializable):
         ("token_id", uint64),  # TODO: double check max token ID
         ("limit", uint32),
         ("minor_block_hash", hash256),
+        ("root_block_hash", Optional(hash256)),
     ]
 
     def __init__(
@@ -1007,12 +1008,14 @@ class GetTotalBalanceRequest(Serializable):
         token_id: int,
         limit: int,
         minor_block_hash: bytes,
+        root_block_hash: typing.Optional[bytes],
     ):
         self.branch = branch
         self.start = start
         self.token_id = token_id
         self.limit = limit
         self.minor_block_hash = minor_block_hash
+        self.root_block_hash = root_block_hash
 
 
 class GetTotalBalanceResponse(Serializable):

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -73,9 +73,13 @@ class XshardTxCursor:
     # - EOF
     # - A valid x-shard transaction deposit
 
-    def __init__(self, shard_state, mblock_header, cursor_info):
+    def __init__(self, shard_state, mblock_header):
         self.shard_state = shard_state
         self.db = shard_state.db
+
+        cursor_info = self.db.get_minor_block_meta_by_hash(
+            mblock_header.hash_prev_minor_block
+        ).xshard_tx_cursor_info
 
         # Recover cursor
         self.max_rblock_header = self.db.get_root_block_header_by_hash(
@@ -104,8 +108,7 @@ class XshardTxCursor:
     def __get_current_tx(self):
         if self.mblock_index == 0:
             # 0 is reserved for EOF
-            check(self.xshard_deposit_index == 1 or self.xshard_deposit_index == 2)
-            # TODO: for single native token only
+            check(self.xshard_deposit_index in [1, 2])
             if self.xshard_deposit_index == 1:
                 coinbase_amount = 0
                 if self.shard_state.branch.is_in_branch(
@@ -1347,7 +1350,7 @@ class ShardState:
         The list should be validated by remote shard, however,
         it is better to diagnose some bugs in peer shard if we could check
         - x-shard gas limit exceeded
-        - it is a neighor of current shard following our routing rule
+        - it is a neighbor of current shard following our routing rule
         """
         self.db.put_minor_block_xshard_tx_list(h, tx_list)
         tx_hashes = [
@@ -1573,10 +1576,7 @@ class ShardState:
         check(evm_state.gas_used <= evm_state.gas_limit)
 
     def __run_cross_shard_tx_with_cursor(self, evm_state, mblock):
-        cursor_info = self.db.get_minor_block_meta_by_hash(
-            mblock.header.hash_prev_minor_block
-        ).xshard_tx_cursor_info
-        cursor = XshardTxCursor(self, mblock.header, cursor_info)
+        cursor = XshardTxCursor(self, mblock.header)
         tx_list = []
 
         while True:
@@ -1897,23 +1897,28 @@ class ShardState:
             return None
         return self._get_evm_state_for_new_block(block)
 
-    def _get_evm_state_from_hash(self, block_hash: bytes) -> Optional[EvmState]:
+    def _get_evm_state_from_hash(
+        self, block_hash: bytes
+    ) -> Tuple[Optional[EvmState], Optional[MinorBlock]]:
         if block_hash == self.header_tip.get_hash():
-            return self.evm_state
+            return (
+                self.evm_state,
+                self.db.get_minor_block_by_height(self.header_tip.height + 1),
+            )
 
         # note `_get_evm_state_for_new_block` actually fetches the state in the previous block
         # first get the current block then get next block through height
         block = self.db.get_minor_block_by_hash(block_hash)
         if not block:
             Logger.error("Failed to get block with hash {}".format(block_hash.hex()))
-            return None
+            return None, None
         next_block = self.db.get_minor_block_by_height(block.header.height + 1)
         if next_block.header.hash_prev_minor_block != block_hash:
             Logger.error(
                 "Blocks not correctly linked at height {}".format(block.header.height)
             )
-            return None
-        return self._get_evm_state_for_new_block(next_block)
+            return None, None
+        return self._get_evm_state_for_new_block(next_block), next_block
 
     def _get_posw_coinbase_blockcnt(self, header_hash: bytes) -> Dict[bytes, int]:
         """ PoSW needed function: get coinbase addresses up until the given block
@@ -2041,13 +2046,14 @@ class ShardState:
         self,
         token_id: int,
         block_hash: bytes,
+        root_block_hash: Optional[bytes],
         limit: int,
         start: Optional[bytes] = None,
     ) -> Tuple[int, bytes]:
         """
         Start should be exclusive during the iteration.
         """
-        evm_state = self._get_evm_state_from_hash(block_hash)
+        evm_state, next_block = self._get_evm_state_from_hash(block_hash)
         if not evm_state:
             raise Exception("block hash not found")
         trie = evm_state.trie.trie
@@ -2060,4 +2066,29 @@ class ShardState:
             addr = evm_state.db.get(key)
             total += evm_state.get_balance(addr, token_id, should_cache=False)
             limit -= 1
+
+        # get xshard deposit towards the current shard
+        if (
+            self.env.cluster_config.PROMETHEUS.MONITOR_XSHARD_DEPOSIT
+            and start is None  # only calculate for first iteration
+            and root_block_hash is not None  # only if root block is provided
+            # only can get the correct cursor info
+            # note this may yield false results, e.g. quering latest minor block
+            # but should be acceptable for stats purposes
+            and next_block is not None
+        ):
+            # get the cursor AFTER executing this block
+            rh = self.get_root_block_header_by_hash(root_block_hash)
+            if rh and next_block.header.height > 0:  # ignore genesis
+                cursor = XshardTxCursor(self, next_block.header)
+                # sum up all xshard deposit value until passing current root block
+                while True:
+                    xshard_deposit = cursor.get_next_tx()
+                    # exit if running out of deposits or having gone over current root height
+                    if (
+                        xshard_deposit is None
+                        or cursor.rblock.header.height > rh.height
+                    ):
+                        break
+                    total += xshard_deposit.value
         return total, key or bytes(32)

--- a/quarkchain/cluster/shard_state.py
+++ b/quarkchain/cluster/shard_state.py
@@ -2072,14 +2072,14 @@ class ShardState:
             self.env.cluster_config.PROMETHEUS.MONITOR_XSHARD_DEPOSIT
             and start is None  # only calculate for first iteration
             and root_block_hash is not None  # only if root block is provided
-            # only can get the correct cursor info
+            # only when can get the correct cursor info
             # note this may yield false results, e.g. quering latest minor block
             # but should be acceptable for stats purposes
             and next_block is not None
         ):
-            # get the cursor AFTER executing this block
             rh = self.get_root_block_header_by_hash(root_block_hash)
-            if rh and next_block.header.height > 0:  # ignore genesis
+            if rh:
+                # get the cursor AFTER executing this block
                 cursor = XshardTxCursor(self, next_block.header)
                 # sum up all xshard deposit value until passing current root block
                 while True:

--- a/quarkchain/cluster/slave.py
+++ b/quarkchain/cluster/slave.py
@@ -571,7 +571,12 @@ class MasterConnection(ClusterConnection):
         error_code = 0
         try:
             total_balance, next_start = self.slave_server.get_total_balance(
-                req.branch, req.start, req.token_id, req.minor_block_hash, req.limit
+                req.branch,
+                req.start,
+                req.token_id,
+                req.minor_block_hash,
+                req.root_block_hash,
+                req.limit,
             )
             return GetTotalBalanceResponse(error_code, total_balance, next_start)
         except Exception:
@@ -1433,11 +1438,14 @@ class SlaveServer:
         start: Optional[bytes],
         token_id: int,
         block_hash: bytes,
+        root_block_hash: Optional[bytes],
         limit: int,
     ) -> Tuple[int, bytes]:
         shard = self.shards.get(branch, None)
         check(shard is not None)
-        return shard.state.get_total_balance(token_id, block_hash, limit, start)
+        return shard.state.get_total_balance(
+            token_id, block_hash, root_block_hash, limit, start
+        )
 
 
 def parse_args():

--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -148,47 +148,6 @@ class TestShardState(unittest.TestCase):
             qkc_token, state.header_tip.get_hash(), None, 1, start=urandom(32)
         )
 
-    def test_get_total_balance_xshard_deposit(self):
-        id1 = Identity.create_random_identity()
-        acc1 = Address.create_from_identity(id1, full_shard_key=0)
-        acc2 = Address.create_random_account(full_shard_key=1)
-        env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=100000000)
-
-        qkc_token = token_id_encode("QKC")
-        state1 = create_default_shard_state(env=env)
-        state2 = create_default_shard_state(env=env, shard_id=1)
-
-        # Add a root block to have all the shards initialized
-        root_block = state1.root_tip.create_block_to_append().finalize()
-        state1.add_root_block(root_block)
-        state2.add_root_block(root_block)
-
-        tx = create_transfer_transaction(
-            shard_state=state1,
-            key=id1.get_key(),
-            from_address=acc1,
-            to_address=acc2,
-            value=100,
-            transfer_token_id=qkc_token,
-            gas=30000,
-            gas_price=0,
-        )
-        self.assertTrue(state1.add_tx(tx))
-        b1 = state1.create_block_to_mine(address=acc1)
-        state1.finalize_and_add_block(b1)
-
-        # Source shard should have deducted xshard value
-        balance, _ = state1.get_total_balance(
-            qkc_token, state1.header_tip.get_hash(), None, 100, None
-        )
-        self.assertEqual(
-            balance, 100000000 - 100 + self.get_after_tax_reward(self.shard_coinbase)
-        )
-
-        # self.assertEqual(
-        #     state1.get_token_balance(acc_list[1].recipient, self.genesis_token), 100
-        # )
-
     def test_init_genesis_state(self):
         env = get_test_env()
         state = create_default_shard_state(env)

--- a/quarkchain/cluster/tests/test_shard_state.py
+++ b/quarkchain/cluster/tests/test_shard_state.py
@@ -129,7 +129,7 @@ class TestShardState(unittest.TestCase):
             next_start = None
             for _ in range(num_of_calls):
                 balance, next_start = state.get_total_balance(
-                    qkc_token, state.header_tip.get_hash(), batch, next_start
+                    qkc_token, state.header_tip.get_hash(), None, batch, next_start
                 )
                 total += balance
             self.assertEqual(
@@ -145,8 +145,49 @@ class TestShardState(unittest.TestCase):
 
         # Random start should also succeed
         state.get_total_balance(
-            qkc_token, state.header_tip.get_hash(), 1, start=urandom(32)
+            qkc_token, state.header_tip.get_hash(), None, 1, start=urandom(32)
         )
+
+    def test_get_total_balance_xshard_deposit(self):
+        id1 = Identity.create_random_identity()
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+        acc2 = Address.create_random_account(full_shard_key=1)
+        env = get_test_env(genesis_account=acc1, genesis_minor_quarkash=100000000)
+
+        qkc_token = token_id_encode("QKC")
+        state1 = create_default_shard_state(env=env)
+        state2 = create_default_shard_state(env=env, shard_id=1)
+
+        # Add a root block to have all the shards initialized
+        root_block = state1.root_tip.create_block_to_append().finalize()
+        state1.add_root_block(root_block)
+        state2.add_root_block(root_block)
+
+        tx = create_transfer_transaction(
+            shard_state=state1,
+            key=id1.get_key(),
+            from_address=acc1,
+            to_address=acc2,
+            value=100,
+            transfer_token_id=qkc_token,
+            gas=30000,
+            gas_price=0,
+        )
+        self.assertTrue(state1.add_tx(tx))
+        b1 = state1.create_block_to_mine(address=acc1)
+        state1.finalize_and_add_block(b1)
+
+        # Source shard should have deducted xshard value
+        balance, _ = state1.get_total_balance(
+            qkc_token, state1.header_tip.get_hash(), None, 100, None
+        )
+        self.assertEqual(
+            balance, 100000000 - 100 + self.get_after_tax_reward(self.shard_coinbase)
+        )
+
+        # self.assertEqual(
+        #     state1.get_token_balance(acc_list[1].recipient, self.genesis_token), 100
+        # )
 
     def test_init_genesis_state(self):
         env = get_test_env()

--- a/quarkchain/tools/count_total_balance.py
+++ b/quarkchain/tools/count_total_balance.py
@@ -60,10 +60,12 @@ class Fetcher(object):
         return latest_rb, list(self.shard_to_latest_id.values())
 
     def count_total_balance(
-        self, block_id: str, token_id: int, start: str
+        self, block_id: str, root_block_id: str, token_id: int, start: str
     ) -> Tuple[int, str]:
         res = self.cli.send(
-            jsonrpcclient.Request("getTotalBalance", block_id, hex(token_id), start),
+            jsonrpcclient.Request(
+                "getTotalBalance", block_id, root_block_id, hex(token_id), start
+            ),
             timeout=self.timeout,
         )
         if not res:
@@ -91,7 +93,7 @@ def main():
 
     root_block_height = args.rheight
     fetcher = Fetcher(host, TIMEOUT)
-    _, minor_block_ids = fetcher.get_latest_minor_block_id_from_root_block(
+    rb, minor_block_ids = fetcher.get_latest_minor_block_id_from_root_block(
         root_block_height
     )
     logging.info(
@@ -105,7 +107,9 @@ def main():
         logging.info("querying total balance for shard %s" % shard)
         total, start, cnt = 0, None, 0
         while start != "0x" + "0" * 64:
-            balance, start = fetcher.count_total_balance(block_id, token_id, start)
+            balance, start = fetcher.count_total_balance(
+                block_id, rb["hash"], token_id, start
+            )
             total += balance
             cnt += 1
             if cnt % 10 == 0:


### PR DESCRIPTION
1. a separate prometheus flag is added to turn on counting xshard
   deposit values
1. shard state needs to have a separate `root_block_hash` parameter to
   identify xshard deposit cursor progress. JSONRPC and internal cluster
   RPC have been updated to provide it as an optional argument. if not
   provided, xshard deposits will be ignored
1. xshard deposit will only be counted when starter is None, i.e. the
   first iteration
1. shard state will iterate cursor until surpassing provided root block,
   or exhausting deposits

tests are added in `test_cluster.py`. note a race may happen if querying
latest minor block since we won't know the xshard deposit progress.

will test this change on our monitoring node.