### PR TITLE
fix: Make `Shard.add_block` cancellation-safe; stop cancelling in-flight handlers

### DIFF
--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -811,6 +811,10 @@ class Shard:
                 # forever.  Use RuntimeError to avoid propagating CancelledError
                 # into a non-cancelled waiter.
                 fut.set_exception(RuntimeError("add_block interrupted: {}".format(e)))
+                # Mark the exception as retrieved so asyncio does not log
+                # "Future exception was never retrieved" when no waiter consumes
+                # it (the common single-caller cancellation case).
+                fut.exception()
             raise
 
     def check_minor_block_by_header(self, header):
@@ -822,6 +826,27 @@ class Shard:
         if header.height == 0:
             return
         self.state.add_block(block, force=True, write_db=False, skip_if_too_old=False)
+
+    def _abort_uncommitted_add_block_futures(self, uncommitted_block_header_list, reason):
+        """Fail the add_block_futures we created for the given headers.
+
+        Waiters (and retries that would otherwise see BLOCK_COMMITTING and
+        gather() on these futures) must not hang forever.  Use RuntimeError, not
+        cancellation, so a non-cancelled waiter takes its `except Exception`
+        path instead of having CancelledError propagated into it.
+        """
+        for block_header in uncommitted_block_header_list:
+            block_hash = block_header.get_hash()
+            fut = self.add_block_futures.pop(block_hash, None)
+            if fut is not None and not fut.done():
+                fut.set_exception(
+                    RuntimeError(
+                        "add_block_list_for_sync interrupted: {}".format(reason)
+                    )
+                )
+                # Mark retrieved to avoid asyncio's "Future exception was never
+                # retrieved" log noise when no waiter consumes it.
+                fut.exception()
 
     async def add_block_list_for_sync(self, block_list):
         """ Add blocks in batch to reduce RPCs. Will NOT broadcast to peers.
@@ -840,54 +865,61 @@ class Shard:
         block_hash_to_x_shard_list = dict()
         uncommitted_block_header_list = []
         uncommitted_coinbase_amount_map_list = []
-        for block in block_list:
-            check(block.header.branch.get_full_shard_id() == self.full_shard_id)
-
-            block_hash = block.header.get_hash()
-            # adding the block header one assuming the block will be validated.
-            coinbase_amount_list.append(block.header.coinbase_amount_map)
-
-            commit_status, future = self.__get_block_commit_status_by_hash(block_hash)
-            if commit_status == BLOCK_COMMITTED:
-                # Skip processing the block if it is already committed
-                Logger.warning(
-                    "minor block to sync {} is already committed".format(
-                        block_hash.hex()
-                    )
-                )
-                continue
-            elif commit_status == BLOCK_COMMITTING:
-                # Check if the block is being propagating to other slaves and the master
-                # Let's make sure all the shards and master got it before committing it
-                Logger.info(
-                    "[{}] {} is being added ... waiting for it to finish".format(
-                        block.header.branch.to_str(), block.header.height
-                    )
-                )
-                existing_add_block_futures.append(future)
-                continue
-
-            check(commit_status == BLOCK_UNCOMMITTED)
-            # Validate and add the block
-            try:
-                xshard_list, coinbase_amount_map = self.state.add_block(
-                    block, skip_if_too_old=False, force=True
-                )
-            except Exception as e:
-                Logger.error_exception()
-                return False, None
-
-            prev_root_height = self.state.db.get_root_block_header_by_hash(
-                block.header.hash_prev_root_block
-            ).height
-            block_hash_to_x_shard_list[block_hash] = (xshard_list, prev_root_height)
-            self.add_block_futures[block_hash] = self.loop.create_future()
-            uncommitted_block_header_list.append(block.header)
-            uncommitted_coinbase_amount_map_list.append(
-                block.header.coinbase_amount_map
-            )
-
         try:
+            for block in block_list:
+                check(block.header.branch.get_full_shard_id() == self.full_shard_id)
+
+                block_hash = block.header.get_hash()
+                # adding the block header one assuming the block will be validated.
+                coinbase_amount_list.append(block.header.coinbase_amount_map)
+
+                commit_status, future = self.__get_block_commit_status_by_hash(
+                    block_hash
+                )
+                if commit_status == BLOCK_COMMITTED:
+                    # Skip processing the block if it is already committed
+                    Logger.warning(
+                        "minor block to sync {} is already committed".format(
+                            block_hash.hex()
+                        )
+                    )
+                    continue
+                elif commit_status == BLOCK_COMMITTING:
+                    # Check if the block is being propagating to other slaves and the master
+                    # Let's make sure all the shards and master got it before committing it
+                    Logger.info(
+                        "[{}] {} is being added ... waiting for it to finish".format(
+                            block.header.branch.to_str(), block.header.height
+                        )
+                    )
+                    existing_add_block_futures.append(future)
+                    continue
+
+                check(commit_status == BLOCK_UNCOMMITTED)
+                # Validate and add the block
+                try:
+                    xshard_list, coinbase_amount_map = self.state.add_block(
+                        block, skip_if_too_old=False, force=True
+                    )
+                except Exception:
+                    Logger.error_exception()
+                    # `return` skips the `except BaseException` below, so clean up
+                    # the futures we already created before bailing out.
+                    self._abort_uncommitted_add_block_futures(
+                        uncommitted_block_header_list, "block validation failed"
+                    )
+                    return False, None
+
+                prev_root_height = self.state.db.get_root_block_header_by_hash(
+                    block.header.hash_prev_root_block
+                ).height
+                block_hash_to_x_shard_list[block_hash] = (xshard_list, prev_root_height)
+                self.add_block_futures[block_hash] = self.loop.create_future()
+                uncommitted_block_header_list.append(block.header)
+                uncommitted_coinbase_amount_map_list.append(
+                    block.header.coinbase_amount_map
+                )
+
             await self.slave.batch_broadcast_xshard_tx_list(
                 block_hash_to_x_shard_list, block_list[0].header.branch
             )
@@ -908,11 +940,9 @@ class Shard:
                 self.add_block_futures[block_hash].set_result(None)
                 del self.add_block_futures[block_hash]
         except BaseException as e:
-            for block_header in uncommitted_block_header_list:
-                block_hash = block_header.get_hash()
-                fut = self.add_block_futures.pop(block_hash, None)
-                if fut is not None and not fut.done():
-                    fut.set_exception(RuntimeError("add_block_list_for_sync interrupted: {}".format(e)))
+            self._abort_uncommitted_add_block_futures(
+                uncommitted_block_header_list, e
+            )
             raise
 
         # Wait for blocks that were already in-flight when we started.

--- a/quarkchain/cluster/shard.py
+++ b/quarkchain/cluster/shard.py
@@ -755,7 +755,10 @@ class Shard:
                     block.header.branch.to_str(), block.header.height
                 )
             )
-            await future
+            try:
+                await future
+            except Exception:
+                return False
             return True
 
         check(commit_status == BLOCK_UNCOMMITTED)
@@ -780,27 +783,35 @@ class Shard:
 
         # Add the block in future and wait
         self.add_block_futures[block_hash] = self.loop.create_future()
+        try:
+            prev_root_height = self.state.db.get_root_block_header_by_hash(
+                block.header.hash_prev_root_block
+            ).height
+            await self.slave.broadcast_xshard_tx_list(block, xshard_list, prev_root_height)
+            await self.slave.send_minor_block_header_to_master(
+                block.header,
+                len(block.tx_list),
+                len(xshard_list),
+                coinbase_amount_map,
+                self.state.get_shard_stats(),
+            )
 
-        prev_root_height = self.state.db.get_root_block_header_by_hash(
-            block.header.hash_prev_root_block
-        ).height
-        await self.slave.broadcast_xshard_tx_list(block, xshard_list, prev_root_height)
-        await self.slave.send_minor_block_header_to_master(
-            block.header,
-            len(block.tx_list),
-            len(xshard_list),
-            coinbase_amount_map,
-            self.state.get_shard_stats(),
-        )
+            # Commit the block
+            self.state.commit_by_hash(block_hash)
+            Logger.debug("committed mblock {}".format(block_hash.hex()))
 
-        # Commit the block
-        self.state.commit_by_hash(block_hash)
-        Logger.debug("committed mblock {}".format(block_hash.hex()))
-
-        # Notify the rest
-        self.add_block_futures[block_hash].set_result(None)
-        del self.add_block_futures[block_hash]
-        return True
+            # Notify the rest
+            self.add_block_futures[block_hash].set_result(None)
+            del self.add_block_futures[block_hash]
+            return True
+        except BaseException as e:
+            fut = self.add_block_futures.pop(block_hash, None)
+            if fut is not None and not fut.done():
+                # Unblock any coroutine waiting on this future so it does not hang
+                # forever.  Use RuntimeError to avoid propagating CancelledError
+                # into a non-cancelled waiter.
+                fut.set_exception(RuntimeError("add_block interrupted: {}".format(e)))
+            raise
 
     def check_minor_block_by_header(self, header):
         """ Raise exception of the block is invalid
