### PR TITLE
fix: apply PoSW difficulty divider in external miner and fix Ctrl+C hang

### DIFF
--- a/mainnet/singularity/Dockerfile
+++ b/mainnet/singularity/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.13-slim
 LABEL maintainer="quarkchain"
 
 RUN apt-get update && apt-get install -y \
+    build-essential \
     gcc \
     git \
     curl \

--- a/quarkchain/tools/external_miner.py
+++ b/quarkchain/tools/external_miner.py
@@ -191,7 +191,11 @@ class SigHandler:
         self.stopper.set()
         for thread in self.threads:
             thread.join(timeout=5)
-        print("Stop mining")
+        alive = [t for t in self.threads if t.is_alive()]
+        if alive:
+            print(f"Force-exiting; {len(alive)} thread(s) did not stop in time")
+        else:
+            print("Stopped cleanly")
         import os
         os._exit(0)
 

--- a/quarkchain/tools/external_miner.py
+++ b/quarkchain/tools/external_miner.py
@@ -34,8 +34,10 @@ def get_work_rpc(
 ) -> MiningWork:
     jrpc_url = "http://{}:{}".format(host, jrpc_port)
     cli = get_jsonrpc_cli(jrpc_url)
-    header_hash, height, diff = cli.call("getWork", hex(full_shard_id) if full_shard_id is not None else None)
-    return MiningWork(bytes.fromhex(header_hash[2:]), int(height, 16), int(diff, 16))
+    header_hash, height, diff, *rest = cli.call("getWork", hex(full_shard_id) if full_shard_id is not None else None)
+    divider = int(rest[0], 16) if rest else 1
+    effective_diff = int(diff, 16) // divider
+    return MiningWork(bytes.fromhex(header_hash[2:]), int(height, 16), effective_diff)
 
 
 def submit_work_rpc(
@@ -185,10 +187,13 @@ class SigHandler:
         self.threads = threads
 
     def __call__(self, signum, frame):
+        print("\nStopping miners...")
         self.stopper.set()
         for thread in self.threads:
-            thread.join()
+            thread.join(timeout=5)
         print("Stop mining")
+        import os
+        os._exit(0)
 
 
 def main():


### PR DESCRIPTION
### 1. PoSW difficulty divider ignored

  getWork returns 4 elements when PoSW is active:
  [header_hash, height, difficulty, divider]
  The old code unpacked only 3, causing too many values to unpack. After the fix to accept 4 elements, the divider was silently discarded — so the miner was solving the full original
  difficulty instead of the PoSW-reduced difficulty // divider.

  The node validates submitted blocks using effective_difficulty = difficulty // divider (see shard_state.py:posw_diff_adjust), meaning miners with valid PoSW stakes were doing
  divider× more work than necessary.

###  2. Ctrl+C hangs indefinitely

  SigHandler.__call__ called thread.join() with no timeout. The mining thread blocks on output_q.get(block=True), so SIGINT could never terminate the process.

###  3. Add `build-essential` to `mainnet/singularity/Dockerfile`

  `build-essential` (which includes `make`, `gcc`, `g++`) is needed if we want to build qkchash .
  **Impact**
  - No functional change, only adds a build dependency
  - Increases image size marginally (~20MB for build-essential)

###  Changes

  - get_work_rpc: use *rest to safely handle 3- or 4-element getWork response; apply divider to compute effective_diff
  - SigHandler.__call__: add timeout=5 to thread.join() and call os._exit(0) to ensure clean exit
  - Add `build-essential` to `mainnet/singularity/Dockerfile` apt install to enable `make` in docker.