### PR TITLE
Skip fast path for mblock if its rblock confirmation is too old

### DIFF
--- a/quarkchain/cluster/jsonrpc.py
+++ b/quarkchain/cluster/jsonrpc.py
@@ -2,6 +2,8 @@ import asyncio
 import inspect
 import json
 from typing import Callable, Dict, List, Optional
+import cProfile
+
 
 import aiohttp_cors
 import websockets
@@ -1279,6 +1281,19 @@ class JSONRPCHttpServer:
         return await self.master.set_target_block_time(
             root_block_time, minor_block_time
         )
+
+    @private_methods.add
+    async def setProfiling(self, enable=False):
+        if enable:
+            self.profile = cProfile.Profile()
+            self.profile.enable()
+        else:
+            if self.profile is not None:
+                self.profile.disable()
+                self.profile.print_stats("time")
+
+            self.profile = None
+
 
     @public_methods.add
     @decode_arg("block_id", id_decoder)

--- a/quarkchain/cluster/jsonrpc.py
+++ b/quarkchain/cluster/jsonrpc.py
@@ -2,8 +2,6 @@ import asyncio
 import inspect
 import json
 from typing import Callable, Dict, List, Optional
-import cProfile
-
 
 import aiohttp_cors
 import websockets
@@ -1281,19 +1279,6 @@ class JSONRPCHttpServer:
         return await self.master.set_target_block_time(
             root_block_time, minor_block_time
         )
-
-    @private_methods.add
-    async def setProfiling(self, enable=False):
-        if enable:
-            self.profile = cProfile.Profile()
-            self.profile.enable()
-        else:
-            if self.profile is not None:
-                self.profile.disable()
-                self.profile.print_stats("time")
-
-            self.profile = None
-
 
     @public_methods.add
     @decode_arg("block_id", id_decoder)

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -245,6 +245,17 @@ class PeerShardConnection(VirtualConnection):
         if self.shard_state.header_tip.height >= m_header.height:
             return
 