@@ -876,28 +887,40 @@ class Shard:
                 block.header.coinbase_amount_map
             )
 
-        await self.slave.batch_broadcast_xshard_tx_list(
-            block_hash_to_x_shard_list, block_list[0].header.branch
-        )
-        check(
-            len(uncommitted_coinbase_amount_map_list)
-            == len(uncommitted_block_header_list)
-        )
-        await self.slave.send_minor_block_header_list_to_master(
-            uncommitted_block_header_list, uncommitted_coinbase_amount_map_list
-        )
+        try:
+            await self.slave.batch_broadcast_xshard_tx_list(
+                block_hash_to_x_shard_list, block_list[0].header.branch
+            )
+            check(
+                len(uncommitted_coinbase_amount_map_list)
+                == len(uncommitted_block_header_list)
+            )
+            await self.slave.send_minor_block_header_list_to_master(
+                uncommitted_block_header_list, uncommitted_coinbase_amount_map_list
+            )
 
-        # Commit all blocks and notify all rest add block operations
-        for block_header in uncommitted_block_header_list:
-            block_hash = block_header.get_hash()
-            self.state.commit_by_hash(block_hash)
-            Logger.debug("committed mblock {}".format(block_hash.hex()))
+            # Commit all blocks and notify all rest add block operations
+            for block_header in uncommitted_block_header_list:
+                block_hash = block_header.get_hash()
+                self.state.commit_by_hash(block_hash)
+                Logger.debug("committed mblock {}".format(block_hash.hex()))
 
