### PR TITLE
fix: JSON-RPC protocol compliance + protocol tests

### DIFF
--- a/quarkchain/cluster/jsonrpc.py
+++ b/quarkchain/cluster/jsonrpc.py
@@ -520,15 +520,19 @@ class JSONRPCHttpServer:
             self.handlers[rpc_name] = func.__get__(self, self.__class__)
 
     async def __handle(self, request):
-        request = await request.text()
-        Logger.info(request)
+        body = await request.text()
+        Logger.info(body)
 
-        d = dict()
         try:
-            d = json.loads(request)
+            d = json.loads(body)
         except Exception:
-            pass
-        method = d.get("method", "null")
+            return web.json_response({
+                "jsonrpc": "2.0",
+                "error": {"code": -32700, "message": "Parse error"},
+                "id": None,
+            })
+
+        method = d.get("method", "null") if isinstance(d, dict) else "null"
         if method in self.counters:
             self.counters[method] += 1
         else:
@@ -1481,17 +1485,21 @@ class JSONRPCWebsocketServer:
             async for message in websocket:
                 Logger.info(message)
 
-                d = dict()
                 try:
                     d = json.loads(message)
                 except Exception:
-                    raise InvalidParams("Cannot parse message as JSON")
-                method = d.get("method", "null")
+                    await websocket.send(json.dumps({
+                        "jsonrpc": "2.0",
+                        "error": {"code": -32700, "message": "Parse error"},
+                        "id": None,
+                    }))
+                    continue
+                method = d.get("method", "null") if isinstance(d, dict) else "null"
                 if method in self.counters:
                     self.counters[method] += 1
                 else:
                     self.counters[method] = 1
-                msg_id = d.get("id", 0)
+                msg_id = d.get("id", 0) if isinstance(d, dict) else 0
 
                 response = await self.handlers.dispatch(
                     d,

--- a/quarkchain/cluster/jsonrpc_server.py
+++ b/quarkchain/cluster/jsonrpc_server.py
@@ -91,12 +91,14 @@ class RpcMethods:
 
     async def dispatch(self, request_json: Dict[str, Any], context=None) -> Optional[Dict[str, Any]]:
         req_id = None
+        is_notification = False
 
         try:
             if not isinstance(request_json, dict):
                 raise InvalidRequest("Request must be object")
 
             req_id = request_json.get("id")
+            is_notification = "id" not in request_json
 
             if request_json.get("jsonrpc") != "2.0":
                 raise InvalidRequest("Invalid JSON-RPC version")
@@ -104,8 +106,6 @@ class RpcMethods:
             method = request_json.get("method")
             if not isinstance(method, str):
                 raise InvalidRequest("Method must be string")
-
-            is_notification = "id" not in request_json
 
             if method not in self._methods:
                 raise MethodNotFound()
@@ -139,13 +139,17 @@ class RpcMethods:
             }
 
         except JsonRpcError as e:
+            if is_notification:
+                return None
             return {
                 "jsonrpc": "2.0",
                 "error": e.to_dict(),
                 "id": req_id,
             }
         except Exception:
