### PR TITLE
fix docker upgrade issue

### DIFF
--- a/.github/workflows/nightly-check-db.yml
+++ b/.github/workflows/nightly-check-db.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Install Dependencies and Build
       run: |
-        apt update && apt upgrade -y && apt install sshpass
+        apt update && apt upgrade -y && apt install sshpass -y
         PYTHONPATH=/code/pyquarkchain pip3 install -e .
         cd qkchash && make clean && make
 

--- a/mainnet/singularity/Dockerfile
+++ b/mainnet/singularity/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.7-buster
 LABEL maintainer="quarkchain"
+RUN sed -i 's/deb.debian.org/archive.debian.org/' /etc/apt/sources.list
 # install rocksdb
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     libbz2-dev \


### PR DESCRIPTION
Since the current python:3.7-buster version is no longer supported, the current apt update and apt upgrade will fail, affecting user usage and causing the nightly-check-db action to fail.
https://github.com/QuarkChain/pyquarkchain/actions/runs/16411645044; the update address needs to be replaced from http://deb.debian.org to http://archive.debian.org

<img width="1548" height="1132" alt="image" src="https://github.com/user-attachments/assets/920ae949-19b6-46ca-8183-e8e5ded4f21f" />
