### PR TITLE
memory improvement

### DIFF
--- a/ethereum/pow/ethpow.py
+++ b/ethereum/pow/ethpow.py
@@ -36,7 +36,7 @@ if ETHASH_LIB == "ethash":
     hashimoto = hashimoto_slow
 elif ETHASH_LIB == "pyethash":
 
-    @lru_cache(10)
+    @lru_cache(2)
     def calculate_cache(n):
         return pyethash.mkcache_bytes(n * EPOCH_LENGTH)
 

--- a/ethereum/pow/ethpow.py
+++ b/ethereum/pow/ethpow.py
@@ -36,7 +36,7 @@ if ETHASH_LIB == "ethash":
     hashimoto = hashimoto_slow
 elif ETHASH_LIB == "pyethash":
 
-    @lru_cache(2)
+    @lru_cache(10)
     def calculate_cache(n):
         return pyethash.mkcache_bytes(n * EPOCH_LENGTH)
 

--- a/quarkchain/cluster/shard_db_operator.py
+++ b/quarkchain/cluster/shard_db_operator.py
@@ -332,6 +332,11 @@ class ShardDbOperator(TransactionHistoryMixin):
         self.height_to_minor_block_hashes.setdefault(m_block.header.height, set()).add(
             m_block.header.get_hash()
         )
