### PR TITLE
Replace python-rocksdb with Rocksdict

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Project Dependencies
-      run: PYTHONPATH=/code/pyquarkchain pip3 install -e .
+      run: pip3 install --upgrade pip && PYTHONPATH=/code/pyquarkchain pip3 install -e .
 
     - name: Run py.test tests excluding integration test
       run: |
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Project Dependencies
-      run: PYTHONPATH=/code/pyquarkchain pip3 install -e .
+      run: pip3 install --upgrade pip && PYTHONPATH=/code/pyquarkchain pip3 install -e .
 
     - name: Run EVM tests - runner 1
       run: |
@@ -40,7 +40,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Project Dependencies
-      run: PYTHONPATH=/code/pyquarkchain pip3 install -e .
+      run: pip3 install --upgrade pip && PYTHONPATH=/code/pyquarkchain pip3 install -e .
 
     - name: Run EVM tests - runner 2
       run: |
@@ -53,7 +53,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Project Dependencies
-      run: PYTHONPATH=/code/pyquarkchain pip3 install -e .
+      run: pip3 install --upgrade pip && PYTHONPATH=/code/pyquarkchain pip3 install -e .
 
     - name: Run py.test tests only on integration test
       run: |

--- a/README.md
+++ b/README.md
@@ -65,12 +65,6 @@ source ~/virtualenv/qc/bin/activate
 # the rest of the tutorial assumes virtual environment
 ```
 
-Install rocksdb which is required by the `python-rocksdb` module in the next step
-
-```bash
-brew install rocksdb
-```
-
 To install the required modules for the project. Under `pyquarkchain` dir where `setup.py` is located
 
 ```bash

--- a/mainnet/singularity/Dockerfile
+++ b/mainnet/singularity/Dockerfile
@@ -1,15 +1,7 @@
 FROM python:3.7-buster
 LABEL maintainer="quarkchain"
 RUN sed -i 's/deb.debian.org/archive.debian.org/' /etc/apt/sources.list
