### PR TITLE
increase rblock cache in root state

### DIFF
--- a/quarkchain/cluster/root_state.py
+++ b/quarkchain/cluster/root_state.py
@@ -59,7 +59,7 @@ class RootDb:
         self.tip_header = None
 
         self.__recover_from_db()
-        self.rblock_cache = LRUCache(maxsize=1024)
+        self.rblock_cache = LRUCache(maxsize=8192) # enough for 8192 * 60 / 3600 / 24 = 5.6 days
 
     def __recover_from_db(self):
         """ Recover the best chain from local database.


### PR DESCRIPTION
If some mblocks are not included in root block for a while, e.g., 2 days, then if a new root block includes them, the mblock's prev_root_block will be 2 days away from the latest root block, which causes the is_same_chain check to take a long time.
https://github.com/QuarkChain/pyquarkchain/blob/af1dd06a50d918aaf45569d9b0f54f5ecceb6afe/quarkchain/cluster/root_state.py#L62

This diff increases the cache to 8K so that we could accept ~5 days difference of mblock's prev_root_block and the latest root block.