+        # Do not download if the prev root block is not synced
+        rblock_header = self.state.get_root_block_header_by_hash(m_header.hash_prev_root_block)
+        if (rblock_header is None):
+            return
+
+        # Do not download if the new header's confirmed root is lower then current root tip last header's confirmed root
+        # This means the minor block's root is a fork, which will be handled by master sync
+        confirmed_root_header = self.state.get_root_block_header_by_hash(self.shard_state.confirmed_header_tip.hash_prev_root_block)
+        if confirmed_root_header != None and confirmed_root_header.height > rblock_header.height:
+            return
+
         Logger.info_every_sec(
             "[{}] received new tip with height {}".format(
                 m_header.branch.to_str(), m_header.height

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -246,13 +246,13 @@ class PeerShardConnection(VirtualConnection):
             return
 
         # Do not download if the prev root block is not synced
-        rblock_header = self.state.get_root_block_header_by_hash(m_header.hash_prev_root_block)
+        rblock_header = self.shard_state.get_root_block_header_by_hash(m_header.hash_prev_root_block)
         if (rblock_header is None):
             return
 
         # Do not download if the new header's confirmed root is lower then current root tip last header's confirmed root
         # This means the minor block's root is a fork, which will be handled by master sync
-        confirmed_root_header = self.state.get_root_block_header_by_hash(self.shard_state.confirmed_header_tip.hash_prev_root_block)
+        confirmed_root_header = self.shard_state.get_root_block_header_by_hash(self.shard_state.confirmed_header_tip.hash_prev_root_block)
         if confirmed_root_header != None and confirmed_root_header.height > rblock_header.height:
             return
 

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -697,7 +697,7 @@ class Shard:
         # Do not download if the new header's confirmed root is lower then current root tip last header's confirmed root
         # This means the minor block's root is a fork, which will be handled by master sync
         confirmed_tip = self.state.confirmed_header_tip
-        confirmed_root_header = None if confirmed_tip is None else self.state.get_root_block_header_by_hash(self.state.confirmed_tip.hash_prev_root_block)
+        confirmed_root_header = None if confirmed_tip is None else self.state.get_root_block_header_by_hash(confirmed_tip.hash_prev_root_block)
         if confirmed_root_header is not None and confirmed_root_header.height > rblock_header.height:
             return
 

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -686,8 +686,7 @@ class Shard:
         # Such block should be synced by master sychronizer
         if (
             self.state.root_tip
-            and self.state.root_tip.height - rblock_header.height
-            > self.state.env.quark_chain_config.ROOT.MAX_STALE_ROOT_BLOCK_HEIGHT_DIFF
+            and self.state.root_tip.height - rblock_header.height > 4096
         ):
             return
 

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -695,7 +695,7 @@ class Shard:
 
         # Do not download if the new header's confirmed root is lower then current root tip last header's confirmed root
         # This means the minor block's root is a fork, which will be handled by master sync
-        confirmed_root_header = self.shard_state.get_root_block_header_by_hash(self.shard_state.confirmed_header_tip.hash_prev_root_block)
+        confirmed_root_header = self.state.get_root_block_header_by_hash(self.state.confirmed_header_tip.hash_prev_root_block)
         if confirmed_root_header is not None and confirmed_root_header.height > rblock_header.height:
             return
 

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -678,9 +678,16 @@ class Shard:
         # There is a race that the root block may not be processed at the moment.
         # Ignore it if its root block is not found.
         # Otherwise, validate_block() will fail and we will disconnect the peer.
+        rblock_header = self.state.get_root_block_header_by_hash(block.header.hash_prev_root_block)
+        if (rblock_header is None):
+            return
+
+        # Ignore old blocks if its confirmed root is too old
+        # Such block should be synced by master sychronizer
         if (
-            self.state.get_root_block_header_by_hash(block.header.hash_prev_root_block)
-            is None
+            self.state.root_tip
+            and self.state.root_tip.height - rblock_header.height
+            > self.state.env.quark_chain_config.ROOT.MAX_STALE_ROOT_BLOCK_HEIGHT_DIFF
         ):
             return
 

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -253,7 +253,7 @@ class PeerShardConnection(VirtualConnection):
         # Do not download if the new header's confirmed root is lower then current root tip last header's confirmed root
         # This means the minor block's root is a fork, which will be handled by master sync
         confirmed_root_header = self.shard_state.get_root_block_header_by_hash(self.shard_state.confirmed_header_tip.hash_prev_root_block)
-        if confirmed_root_header != None and confirmed_root_header.height > rblock_header.height:
+        if confirmed_root_header is not None and confirmed_root_header.height > rblock_header.height:
             return
 
         Logger.info_every_sec(

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -693,12 +693,10 @@ class Shard:
         if (rblock_header is None):
             return
 
-        # Ignore old blocks if its confirmed root is too old
-        # Such block should be synced by master sychronizer
-        if (
-            self.state.root_tip
-            and self.state.root_tip.height - rblock_header.height > 4096
-        ):
+        # Do not download if the new header's confirmed root is lower then current root tip last header's confirmed root
+        # This means the minor block's root is a fork, which will be handled by master sync
+        confirmed_root_header = self.shard_state.get_root_block_header_by_hash(self.shard_state.confirmed_header_tip.hash_prev_root_block)
+        if confirmed_root_header is not None and confirmed_root_header.height > rblock_header.height:
             return
 
         try:

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -252,7 +252,8 @@ class PeerShardConnection(VirtualConnection):
 
         # Do not download if the new header's confirmed root is lower then current root tip last header's confirmed root
         # This means the minor block's root is a fork, which will be handled by master sync
-        confirmed_root_header = self.shard_state.get_root_block_header_by_hash(self.shard_state.confirmed_header_tip.hash_prev_root_block)
+        confirmed_tip = self.shard_state.confirmed_header_tip
+        confirmed_root_header = None if confirmed_tip is None else self.shard_state.get_root_block_header_by_hash(confirmed_tip.hash_prev_root_block)
         if confirmed_root_header is not None and confirmed_root_header.height > rblock_header.height:
             return
 
@@ -695,7 +696,8 @@ class Shard:
 
         # Do not download if the new header's confirmed root is lower then current root tip last header's confirmed root
         # This means the minor block's root is a fork, which will be handled by master sync
-        confirmed_root_header = self.state.get_root_block_header_by_hash(self.state.confirmed_header_tip.hash_prev_root_block)
+        confirmed_tip = self.state.confirmed_header_tip
+        confirmed_root_header = None if confirmed_tip is None else self.state.get_root_block_header_by_hash(self.state.confirmed_tip.hash_prev_root_block)
         if confirmed_root_header is not None and confirmed_root_header.height > rblock_header.height:
             return
 


### PR DESCRIPTION
This prevents an attacker can send a minor block with a very old root confirmation.