+        
+        # remove the oldest minor block hash from the height_to_minor_block_hashes
+        # if the height is greater than 4096
+        # this is to prevent the height_to_minor_block_hashes from growing indefinitely
+        # and to keep the memory usage in check
         if m_block.header.height - 4096 in self.height_to_minor_block_hashes:
             del self.height_to_minor_block_hashes[
                 m_block.header.height - 4096

--- a/quarkchain/cluster/shard_db_operator.py
+++ b/quarkchain/cluster/shard_db_operator.py
@@ -332,6 +332,10 @@ class ShardDbOperator(TransactionHistoryMixin):
         self.height_to_minor_block_hashes.setdefault(m_block.header.height, set()).add(
             m_block.header.get_hash()
         )
+        if m_block.header.height - 4096 in self.height_to_minor_block_hashes:
+            del self.height_to_minor_block_hashes[
+                m_block.header.height - 4096
+            ]
 
         self.put_confirmed_cross_shard_transaction_deposit_list(
             m_block_hash, x_shard_receive_tx_list


### PR DESCRIPTION
Issue: https://github.com/QuarkChain/quarkchain-dev/issues/474

According to memory analysis. pyquarkchain syncing from genesis to latest, the memory increasing 4G ~ 10G for 24 hours now. And after and profile code:


## Detail data before changes
**The following is the detail memory usage after running 11 hours**
```
MASTER: [ =============== Top 20 =============== ]
MASTER: /code/pyquarkchain/quarkchain/core.py:259: size=142 MiB, count=1859953, average=80 B
MASTER: /code/pyquarkchain/quarkchain/core.py:96: size=140 MiB, count=2344838, average=63 B
MASTER: /code/pyquarkchain/quarkchain/core.py:262: size=113 MiB, count=1859125, average=64 B
MASTER: /code/pyquarkchain/quarkchain/core.py:74: size=100 MiB, count=3693091, average=29 B
MASTER: /code/pyquarkchain/quarkchain/core.py:717: size=73.1 MiB, count=456390, average=168 B
MASTER: /code/pyquarkchain/ethereum/pow/ethpow.py:41: size=63.7 MiB, count=3, average=21.2 MiB
MASTER: /code/pyquarkchain/quarkchain/core.py:234: size=42.5 MiB, count=1402843, average=32 B
MASTER: /code/pyquarkchain/quarkchain/core.py:217: size=39.2 MiB, count=244968, average=168 B
MASTER: /code/pyquarkchain/quarkchain/core.py:212: size=36.0 MiB, count=468463, average=81 B
MASTER: /code/pyquarkchain/quarkchain/core.py:581: size=17.7 MiB, count=464865, average=40 B
MASTER: /code/pyquarkchain/quarkchain/core.py:431: size=17.7 MiB, count=464759, average=40 B
MASTER: /code/pyquarkchain/quarkchain/core.py:489: size=17.4 MiB, count=456422, average=40 B
MASTER: /code/pyquarkchain/quarkchain/p2p/service.py:120: size=15.6 MiB, count=97124, average=168 B
MASTER: /usr/local/lib/python3.7/site-packages/eth_keys/datatypes.py:285: size=5295 KiB, count=32277, average=168 B
MASTER: /usr/local/lib/python3.7/asyncio/base_events.py:404: size=4465 KiB, count=28019, average=163 B
MASTER: /code/pyquarkchain/quarkchain/core.py:186: size=3941 KiB, count=8282, average=487 B
MASTER: /usr/local/lib/python3.7/site-packages/eth_keys/datatypes.py:284: size=3664 KiB, count=22336, average=168 B
MASTER: /usr/local/lib/python3.7/site-packages/eth_keys/datatypes.py:300: size=3063 KiB, count=18672, average=168 B
MASTER: /usr/local/lib/python3.7/site-packages/eth_keys/datatypes.py:315: size=2551 KiB, count=15549, average=168 B
MASTER: /code/pyquarkchain/quarkchain/core.py:923: size=1371 KiB, count=8354, average=168 B
MASTER: [ =============== End =============== ]
MASTER: I0502 15:20:35.309445 master.py:1871] [GC Monitor] Collected: 1392 objects | Memory: 4576.7734375 -> 4563.7734375 MB
SLAVE_S1: [ =============== Top 20 =============== ]
SLAVE_S1: /code/pyquarkchain/ethereum/pow/ethpow.py:41: size=473 MiB, count=10, average=47.3 MiB
SLAVE_S1: /code/pyquarkchain/quarkchain/cluster/shard_db_operator.py:332: size=229 MiB, count=854639, average=281 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:259: size=168 MiB, count=2207401, average=80 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:96: size=168 MiB, count=2802131, average=63 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:74: size=143 MiB, count=5284093, average=28 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:262: size=136 MiB, count=2227038, average=64 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:717: size=86.9 MiB, count=542391, average=168 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:217: size=85.1 MiB, count=530934, average=168 B
SLAVE_S1: /usr/local/lib/python3.7/site-packages/Crypto/Util/_raw_api.py:134: size=54.3 MiB, count=875158, average=65 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:234: size=50.4 MiB, count=1660098, average=32 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:212: size=42.0 MiB, count=550679, average=80 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:581: size=21.0 MiB, count=550618, average=40 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:431: size=21.0 MiB, count=550618, average=40 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:489: size=20.7 MiB, count=542396, average=40 B
SLAVE_S1: /usr/local/lib/python3.7/site-packages/cachetools/lru.py:42: size=4514 KiB, count=37136, average=124 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:186: size=4483 KiB, count=8181, average=561 B
SLAVE_S1: /usr/local/lib/python3.7/site-packages/cachetools/cache.py:57: size=2322 KiB, count=8, average=290 KiB
SLAVE_S1: /code/pyquarkchain/quarkchain/config.py:89: size=1552 KiB, count=19211, average=83 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:923: size=1350 KiB, count=8227, average=168 B
SLAVE_S1: /usr/local/lib/python3.7/collections/__init__.py:568: size=1165 KiB, count=7099, average=168 B
SLAVE_S1: [ =============== End =============== ]
SLAVE_S1: I0502 15:20:58.669585 slave.py:1488] [GC Monitor] Collected: 64 objects | Memory: 6751.03515625 -> 6751.03515625 MB
```

**The following is the detail memory usage after running 11 + 24 hours**
```
MASTER: [ =============== Top 20 =============== ]
MASTER: /code/pyquarkchain/quarkchain/core.py:259: size=122 MiB, count=1593010, average=80 B
MASTER: /code/pyquarkchain/quarkchain/core.py:96: size=120 MiB, count=2007583, average=63 B
MASTER: /code/pyquarkchain/quarkchain/core.py:262: size=97.2 MiB, count=1592026, average=64 B
MASTER: /code/pyquarkchain/quarkchain/core.py:74: size=85.9 MiB, count=3158665, average=29 B
MASTER: /code/pyquarkchain/ethereum/pow/ethpow.py:41: size=72.4 MiB, count=3, average=24.1 MiB
MASTER: /code/pyquarkchain/quarkchain/core.py:717: size=62.4 MiB, count=389358, average=168 B
MASTER: /code/pyquarkchain/quarkchain/core.py:234: size=36.7 MiB, count=1203072, average=32 B
MASTER: /code/pyquarkchain/quarkchain/core.py:212: size=30.8 MiB, count=400674, average=81 B
MASTER: /code/pyquarkchain/quarkchain/core.py:217: size=28.3 MiB, count=176628, average=168 B
MASTER: /code/pyquarkchain/quarkchain/core.py:581: size=15.2 MiB, count=398120, average=40 B
MASTER: /code/pyquarkchain/quarkchain/core.py:431: size=15.2 MiB, count=398100, average=40 B
MASTER: /code/pyquarkchain/quarkchain/core.py:489: size=14.9 MiB, count=389385, average=40 B
MASTER: /code/pyquarkchain/quarkchain/p2p/service.py:120: size=14.7 MiB, count=91588, average=168 B
MASTER: /usr/local/lib/python3.7/asyncio/base_events.py:404: size=6255 KiB, count=39162, average=164 B
MASTER: /usr/local/lib/python3.7/site-packages/eth_keys/datatypes.py:285: size=5025 KiB, count=30627, average=168 B
MASTER: /usr/local/lib/python3.7/site-packages/Crypto/Util/_raw_api.py:134: size=4260 KiB, count=67108, average=65 B
MASTER: /code/pyquarkchain/quarkchain/p2p/discovery.py:581: size=4253 KiB, count=67004, average=65 B
MASTER: /usr/local/lib/python3.7/site-packages/eth_keys/datatypes.py:284: size=3408 KiB, count=20776, average=168 B
MASTER: /code/pyquarkchain/quarkchain/core.py:186: size=3407 KiB, count=8284, average=421 B
MASTER: /usr/local/lib/python3.7/site-packages/eth_keys/datatypes.py:300: size=2957 KiB, count=18021, average=168 B
MASTER: [ =============== End =============== ]
MASTER: I0507 14:58:03.269823 master.py:1871] [GC Monitor] Collected: 116 objects | Memory: 4064.09375 -> 4047.59375 MB
SLAVE_S1: [ =============== Top 20 =============== ]
SLAVE_S1: /code/pyquarkchain/ethereum/pow/ethpow.py:41: size=193 MiB, count=3, average=64.5 MiB
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:96: size=128 MiB, count=2125848, average=63 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:259: size=127 MiB, count=1665854, average=80 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:262: size=103 MiB, count=1685856, average=64 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:74: size=91.0 MiB, count=3355283, average=28 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:717: size=65.2 MiB, count=407093, average=168 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:217: size=63.8 MiB, count=398393, average=168 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:234: size=38.3 MiB, count=1254218, average=32 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:212: size=31.7 MiB, count=415373, average=80 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:431: size=15.8 MiB, count=415325, average=40 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:581: size=15.8 MiB, count=415324, average=40 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:489: size=15.5 MiB, count=407098, average=40 B
SLAVE_S1: /usr/local/lib/python3.7/site-packages/cachetools/lru.py:42: size=4514 KiB, count=37136, average=124 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:186: size=3373 KiB, count=8160, average=423 B
SLAVE_S1: /code/pyquarkchain/quarkchain/cluster/shard_db_operator.py:332: size=2432 KiB, count=8194, average=304 B
SLAVE_S1: /usr/local/lib/python3.7/site-packages/cachetools/cache.py:57: size=2322 KiB, count=8, average=290 KiB
SLAVE_S1: /usr/local/lib/python3.7/site-packages/Crypto/Util/_raw_api.py:134: size=1823 KiB, count=28719, average=65 B
SLAVE_S1: /code/pyquarkchain/quarkchain/config.py:89: size=1525 KiB, count=18823, average=83 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:923: size=1350 KiB, count=8231, average=168 B
SLAVE_S1: /usr/local/lib/python3.7/site-packages/eth_utils/decorators.py:31: size=1151 KiB, count=16369, average=72 B
SLAVE_S1: [ =============== End =============== ]
SLAVE_S1: I0507 14:58:58.888355 slave.py:1488] [GC Monitor] Collected: 56 objects | Memory: 5053.69140625 -> 5053.44140625 MB
```

**Compare the top 20  two data:**
- For master, ethpow.py increase 86 MB
- For slaves, the 4 items found in the previous analysis added a total of 500 MB of content 
  - shard_db_operator.py:332 increase 369 MB 
  - ethpow.py:41 increase 31  MB
  - core.py:74 increase 12 MB
  - _raw_api.py:134 increase 92 MB
- **The estimate memory inscrease for one day:** 500 + 890 * 4 = 4100（MB）


## How to fix

**For shard_db_operator.py:332:** 
that is not a memory leak, but we keep adding height to hash mapping without clearing it. but we only need this mapping for the last minutes (compare with the header_tip). So we can make this map just keep a few recode.

After change the map only keep last 4096 items, and run the node for half day. After 5 minutes, its memory usage remains the same.

`SLAVE_S0: /code/pyquarkchain/quarkchain/cluster/shard_db_operator.py:332: size=2432 KiB, count=8194, average=304 B`

**For ethpow.py:41:**
that is not a memory leak, miner need bytes (generated and cache by `pyethash.mkcache_bytes(n * EPOCH_LENGTH)`) for mining, and cache it for last 10 epochs. As the number of epochs increases, the size of the data also increases. 
```
    @lru_cache(10)
    def calculate_cache(n):
        return pyethash.mkcache_bytes(n * EPOCH_LENGTH)
```

To reduce the memory it used, we can reduce the lru cache number from 10 to 2

## Detail data after changes
**The following is the detail memory usage after running 11 hours**
```
MASTER: [ =============== Top 20 =============== ]
MASTER: /code/pyquarkchain/quarkchain/core.py:259: size=121 MiB, count=1587294, average=80 B
MASTER: /code/pyquarkchain/quarkchain/core.py:96: size=120 MiB, count=2000073, average=63 B
MASTER: /code/pyquarkchain/quarkchain/core.py:262: size=96.8 MiB, count=1586333, average=64 B
MASTER: /code/pyquarkchain/quarkchain/core.py:74: size=85.6 MiB, count=3147534, average=29 B
MASTER: /code/pyquarkchain/ethereum/pow/ethpow.py:41: size=70.5 MiB, count=3, average=23.5 MiB
MASTER: /code/pyquarkchain/quarkchain/core.py:717: size=62.2 MiB, count=388085, average=168 B
MASTER: /code/pyquarkchain/quarkchain/core.py:234: size=36.6 MiB, count=1198443, average=32 B
MASTER: /code/pyquarkchain/quarkchain/core.py:217: size=30.9 MiB, count=192821, average=168 B
MASTER: /code/pyquarkchain/quarkchain/core.py:212: size=30.8 MiB, count=399773, average=81 B
MASTER: /code/pyquarkchain/quarkchain/core.py:431: size=15.1 MiB, count=396638, average=40 B
MASTER: /code/pyquarkchain/quarkchain/core.py:581: size=15.1 MiB, count=396630, average=40 B
MASTER: /code/pyquarkchain/quarkchain/core.py:489: size=14.8 MiB, count=388112, average=40 B
MASTER: /code/pyquarkchain/quarkchain/p2p/service.py:120: size=13.2 MiB, count=82181, average=168 B
MASTER: /usr/local/lib/python3.7/site-packages/eth_keys/datatypes.py:285: size=5079 KiB, count=30957, average=168 B
MASTER: /usr/local/lib/python3.7/asyncio/base_events.py:404: size=4925 KiB, count=30934, average=163 B
MASTER: /usr/local/lib/python3.7/site-packages/eth_keys/datatypes.py:284: size=3470 KiB, count=21153, average=168 B
MASTER: /code/pyquarkchain/quarkchain/core.py:186: size=3381 KiB, count=8273, average=419 B
MASTER: /usr/local/lib/python3.7/site-packages/eth_keys/datatypes.py:300: size=2949 KiB, count=17974, average=168 B
MASTER: /usr/local/lib/python3.7/site-packages/eth_keys/datatypes.py:315: size=2437 KiB, count=14857, average=168 B
MASTER: /usr/local/lib/python3.7/site-packages/Crypto/Util/_raw_api.py:134: size=1405 KiB, count=22135, average=65 B
MASTER: [ =============== End =============== ]
MASTER: I0506 14:50:23.266602 master.py:1871] [GC Monitor] Collected: 116 objects | Memory: 3841.95703125 -> 3820.70703125 MB
SLAVE_S1: [ =============== Top 20 =============== ]
SLAVE_S1: /code/pyquarkchain/ethereum/pow/ethpow.py:41: size=182 MiB, count=3, average=60.7 MiB
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:96: size=128 MiB, count=2130305, average=63 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:259: size=127 MiB, count=1670371, average=80 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:262: size=103 MiB, count=1689424, average=64 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:74: size=91.2 MiB, count=3362405, average=28 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:717: size=65.4 MiB, count=407983, average=168 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:217: size=63.9 MiB, count=398549, average=168 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:234: size=38.4 MiB, count=1256888, average=32 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:212: size=31.8 MiB, count=416297, average=80 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:581: size=15.9 MiB, count=416214, average=40 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:431: size=15.9 MiB, count=416214, average=40 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:489: size=15.6 MiB, count=407988, average=40 B
SLAVE_S1: /usr/local/lib/python3.7/site-packages/cachetools/lru.py:42: size=4514 KiB, count=37136, average=124 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:186: size=3373 KiB, count=8151, average=424 B
SLAVE_S1: /code/pyquarkchain/quarkchain/cluster/shard_db_operator.py:332: size=2432 KiB, count=8194, average=304 B
SLAVE_S1: /usr/local/lib/python3.7/site-packages/cachetools/cache.py:57: size=2322 KiB, count=8, average=290 KiB
SLAVE_S1: /usr/local/lib/python3.7/site-packages/Crypto/Util/_raw_api.py:134: size=1822 KiB, count=28711, average=65 B
SLAVE_S1: /code/pyquarkchain/quarkchain/config.py:89: size=1474 KiB, count=18359, average=82 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:923: size=1350 KiB, count=8231, average=168 B
SLAVE_S1: /usr/local/lib/python3.7/site-packages/eth_utils/decorators.py:31: size=1151 KiB, count=16376, average=72 B
SLAVE_S1: [ =============== End =============== ]
SLAVE_S1: I0506 14:48:57.323045 slave.py:1488] [GC Monitor] Collected: 37 objects | Memory: 4627.0390625 -> 4627.0390625 MB
 
```

**The following is the detail memory usage after running 11 + 24 hours**
```
MASTER: [ =============== Top 20 =============== ]
MASTER: /code/pyquarkchain/quarkchain/core.py:259: size=122 MiB, count=1593010, average=80 B
MASTER: /code/pyquarkchain/quarkchain/core.py:96: size=120 MiB, count=2007583, average=63 B
MASTER: /code/pyquarkchain/quarkchain/core.py:262: size=97.2 MiB, count=1592026, average=64 B
MASTER: /code/pyquarkchain/quarkchain/core.py:74: size=85.9 MiB, count=3158665, average=29 B
MASTER: /code/pyquarkchain/ethereum/pow/ethpow.py:41: size=72.4 MiB, count=3, average=24.1 MiB
MASTER: /code/pyquarkchain/quarkchain/core.py:717: size=62.4 MiB, count=389358, average=168 B
MASTER: /code/pyquarkchain/quarkchain/core.py:234: size=36.7 MiB, count=1203072, average=32 B
MASTER: /code/pyquarkchain/quarkchain/core.py:212: size=30.8 MiB, count=400674, average=81 B
MASTER: /code/pyquarkchain/quarkchain/core.py:217: size=28.3 MiB, count=176628, average=168 B
MASTER: /code/pyquarkchain/quarkchain/core.py:581: size=15.2 MiB, count=398120, average=40 B
MASTER: /code/pyquarkchain/quarkchain/core.py:431: size=15.2 MiB, count=398100, average=40 B
MASTER: /code/pyquarkchain/quarkchain/core.py:489: size=14.9 MiB, count=389385, average=40 B
MASTER: /code/pyquarkchain/quarkchain/p2p/service.py:120: size=14.7 MiB, count=91588, average=168 B
MASTER: /usr/local/lib/python3.7/asyncio/base_events.py:404: size=6255 KiB, count=39162, average=164 B
MASTER: /usr/local/lib/python3.7/site-packages/eth_keys/datatypes.py:285: size=5025 KiB, count=30627, average=168 B
MASTER: /usr/local/lib/python3.7/site-packages/Crypto/Util/_raw_api.py:134: size=4260 KiB, count=67108, average=65 B
MASTER: /code/pyquarkchain/quarkchain/p2p/discovery.py:581: size=4253 KiB, count=67004, average=65 B
MASTER: /usr/local/lib/python3.7/site-packages/eth_keys/datatypes.py:284: size=3408 KiB, count=20776, average=168 B
MASTER: /code/pyquarkchain/quarkchain/core.py:186: size=3407 KiB, count=8284, average=421 B
MASTER: /usr/local/lib/python3.7/site-packages/eth_keys/datatypes.py:300: size=2957 KiB, count=18021, average=168 B
MASTER: [ =============== End =============== ]
MASTER: I0507 14:58:03.269823 master.py:1871] [GC Monitor] Collected: 116 objects | Memory: 4064.09375 -> 4047.59375 MB
SLAVE_S1: [ =============== Top 20 =============== ]
SLAVE_S1: /code/pyquarkchain/ethereum/pow/ethpow.py:41: size=193 MiB, count=3, average=64.5 MiB
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:96: size=128 MiB, count=2125848, average=63 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:259: size=127 MiB, count=1665854, average=80 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:262: size=103 MiB, count=1685856, average=64 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:74: size=91.0 MiB, count=3355283, average=28 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:717: size=65.2 MiB, count=407093, average=168 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:217: size=63.8 MiB, count=398393, average=168 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:234: size=38.3 MiB, count=1254218, average=32 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:212: size=31.7 MiB, count=415373, average=80 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:431: size=15.8 MiB, count=415325, average=40 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:581: size=15.8 MiB, count=415324, average=40 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:489: size=15.5 MiB, count=407098, average=40 B
SLAVE_S1: /usr/local/lib/python3.7/site-packages/cachetools/lru.py:42: size=4514 KiB, count=37136, average=124 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:186: size=3373 KiB, count=8160, average=423 B
SLAVE_S1: /code/pyquarkchain/quarkchain/cluster/shard_db_operator.py:332: size=2432 KiB, count=8194, average=304 B
SLAVE_S1: /usr/local/lib/python3.7/site-packages/cachetools/cache.py:57: size=2322 KiB, count=8, average=290 KiB
SLAVE_S1: /usr/local/lib/python3.7/site-packages/Crypto/Util/_raw_api.py:134: size=1823 KiB, count=28719, average=65 B
SLAVE_S1: /code/pyquarkchain/quarkchain/config.py:89: size=1525 KiB, count=18823, average=83 B
SLAVE_S1: /code/pyquarkchain/quarkchain/core.py:923: size=1350 KiB, count=8231, average=168 B
SLAVE_S1: /usr/local/lib/python3.7/site-packages/eth_utils/decorators.py:31: size=1151 KiB, count=16369, average=72 B
SLAVE_S1: [ =============== End =============== ]
SLAVE_S1: I0507 14:58:58.888355 slave.py:1488] [GC Monitor] Collected: 56 objects | Memory: 5053.69140625 -> 5053.44140625 MB

```

**Compare these two data:**
- no significant growth for Master and Slave: expect ethpow.py 
- For slaves: 
  - ethpow.py grow about 10 MB for every slave which is expected;
  - other 3 itmes do not showed any growth.


**Remove the memory profile code and run the node again**. And use `docker stats mainnet` to monitor the how menory used by the how nodes (master + 4 slaves). The memory used increase quickly, and it grow to `10 GB after running 11 hour`s. and the memory used `increase to 11.1 GB after running 11 + 24 hours` and `increase to 11.9 GB after running 11 + 48 hours`.
**So the memory increase 0.8 ~1.2 GB for 24 hours after changes**

The following is the snapshot after 11 + 24 hours.
![Image](https://github.com/user-attachments/assets/82c6ebfe-d2f0-4ad3-936e-7048a1f2817c)

The following is the snapshot after 11 + 48 hours.
![Image](https://github.com/user-attachments/assets/ee926176-3fb2-4620-9021-91a7a233d39a)