-            logger.exception("Internal JSON-RPC error for method %s", method)
+            if is_notification:
+                return None
+            logger.exception("Internal JSON-RPC error for method %s", locals().get("method", "<unknown>"))
             return {
                 "jsonrpc": "2.0",
                 "error": {

--- a/quarkchain/cluster/jsonrpc_server.py
+++ b/quarkchain/cluster/jsonrpc_server.py
@@ -92,8 +92,11 @@ class RpcMethods:
     async def dispatch(self, request_json: Dict[str, Any], context=None) -> Optional[Dict[str, Any]]:
         req_id = None
         is_notification = False
+        method = ""
 
         try:
+            if isinstance(request_json, list):
+                raise InvalidRequest("Batch requests not supported")
             if not isinstance(request_json, dict):
                 raise InvalidRequest("Request must be object")
 
@@ -147,7 +150,7 @@ class RpcMethods:
                 "id": req_id,
             }
         except Exception:
-            logger.exception("Internal JSON-RPC error for method %s", locals().get("method", "<unknown>"))
+            logger.exception("Internal JSON-RPC error for method %s", method)
             if is_notification:
                 return None
             return {

--- a/quarkchain/cluster/jsonrpc_server.py
+++ b/quarkchain/cluster/jsonrpc_server.py
@@ -147,9 +147,9 @@ class RpcMethods:
                 "id": req_id,
             }
         except Exception:
+            logger.exception("Internal JSON-RPC error for method %s", locals().get("method", "<unknown>"))
             if is_notification:
                 return None
-            logger.exception("Internal JSON-RPC error for method %s", locals().get("method", "<unknown>"))
             return {
                 "jsonrpc": "2.0",
                 "error": {

--- a/quarkchain/cluster/tests/test_jsonrpc.py
+++ b/quarkchain/cluster/tests/test_jsonrpc.py
@@ -2219,6 +2219,39 @@ class TestJSONRPCWebsocket(unittest.IsolatedAsyncioTestCase):
             response = json.loads(await websocket.recv())
             self.assertTrue(response["error"])
 
+    async def test_malformed_json_keeps_connection_alive(self):
+        # Malformed JSON must get a -32700 Parse error reply WITHOUT killing the
+        # connection (which would silently drop every subscription on it). After
+        # the error, a valid request on the same socket must still succeed.
+        id1 = Identity.create_random_identity()
+        acc1 = Address.create_from_identity(id1, full_shard_key=0)
+
+        async with ClusterContext(
+            1, acc1, small_coinbase=True
+        ) as clusters, jrpc_websocket_server_context(
+            clusters[0].slave_list[0], port=38601
+        ):
+            websocket = await get_websocket(port=38601)
+
+            # send invalid JSON -> expect a -32700 reply, not a closed socket
+            await websocket.send("{not valid json")
+            response = json.loads(await websocket.recv())
+            self.assertEqual(response["error"]["code"], -32700)
+            self.assertEqual(response["error"]["message"], "Parse error")
+            self.assertIsNone(response["id"])
+
+            # connection is still alive: a valid subscribe on the same socket works
+            request = {
+                "jsonrpc": "2.0",
+                "method": "subscribe",
+                "params": ["newHeads", "0x00000002"],
+                "id": 7,
+            }
+            await websocket.send(json.dumps(request))
+            response = json.loads(await websocket.recv())
+            self.assertEqual(response["id"], 7)
+            self.assertEqual(len(response["result"]), 34)
+
 
 # Reuse the standard JSON-RPC port (38391). unittest runs sequentially and each
 # fixture binds/releases inside its own ``async with``, the same way

--- a/quarkchain/cluster/tests/test_jsonrpc.py
+++ b/quarkchain/cluster/tests/test_jsonrpc.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import unittest
 from contextlib import asynccontextmanager
+import aiohttp
 import rlp
 import websockets
 
@@ -10,6 +11,7 @@ from quarkchain.cluster.jsonrpc import (
     EMPTY_TX_ID,
     JSONRPCHttpServer,
     JSONRPCWebsocketServer,
+    RpcMethods,
     quantity_encoder,
     data_encoder,
 )
@@ -2216,3 +2218,116 @@ class TestJSONRPCWebsocket(unittest.IsolatedAsyncioTestCase):
             await websocket.send(json.dumps(unsubscribe))
             response = json.loads(await websocket.recv())
             self.assertTrue(response["error"])
+
+
+# Reuse the standard JSON-RPC port (38391). unittest runs sequentially and each
+# fixture binds/releases inside its own ``async with``, the same way
+# jrpc_http_server_context and jrpc_websocket_server_context already share 38391.
+PROTOCOL_SERVER_URL = "http://localhost:38391/"
+
+
+async def _protocol_echo(self, value):
+    """Master-free dummy handler so protocol tests need no cluster/MasterServer."""
+    return value
+
+
+@asynccontextmanager
+async def jrpc_protocol_server_context():
+    """Start a standalone JSON-RPC HTTP server with no MasterServer.
+
+    The protocol-compliance cases below either fail before reaching a handler
+    (parse / dispatch level) or use the master-free ``echo`` method, so
+    ``master=None`` is safe and we avoid spinning up a full ClusterContext.
+    """
+    env = DEFAULT_ENV.copy()
+    env.cluster_config = ClusterConfig()
+    env.cluster_config.JSON_RPC_PORT = 38391
+    env.cluster_config.JSON_RPC_HOST = "127.0.0.1"
+
+    methods = RpcMethods()
+    methods.add(_protocol_echo, name="echo")
+
+    server = JSONRPCHttpServer(env, None, 38391, "127.0.0.1", methods)
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.shutdown()
+
+
+async def post_raw(body):
+    """POST an arbitrary (possibly malformed) request body; return (status, text)."""
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            PROTOCOL_SERVER_URL,
+            data=body,
+            headers={"Content-Type": "application/json"},
+        ) as resp:
+            return resp.status, await resp.text()
+
+
+class TestJSONRPCProtocol(unittest.IsolatedAsyncioTestCase):
+    """Protocol-level compliance for the custom JSON-RPC server.
+
+    Replaces jsonrpcserver 3.5.4. Guards the regressions documented in the
+    P2-6 review:
+      - malformed JSON must return -32700 Parse error (not -32600)
+      - a JSON array (batch) must be rejected cleanly, NOT crash with HTTP 500
+        (batch is intentionally unsupported)
+      - a notification (no "id") that errors must produce no response body
+      - error responses are returned with HTTP 200
+    """
+
+    async def test_malformed_json_returns_parse_error(self):
+        async with jrpc_protocol_server_context():
+            status, text = await post_raw("{not valid json")
+        self.assertEqual(status, 200)
+        resp = json.loads(text)
+        self.assertEqual(resp["error"]["code"], -32700)
+        self.assertEqual(resp["error"]["message"], "Parse error")
+        self.assertIsNone(resp["id"])
+
+    async def test_batch_array_rejected_without_crash(self):
+        # Batch is intentionally unsupported. A JSON array must be rejected with
+        # a clean -32600 Invalid Request, never an unhandled AttributeError/HTTP 500.
+        batch = json.dumps(
+            [
+                {"jsonrpc": "2.0", "method": "echo", "params": ["0x1"], "id": 1},
+                {"jsonrpc": "2.0", "method": "echo", "params": ["0x2"], "id": 2},
+            ]
+        )
+        async with jrpc_protocol_server_context():
+            status, text = await post_raw(batch)
+        self.assertEqual(status, 200)
+        resp = json.loads(text)
+        self.assertEqual(resp["error"]["code"], -32600)
+
+    async def test_notification_error_no_response(self):
+        # No "id" => notification. Even on error, the server must return no body.
+        notif = json.dumps(
+            {"jsonrpc": "2.0", "method": "noSuchMethod", "params": []}
+        )
+        async with jrpc_protocol_server_context():
+            status, text = await post_raw(notif)
+        self.assertEqual(status, 200)
+        self.assertEqual(text, "")
+
+    async def test_error_response_uses_http_200(self):
+        req = json.dumps({"jsonrpc": "2.0", "method": "noSuchMethod", "id": 7})
+        async with jrpc_protocol_server_context():
+            status, text = await post_raw(req)
+        self.assertEqual(status, 200)
+        resp = json.loads(text)
+        self.assertEqual(resp["error"]["code"], -32601)  # Method not found
+        self.assertEqual(resp["id"], 7)
+
+    async def test_valid_request_success(self):
+        req = json.dumps(
+            {"jsonrpc": "2.0", "method": "echo", "params": ["0x5"], "id": 1}
+        )
+        async with jrpc_protocol_server_context():
+            status, text = await post_raw(req)
+        self.assertEqual(status, 200)
+        resp = json.loads(text)
+        self.assertEqual(resp["result"], "0x5")
+        self.assertEqual(resp["id"], 1)

--- a/quarkchain/jsonrpc_client.py
+++ b/quarkchain/jsonrpc_client.py
@@ -28,6 +28,8 @@ class JsonRpcClient:
         resp.raise_for_status()
         data = resp.json()
 
+        if data.get("id") != payload["id"]:
+            raise JsonRpcError({"code": -32600, "message": f"response id {data.get('id')!r} does not match request id {payload['id']!r}"})
         if "error" in data:
             raise JsonRpcError(data["error"])
 
@@ -58,10 +60,12 @@ class AsyncJsonRpcClient:
         resp.raise_for_status()
         data = resp.json()
 
+        if data.get("id") != payload["id"]:
+            raise JsonRpcError({"code": -32600, "message": f"response id {data.get('id')!r} does not match request id {payload['id']!r}"})
         if "error" in data:
             raise JsonRpcError(data["error"])
 
         return data.get("result")
 
     async def close(self):
-        await self.client.aclose()        
+        await self.client.aclose()

--- a/quarkchain/jsonrpc_client.py
+++ b/quarkchain/jsonrpc_client.py
@@ -28,8 +28,6 @@ class JsonRpcClient:
         resp.raise_for_status()
         data = resp.json()
 
-        if data.get("id") != payload["id"]:
-            raise JsonRpcError({"code": -32600, "message": f"response id {data.get('id')!r} does not match request id {payload['id']!r}"})
         if "error" in data:
             raise JsonRpcError(data["error"])
         if data.get("id") != payload["id"]:
@@ -62,8 +60,6 @@ class AsyncJsonRpcClient:
         resp.raise_for_status()
         data = resp.json()
 
-        if data.get("id") != payload["id"]:
-            raise JsonRpcError({"code": -32600, "message": f"response id {data.get('id')!r} does not match request id {payload['id']!r}"})
         if "error" in data:
             raise JsonRpcError(data["error"])
         if data.get("id") != payload["id"]:

--- a/quarkchain/jsonrpc_client.py
+++ b/quarkchain/jsonrpc_client.py
@@ -32,6 +32,8 @@ class JsonRpcClient:
             raise JsonRpcError({"code": -32600, "message": f"response id {data.get('id')!r} does not match request id {payload['id']!r}"})
         if "error" in data:
             raise JsonRpcError(data["error"])
+        if data.get("id") != payload["id"]:
+            raise JsonRpcError({"code": -32600, "message": f"response id {data.get('id')!r} does not match request id {payload['id']!r}"})
 
         return data.get("result")
 
@@ -64,6 +66,8 @@ class AsyncJsonRpcClient:
             raise JsonRpcError({"code": -32600, "message": f"response id {data.get('id')!r} does not match request id {payload['id']!r}"})
         if "error" in data:
             raise JsonRpcError(data["error"])
+        if data.get("id") != payload["id"]:
+            raise JsonRpcError({"code": -32600, "message": f"response id {data.get('id')!r} does not match request id {payload['id']!r}"})
 
         return data.get("result")
 


### PR DESCRIPTION
### Summary
Brings the HTTP and WebSocket JSON-RPC servers into spec compliance for malformed input,
notifications, and batch requests, and adds a protocol test suite. Also hardens the JSON-RPC client
to validate response ids.

### Related Issue 
https://github.com/QuarkChain/pyquarkchain/issues/985

### Changes
- **`jsonrpc.py` (HTTP/WS `__handle`):** return `-32700 Parse error` on malformed JSON instead of
  swallowing the error and dispatching an empty dict. Drop the dead `d = dict()` fallback and guard
  non-dict payloads with `isinstance`.
- **`jsonrpc_server.py` (`dispatch`):** suppress responses for notifications (requests with no
  `"id"`), even on the error paths. Batch (JSON array) requests are intentionally still unsupported
  but now rejected cleanly with `-32600` instead of crashing with an `AttributeError` / HTTP 500.
- **`jsonrpc_client.py`:** `JsonRpcClient` / `AsyncJsonRpcClient` now raise `JsonRpcError(-32600)`
  when the response `id` doesn't match the request `id`; also fixes a missing trailing newline.
- **`tests/test_jsonrpc.py`:** add `TestJSONRPCProtocol` — parse error, batch rejection,
  notification-no-response, error-uses-HTTP-200, and a success baseline (standalone master-free
  server on port 38391, raw POST for malformed/array bodies).

### Files
`quarkchain/cluster/jsonrpc.py`, `quarkchain/cluster/jsonrpc_server.py`,
`quarkchain/jsonrpc_client.py`, `quarkchain/cluster/tests/test_jsonrpc.py`