### PR TITLE
fix(P3-8): skip dead connections when adding peers after active_event

### DIFF
--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -597,7 +597,8 @@ class Shard:
             conns.append(peer_shard_conn)
         await asyncio.gather(*[conn.active_event.wait() for conn in conns])
         for conn in conns:
-            self.add_peer(conn)
+            if conn.is_active():
+                self.add_peer(conn)
 
     async def __init_genesis_state(self, root_block: RootBlock):
         block, coinbase_amount_map = self.state.init_genesis_state(root_block)

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -599,6 +599,13 @@ class Shard:
         for conn in conns:
             if conn.is_active():
                 self.add_peer(conn)
+            else:
+                Logger.warning(
+                    "cluster peer {} vconn for shard {} closed before becoming "
+                    "active, skipped".format(
+                        conn.cluster_peer_id, self.full_shard_id
+                    )
+                )
 
     async def __init_genesis_state(self, root_block: RootBlock):
         block, coinbase_amount_map = self.state.init_genesis_state(root_block)

--- a/quarkchain/cluster/simple_network.py
+++ b/quarkchain/cluster/simple_network.py
@@ -131,6 +131,16 @@ class Peer(P2PConnection):
         self._loop_task = asyncio.create_task(self.active_and_loop_forever())
         await self.wait_until_active()
 
+        # wait_until_active() also returns when the connection closed before ever
+        # becoming active (active_event is set in the finally block of
+        # active_and_loop_forever). Adding a CLOSED peer to the pools would leak it:
+        # close() only removes ACTIVE peers, so broadcasts/get_peer_list would keep
+        # using it forever. close_dead_peer() removes it from the pools (if present)
+        # and tears down the virtual shard connections created above.
+        if not self.is_active():
+            self.close_dead_peer()
+            return "peer {} closed before becoming active".format(self.id.hex())
+
         # Only make the peer connection avaialbe after exchanging HELLO and creating virtual shard connections
         self.network.active_peer_pool[self.id] = self
         self.network.cluster_peer_pool[self.cluster_peer_id] = self

--- a/quarkchain/cluster/slave.py
+++ b/quarkchain/cluster/slave.py
@@ -353,9 +353,12 @@ class MasterConnection(ClusterConnection):
         # wait for all the connections to become active before return
         await asyncio.gather(*active_futures)
 
-        # Make peer connection available to shard once they are active
+        # Make peer connection available to shard once they are active.
+        # Skip connections that died before becoming active (active_event is also
+        # set in the finally block of active_and_loop_forever on early close).
         for shard, peer_shard_conn in shard_to_conn.items():
-            shard.add_peer(peer_shard_conn)
+            if peer_shard_conn.is_active():
+                shard.add_peer(peer_shard_conn)
 
         return CreateClusterPeerConnectionResponse(error_code=0)
 

--- a/quarkchain/cluster/slave.py
+++ b/quarkchain/cluster/slave.py
@@ -359,6 +359,13 @@ class MasterConnection(ClusterConnection):
         for shard, peer_shard_conn in shard_to_conn.items():
             if peer_shard_conn.is_active():
                 shard.add_peer(peer_shard_conn)
+            else:
+                Logger.warning(
+                    "cluster peer {} vconn for shard {} closed before becoming "
+                    "active, skipped".format(
+                        req.cluster_peer_id, shard.full_shard_id
+                    )
+                )
 
         return CreateClusterPeerConnectionResponse(error_code=0)
 


### PR DESCRIPTION
### Summary
`active_and_loop_forever`'s `finally` block now sets `active_event` even on an early close, so
callers awaiting `active_event.wait()` can no longer assume the connection is live. Both
peer-registration call sites are guarded with `conn.is_active()` before `add_peer()`.

### Related Issue
https://github.com/QuarkChain/pyquarkchain/issues/985

### Changes
- **`shard.py` `__init_connections`:** guard peer-shard connections received from master with
  `if conn.is_active()` before `add_peer`.
- **`slave.py` `handle_create_cluster_peer_connection`:** same guard for cluster peer connections,
  with a comment noting that `active_event` is also set on early close.

### Files
`quarkchain/cluster/shard.py`, `quarkchain/cluster/slave.py`