### PR TITLE
Use 'Repository variables' to set docker container version

### DIFF
--- a/.github/workflows/nightly-check-db.yml
+++ b/.github/workflows/nightly-check-db.yml
@@ -1,6 +1,8 @@
 name: nightly-check-db
 
-on: [push]
+on:
+  schedule:
+    - cron: '1 8 */2 * *'
 
 env:
   PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/nightly-check-db.yml
+++ b/.github/workflows/nightly-check-db.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   download-snapshot-and-checkdb:
     runs-on: self-hosted
-    container: quarkchaindocker/pyquarkchain:mainnet1.6.1
+    container: quarkchaindocker/pyquarkchain:${{ vars.DOCKER_VERSION }}
     timeout-minutes: 4320
 
     steps:

--- a/.github/workflows/nightly-check-db.yml
+++ b/.github/workflows/nightly-check-db.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Install Dependencies and Build
       run: |
-        apt update && apt upgrade -y && apt install sshpass
+        apt update && apt upgrade -y && apt install sshpass -y
         PYTHONPATH=/code/pyquarkchain pip3 install -e .
         cd qkchash && make clean && make
 

--- a/.github/workflows/nightly-check-db.yml
+++ b/.github/workflows/nightly-check-db.yml
@@ -1,8 +1,6 @@
 name: nightly-check-db
 
-on:
-  schedule:
-    - cron: '1 8 */2 * *'
+on: [push]
 
 env:
   PYTHONPATH: ${{ github.workspace }}

--- a/mainnet/singularity/Dockerfile
+++ b/mainnet/singularity/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.7-buster
 LABEL maintainer="quarkchain"
+RUN sed -i 's/deb.debian.org/archive.debian.org/' /etc/apt/sources.list
 # install rocksdb
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     libbz2-dev \


### PR DESCRIPTION
Use 'Repository variables' to set the docker container version so that we can change the variable to apply the version next time we release a new docker image instead of updating the code.