-# install rocksdb
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
-    libbz2-dev \
-    libgflags-dev \
-    liblz4-dev \
-    librocksdb-dev \
-    libsnappy-dev \
-    libzstd-dev \
-    zlib1g-dev \
     vim \
   && rm -rf /var/lib/apt/lists/*
 # set up code
@@ -22,14 +14,6 @@ WORKDIR /code/pyquarkchain
 ARG GIT_TAG
 RUN echo "checkout to $GIT_TAG"
 RUN git checkout $GIT_TAG
-
-# Cython 3.x was released in mid-2023 and deprecated many older language features which python-rocksdb needed.
-# So pip install -r requirements.txt will fail after mid-2023.
-# This is an issue caused by an incompatibility between python-rocksdb and newer versions of Cython.
-# Downgrade Cython to a compatible version (0.29.x) is a solution for that.
-# We can replicate that success by explicitly installing an older Cython version before building.
-# Install Cython separately, because adding it to requirements.txt and installing it will cause docker build to fail.
-RUN pip install "Cython<3"
 
 # py dep
 RUN pip install -r requirements.txt

--- a/quarkchain/db.py
+++ b/quarkchain/db.py
@@ -3,7 +3,7 @@ import copy
 import pathlib
 import shutil
 
-import rocksdb
+from rocksdict import Rdict, Options, DBCompressionType
 
 
 class Db:
@@ -63,15 +63,14 @@ class PersistentDb(Db):
             self._destroy()
         pathlib.Path(self.db_path).mkdir(parents=True, exist_ok=True)
 
-        options = rocksdb.Options()
-        options.create_if_missing = True
-        options.max_open_files = 100000  # ubuntu 16.04 max files descriptors 524288
-        options.write_buffer_size = 128 * 1024 * 1024  # 128 MiB
-        options.max_write_buffer_number = 3
-        options.target_file_size_base = 67108864
-
-        options.compression = rocksdb.CompressionType.snappy_compression
-        self._db = rocksdb.DB(db_path, options)
+        options = Options(raw_mode=True)
+        options.create_if_missing(True)
+        options.set_max_open_files(100000)  # ubuntu 16.04 max files descriptors 524288
+        options.set_write_buffer_size(128 * 1024 * 1024)  # 128 MiB
+        options.set_max_write_buffer_number(3)
+        options.set_target_file_size_base(67108864)
+        options.set_compression_type(DBCompressionType.snappy())
+        self._db = Rdict(db_path, options)
 
     def _destroy(self):
         shutil.rmtree(self.db_path, ignore_errors=True)
@@ -83,7 +82,8 @@ class PersistentDb(Db):
 
     def multi_get(self, keys):
         keys = [k.encode() if not isinstance(k, bytes) else k for k in keys]
-        return self._db.multi_get(keys)  # returns a dict with keys as keys
+        values = self._db.get(keys)  # returns a list of values
+        return dict(zip(keys, values))
 
     def put(self, key, value):
         key = key.encode() if not isinstance(key, bytes) else key
@@ -103,29 +103,28 @@ class PersistentDb(Db):
 
     def range_iter(self, start, end):
         """ A generator yielding (key, value) for keys in [start, end) ordered by key in ascending order"""
-        it = self._db.iteritems()
+        it = self._db.iter()
         it.seek(start)
-        for item in it:
-            if item[0] < end:
-                yield item
-            else:
+        while it.valid():
+            k = it.key()
+            if k >= end:
                 return
+            yield k, it.value()
+            it.next()
 
     def reversed_range_iter(self, start, end):
         """ A generator yielding (key, value) for keys in (end, start] ordered key in descending order"""
-        it = self._db.iteritems()
+        it = self._db.iter()
         it.seek_for_prev(start)
-        it = reversed(it)
-        for item in it:
-            if item[0] > end:
-                yield item
-            else:
+        while it.valid():
+            k = it.key()
+            if k <= end:
                 return
+            yield k, it.value()
+            it.prev()
 
     def close(self):
-        # No close() available for rocksdb
-        # see https://github.com/twmht/python-rocksdb/issues/10
-        pass
+        self._db.close()
 
     def __deepcopy__(self, memo):
         raise NotImplementedError

--- a/quarkchain/tests/test_persistent_db.py
+++ b/quarkchain/tests/test_persistent_db.py
@@ -1,0 +1,124 @@
+"""
+Smoke tests for PersistentDb after migration from python-rocksdb to rocksdict.
+Tests every method in PersistentDb to verify rocksdict behaves correctly.
+"""
+import tempfile
+import unittest
+
+from quarkchain.db import PersistentDb
+
+
+class TestPersistentDb(unittest.TestCase):
+    def setUp(self):
+        # Use a temporary directory that is cleaned up after each test
+        self.tmp_dir = tempfile.mkdtemp()
+        self.db = PersistentDb(self.tmp_dir)
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_put_and_get_bytes_key(self):
+        self.db.put(b"key1", b"value1")
+        self.assertEqual(self.db.get(b"key1"), b"value1")
+
+    def test_put_and_get_str_key(self):
+        # keys can be str (auto-encoded to bytes internally)
+        self.db.put("key2", b"value2")
+        self.assertEqual(self.db.get("key2"), b"value2")
+
+    def test_get_missing_key_returns_default(self):
+        self.assertIsNone(self.db.get(b"nonexistent"))
+        self.assertEqual(self.db.get(b"nonexistent", b"default"), b"default")
+
+    def test_put_bytearray_value(self):
+        # bytearray values are accepted and stored as bytes
+        self.db.put(b"key3", bytearray(b"value3"))
+        self.assertEqual(self.db.get(b"key3"), b"value3")
+
+    def test_contains(self):
+        self.db.put(b"key4", b"value4")
+        self.assertIn(b"key4", self.db)
+        self.assertNotIn(b"missing", self.db)
+
+    def test_delete(self):
+        self.db.put(b"key5", b"value5")
+        self.assertIn(b"key5", self.db)
+        self.db.delete(b"key5")
+        self.assertNotIn(b"key5", self.db)
+        self.assertIsNone(self.db.get(b"key5"))
+
+    def test_remove(self):
+        # remove() is an alias for delete()
+        self.db.put(b"key6", b"value6")
+        self.db.remove(b"key6")
+        self.assertNotIn(b"key6", self.db)
+
+    def test_getitem_raises_on_missing(self):
+        with self.assertRaises(KeyError):
+            _ = self.db[b"nonexistent"]
+
+    def test_getitem_returns_value(self):
+        self.db.put(b"key7", b"value7")
+        self.assertEqual(self.db[b"key7"], b"value7")
+
+    def test_multi_get(self):
+        self.db.put(b"k1", b"v1")
+        self.db.put(b"k2", b"v2")
+        result = self.db.multi_get([b"k1", b"k2", b"missing"])
+        self.assertEqual(result[b"k1"], b"v1")
+        self.assertEqual(result[b"k2"], b"v2")
+        self.assertIsNone(result[b"missing"])
+
+    def test_range_iter_ascending(self):
+        # Keys are sorted lexicographically by RocksDB
+        for i in range(5):
+            self.db.put(i.to_bytes(4, "big"), f"val_{i}".encode())
+
+        results = list(self.db.range_iter(
+            (1).to_bytes(4, "big"),
+            (4).to_bytes(4, "big"),
+        ))
+        # Should yield keys 1, 2, 3 (start inclusive, end exclusive)
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0][0], (1).to_bytes(4, "big"))
+        self.assertEqual(results[1][0], (2).to_bytes(4, "big"))
+        self.assertEqual(results[2][0], (3).to_bytes(4, "big"))
+
+    def test_reversed_range_iter_descending(self):
+        for i in range(5):
+            self.db.put(i.to_bytes(4, "big"), f"val_{i}".encode())
+
+        results = list(self.db.reversed_range_iter(
+            (3).to_bytes(4, "big"),
+            (0).to_bytes(4, "big"),
+        ))
+        # Should yield keys 3, 2, 1 (start inclusive, end exclusive)
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0][0], (3).to_bytes(4, "big"))
+        self.assertEqual(results[1][0], (2).to_bytes(4, "big"))
+        self.assertEqual(results[2][0], (1).to_bytes(4, "big"))
+
+    def test_data_persists_after_close_and_reopen(self):
+        # The most important property of a persistent DB
+        self.db.put(b"persist_key", b"persist_value")
+        self.db.close()
+
+        # Re-open the same path
+        db2 = PersistentDb(self.tmp_dir)
+        self.assertEqual(db2.get(b"persist_key"), b"persist_value")
+        db2.close()
+
+        # Re-assign so tearDown's close() doesn't double-close
+        self.db = PersistentDb(self.tmp_dir)
+
+    def test_clean_flag_wipes_existing_data(self):
+        self.db.put(b"wipe_me", b"value")
+        self.db.close()
+
+        # Re-open with clean=True — should destroy previous data
+        self.db = PersistentDb(self.tmp_dir, clean=True)
+        self.assertIsNone(self.db.get(b"wipe_me"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ jsonrpcserver==3.5.4
 jsonrpc-async==0.6
 numpy==1.15.1
 psutil==5.6.6
-python-rocksdb==0.6.9
+rocksdict==0.3.29
 requests==2.20.0
 aiohttp_cors==0.7.0
 eth-utils==1.2.0


### PR DESCRIPTION
### Problem: python-rocksdb blocks upgrading to Python 3.13

python-rocksdb is a Cython wrapper around the RocksDB C++ library. It is effectively broken on upgrading to Python 3.13 for two reasons:
 - **Removed C API call (PyEval_InitThreads)**
python-rocksdb calls `PyEval_InitThreads()` from its .pyx source. This API was deprecated in Python 3.9, became a no-op, and was removed in Python 3.12.
**Fix**: delete the call (trivial).
 - **Cython 3.x migration is non-trivial**
Python 3.13 support requires **Cython 3.x**, but `python-rocksdb` was written with **Cython 0.29.x** semantics, and those assumptions break under Cython 3.x. Migrating would require **non-trivial .pyx refactors**.

------

### Is migrating python-rocksdb to Cython 3.x viable?

A serious attempt already exists: [faust-streaming/python-rocksdb](https://github.com/faust-streaming/python-rocksdb) migrated the codebase to Cython 3.x and removed the PyEval_InitThreads() call.

However, it has two major issues:
 - **Still not caught up to Python 3.13**
Even after migrating to Cython 3.x, the fork only reaches Python 3.12. Python 3.13 introduced additional C API changes beyond 3.12, and the fork never added/validated 3.13 support.
 - **Abandoned + recommends moving away**
The fork is effectively unmaintained and explicitly points users to **rocksdict** as the recommended replacement.

------

### Why rocksdict
 - **Rust + PyO3 instead of Cython**
PyO3 abstracts CPython internals, so Python version churn is largely handled by upgrading the PyO3 crate rather than patching our wrapper code. This is the main reason rocksdict already supports Python 3.7–3.14.
 - **Prebuilt wheels across platforms (Linux/macOS/Windows)**
No system RocksDB dependency, no Cython, no local compilation step — significantly lowers install friction and CI variability.
 - **Actively maintained**
The project is actively maintained and has comparable **stars** to python-rocksdb.

------

### Validation/tests completed

I’ve validated the change with the following tests:
  - **Mining test**: ran a mining node in my local devnet.
  - **Sync test**: ran a full node with this change and synced to the latest devnet block.
  - **Compatibility test** (rolling upgrade):
    - synced to latest devnet block on the previous version
    - switched to the version with this change
     - continued syncing successfully

------

### Next step

I’m planning to run a mainnet full node with this change and validate end-to-end sync behavior under real network conditions.