-            self.add_block_futures[block_hash].set_result(None)
-            del self.add_block_futures[block_hash]
+                self.add_block_futures[block_hash].set_result(None)
+                del self.add_block_futures[block_hash]
+        except BaseException as e:
+            for block_header in uncommitted_block_header_list:
+                block_hash = block_header.get_hash()
+                fut = self.add_block_futures.pop(block_hash, None)
+                if fut is not None and not fut.done():
+                    fut.set_exception(RuntimeError("add_block_list_for_sync interrupted: {}".format(e)))
+            raise
 
-        # Wait for the other add block operations
-        await asyncio.gather(*existing_add_block_futures)
+        # Wait for blocks that were already in-flight when we started.
+        # If any were interrupted (future holds an exception), treat this batch as failed.
+        try:
+            await asyncio.gather(*existing_add_block_futures)
+        except Exception:
+            return False, None
 
         return True, coinbase_amount_list
 

--- a/quarkchain/cluster/slave.py
+++ b/quarkchain/cluster/slave.py
@@ -905,10 +905,6 @@ class SlaveServer:
         self.artificial_tx_config = None
         self.shards = dict()  # type: Dict[Branch, Shard]
         self.shutdown_future = self.loop.create_future()
-
-        # block hash -> future (that will return when the block is fully propagated in the cluster)
-        # the block that has been added locally but not have been fully propagated will have an entry here
-        self.add_block_futures = dict()
         self.shard_subscription_managers = dict()
 
     def __cover_shard_id(self, full_shard_id):

