### PR TITLE
increase rblock cache to avoid long xchain cursor update

### DIFF
--- a/quarkchain/cluster/shard_db_operator.py
+++ b/quarkchain/cluster/shard_db_operator.py
@@ -266,7 +266,7 @@ class ShardDbOperator(TransactionHistoryMixin):
 
         # height -> set(minor block hash) for counting wasted blocks
         self.height_to_minor_block_hashes = dict()
-        self.rblock_cache = LRUCache(maxsize=256)
+        self.rblock_cache = LRUCache(maxsize=4096)  # enough for 4096 * 60 / 3600 / 24 = 2.84 days
         self.mblock_cache = LRUCache(maxsize=4096)
         self.mblock_header_cache = LRUCache(maxsize=10240)
 


### PR DESCRIPTION
- When the xchain cursor moves from one root block to another root block, it will find the next root block by iterating from max root block.  If the max root block is much higher than next root block (e.g., > original 256), then the cache will not be effective, and thus causing a lot of raw db operations.

Related code:
https://github.com/QuarkChain/pyquarkchain/blob/ff92683d0314a9969b348aeba60fdc14bfb7ddf4/quarkchain/cluster/shard_state.py#L203
https://github.com/QuarkChain/pyquarkchain/blob/ff92683d0314a9969b348aeba60fdc14bfb7ddf4/quarkchain/cluster/shard_db_operator.py#L297