--- a/quarkchain/cluster/tests/test_cluster.py
+++ b/quarkchain/cluster/tests/test_cluster.py
@@ -1,5 +1,6 @@
 import asyncio
 import unittest
+from unittest.mock import AsyncMock, MagicMock
 
 from eth_keys.datatypes import PrivateKey
 
@@ -9,11 +10,13 @@ from quarkchain.cluster.p2p_commands import (
     GetMinorBlockHeaderListWithSkipRequest,
     Direction,
 )
+from quarkchain.cluster.shard import Shard
 from quarkchain.cluster.tests.test_utils import (
     create_transfer_transaction,
     create_contract_with_storage2_transaction,
     mock_pay_native_token_as_gas,
     ClusterContext,
+    get_test_env,
 )
 from quarkchain.config import ConsensusType
 from quarkchain.core import (
@@ -25,6 +28,7 @@ from quarkchain.core import (
     RootBlock,
 )
 from quarkchain.evm import opcodes
+from quarkchain.genesis import GenesisManager
 from quarkchain.utils import (
     async_assert_true_with_timeout,
     sha3_256,
@@ -2622,3 +2626,85 @@ class TestCluster(unittest.IsolatedAsyncioTestCase):
                     qkc_token, state2.header_tip.get_hash(), rh, 100, None
                 )
                 self.assertEqual(balance, init_coinbase + 100)
+
+
+def _make_finalized_shard_block(shard_state):
+    block = shard_state.get_tip().create_block_to_append()
+    evm_state = shard_state.run_block(block)
+    coinbase_amount_map = shard_state.get_coinbase_amount_map(block.header.height)
+    coinbase_amount_map.add(evm_state.block_fee_tokens)
+    block.finalize(evm_state=evm_state, coinbase_amount_map=coinbase_amount_map)
+    return block
+
+
+class TestAddBlockCancellation(unittest.IsolatedAsyncioTestCase):
+    """
+    Regression: cancelled add_block left the future in add_block_futures permanently
+    pending, causing any subsequent add_block / add_block_list_for_sync for the same
+    block to hang forever and stopping shard sync until process restart.
+    """
+
+    def _make_shard(self):
+        env = get_test_env()
+        slave = MagicMock()
+        full_shard_id = next(iter(env.quark_chain_config.shards))
+        shard = Shard(env, full_shard_id, slave)
+        genesis_manager = GenesisManager(env.quark_chain_config)
+        shard.state.init_genesis_state(genesis_manager.create_root_block())
+        return shard
+
+    async def test_cancelled_add_block_resolves_future(self):
+        """add_block cancelled at broadcast must not leave a permanently-pending future."""
+        shard = self._make_shard()
+        block = _make_finalized_shard_block(shard.state)
+        block_hash = block.header.get_hash()
+
+        broadcast_started = asyncio.Event()
+
+        async def hanging_broadcast(*args, **kwargs):
+            broadcast_started.set()
+            await asyncio.sleep(9999)
+
+        shard.slave.broadcast_xshard_tx_list = hanging_broadcast
+
+        task = asyncio.create_task(shard.add_block(block))
+        await broadcast_started.wait()
+        task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+
+        self.assertNotIn(
+            block_hash,
+            shard.add_block_futures,
+            "Cancelled add_block must clean up the future from add_block_futures",
+        )
+
+    async def test_waiter_unblocks_when_add_block_is_interrupted(self):
+        """
+        A second caller waiting on BLOCK_COMMITTING must unblock and return False
+        when the first caller is interrupted — not hang forever.
+        """
+        shard = self._make_shard()
+        block = _make_finalized_shard_block(shard.state)
+
+        broadcast_started = asyncio.Event()
+
+        async def hanging_broadcast(*args, **kwargs):
+            broadcast_started.set()
+            await asyncio.sleep(9999)
+
+        shard.slave.broadcast_xshard_tx_list = hanging_broadcast
+
+        add_task = asyncio.create_task(shard.add_block(block))
+        await broadcast_started.wait()
+
+        # Second caller arrives while the first is in-flight (BLOCK_COMMITTING)
+        waiter_task = asyncio.create_task(shard.add_block(block))
+        await asyncio.sleep(0)  # let waiter enter the BLOCK_COMMITTING branch
+
+        add_task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await add_task
+
+        result = await asyncio.wait_for(waiter_task, timeout=5.0)
+        self.assertFalse(result, "Waiter for an interrupted block should return False")

--- a/quarkchain/cluster/tests/test_cluster.py
+++ b/quarkchain/cluster/tests/test_cluster.py
@@ -1,6 +1,6 @@
 import asyncio
 import unittest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 from eth_keys.datatypes import PrivateKey
 

--- a/quarkchain/protocol.py
+++ b/quarkchain/protocol.py
@@ -196,9 +196,12 @@ class AbstractConnection:
             while self.state == ConnectionState.ACTIVE:
                 await self.loop_once()
         finally:
-            # Cancel any in-flight handler tasks
-            for task in self._handler_tasks:
-                task.cancel()
+            # Do NOT cancel in-flight handler tasks.  Critical handlers such as
+            # Shard.add_block register futures that waiters depend on; cancelling
+            # them mid-flight leaves those futures permanently pending and causes
+            # the shard to stop syncing until the process restarts.  Tasks that
+            # encounter a dead connection will fail naturally when their next RPC
+            # attempt raises RuntimeError (via rpc_future_map abort below).
             self._handler_tasks.clear()
 
             # Ensure active_event is set so wait_until_active() callers are not stuck


### PR DESCRIPTION
### Summary
Fixes a shard-sync hang. A per-connection `finally` cancelled in-flight message handlers, but
`Shard.add_block` is a multi-step commit with `await`s between steps and no failure cleanup. A
cancellation between awaits left `add_block_futures[hash]` permanently pending, so waiters and
`SyncTask` hung until the process was restarted.

### Related Issue
 https://github.com/QuarkChain/pyquarkchain/issues/985

### Changes
- **`protocol.py`:** `active_and_loop_forever` no longer cancels `_handler_tasks` (restores
  run-to-completion). The fd-leak fix is kept (`writer.close()` on cancel, `reader.feed_eof()`), as
  is the `rpc_future_map` abort that unblocks any handler awaiting a dead connection's RPC.
- **`shard.py`:** wrap the commit protocol in `add_block` and `add_block_list_for_sync` with
  `try/except BaseException` → pop the future and `set_exception(RuntimeError(...))` on any
  interruption (including `CancelledError`), then re-raise. `RuntimeError` (not `CancelledError`) is
  used so a non-cancelled waiter isn't poisoned. Also fixes a pre-existing exception-path leak
  (broadcast to a dead slave). Sync now fails-and-retries on interrupted in-flight blocks instead of
  hanging.
- **`slave.py`:** remove the dead `SlaveServer.add_block_futures` (the live map is on `Shard`).
- **`tests/test_cluster.py`:** regression tests — a cancelled `add_block` cleans up its future, and
  a second waiter returns `False` instead of hanging forever.

### Files
`quarkchain/protocol.py`, `quarkchain/cluster/shard.py`, `quarkchain/cluster/slave.py`,
`quarkchain/cluster/tests/test_cluster.py`