### PR TITLE
fix: Fix miner disable→restart lifecycle; bound test event-loop fd leak

### DIFF
--- a/quarkchain/cluster/miner.py
+++ b/quarkchain/cluster/miner.py
@@ -199,18 +199,29 @@ class Miner:
     def disable(self):
         """Stop the mining process if there is one"""
         if self.enabled and self.process:
-            # end the mining process
+            # Signal the subprocess to stop.  The None sentinel will be read by
+            # handle_mined_block which then exits cleanly.  Do NOT also cancel
+            # the task: cancelling leaves the sentinel in output_q unconsumed,
+            # so the next start() reads a stale None and exits immediately.
             self.input_q.put((None, {}))
-        self.enabled = False
-        if self._mining_task and not self._mining_task.done():
+        elif self._mining_task and not self._mining_task.done():
+            # No subprocess to signal; cancel the task directly.
             self._mining_task.cancel()
-            self._mining_task = None
+        self.enabled = False
+        self._mining_task = None
 
     def _mine_new_block_async(self):
         async def handle_mined_block():
             while True:
                 res = await self.output_q.coro_get()  # type: MiningResult
                 if not res:
+                    # The subprocess has put its terminating sentinel and is
+                    # exiting.  Reset the process handle so a subsequent start()
+                    # spawns a fresh subprocess instead of posting work to the
+                    # dead one (which would silently never mine).
+                    if self.process:
+                        self.process.join()
+                        self.process = None
                     return  # empty result means ending
                 # start mining before processing and propagating mined block
                 self._mine_new_block_async()

--- a/quarkchain/cluster/miner.py
+++ b/quarkchain/cluster/miner.py
@@ -252,6 +252,12 @@ class Miner:
             If a mining process has already been started, update the process to mine the new block.
             """
             block = await self.create_block_async_func(Address.create_empty_account())
+            # disable() may have run while we were awaiting block creation.  If so,
+            # bail out: with self.process now reset to None, falling through would
+            # spawn a fresh subprocess that disable() has already finished tearing
+            # down and can no longer stop, leaving an unstoppable rogue miner.
+            if not self.enabled:
+                return
             if not block:
                 self.input_q.put((None, {}))
                 return

--- a/quarkchain/cluster/miner.py
+++ b/quarkchain/cluster/miner.py
@@ -220,7 +220,10 @@ class Miner:
                     # spawns a fresh subprocess instead of posting work to the
                     # dead one (which would silently never mine).
                     if self.process:
-                        self.process.join()
+                        # Use coro_join (runs join in an executor) instead of the
+                        # blocking join() so reaping the subprocess does not stall
+                        # the event loop.
+                        await self.process.coro_join()
                         self.process = None
                     return  # empty result means ending
                 # start mining before processing and propagating mined block

--- a/quarkchain/cluster/tests/conftest.py
+++ b/quarkchain/cluster/tests/conftest.py
@@ -4,25 +4,49 @@ import pytest
 
 from quarkchain.protocol import AbstractConnection
 
+# Track the gap-filling loop we create so we can close it when it is replaced
+# by an IsolatedAsyncioTestCase framework loop.  Without this, each replaced
+# loop is only closed by CPython's reference-counting GC, which is not
+# guaranteed and leaks one fd per async-test / sync-test boundary.
+_loop_created_by_fixture = None
+
 
 @pytest.fixture(autouse=True)
 def ensure_event_loop():
     """Ensure an event loop exists after each test.
-    
+
     IsolatedAsyncioTestCase tears down its loop and sets the current loop to None,
     which breaks subsequent sync tests that call asyncio.get_event_loop().
-    
+
     This fixture:
     1. Allows tests to run normally with proper cleanup
     2. Resets the event loop state if it's closed
-    3. Clears RPC counters without aggressively cancelling test framework tasks
+    3. Closes any previously-created gap loop to avoid fd leaks
+    4. Clears RPC counters without aggressively cancelling test framework tasks
     """
+    global _loop_created_by_fixture
     yield
-    # Reset after test completes
     AbstractConnection.aborted_rpc_count = 0
+
+    # If our previously-created gap loop has been replaced (e.g. by
+    # IsolatedAsyncioTestCase installing its own loop), close it now.
+    if _loop_created_by_fixture is not None:
+        try:
+            current = asyncio.get_event_loop()
+        except RuntimeError:
+            current = None
+        if current is not _loop_created_by_fixture:
+            if not _loop_created_by_fixture.is_closed():
+                _loop_created_by_fixture.close()
+            _loop_created_by_fixture = None
+
     try:
-        old_loop = asyncio.get_event_loop()
-        if old_loop.is_closed():
-            asyncio.set_event_loop(asyncio.new_event_loop())
+        loop = asyncio.get_event_loop()
+        if loop.is_closed():
+            new_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(new_loop)
+            _loop_created_by_fixture = new_loop
     except RuntimeError:
-        asyncio.set_event_loop(asyncio.new_event_loop())
+        new_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(new_loop)
+        _loop_created_by_fixture = new_loop

--- a/quarkchain/cluster/tests/test_miner.py
+++ b/quarkchain/cluster/tests/test_miner.py
@@ -72,6 +72,104 @@ class TestMiner(unittest.TestCase):
             asyncio.run(go())
             self.assertEqual(len(self.added_blocks), 5)
 
+    def test_disable_with_subprocess_signals_via_queue(self):
+        # When a subprocess is running, disable() must signal termination via
+        # the input queue sentinel and must NOT cancel the handler task.
+        # Cancelling would leave the subprocess's terminating None unconsumed in
+        # output_q, so the next start() would read a stale None and exit.
+        miner = self.miner_gen(ConsensusType.POW_DOUBLESHA256, None, None)
+
+        async def go():
+            async def handler():
+                await asyncio.sleep(60)
+
+            miner.enabled = True
+            miner.process = object()  # pretend a subprocess is running
+            miner._mining_task = asyncio.ensure_future(handler())
+            task = miner._mining_task
+            await asyncio.sleep(0)  # let the task start
+
+            miner.disable()
+
+            # sentinel queued for the subprocess to read and terminate on
+            self.assertEqual(miner.input_q.get(timeout=5), (None, {}))
+            # handler task must NOT be cancelled (it drains the output_q None)
+            self.assertFalse(task.cancelled())
+            self.assertFalse(task.done())
+            self.assertFalse(miner.enabled)
+            self.assertIsNone(miner._mining_task)
+
+            task.cancel()  # cleanup
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        asyncio.run(go())
+
+    def test_disable_without_subprocess_cancels_task(self):
+        # With no subprocess yet (e.g. disable() during block creation), there
+        # is nothing to signal, so the handler task is cancelled directly.
+        miner = self.miner_gen(ConsensusType.POW_DOUBLESHA256, None, None)
+
+        async def go():
+            async def handler():
+                await asyncio.sleep(60)
+
+            miner.enabled = True
+            miner.process = None  # no subprocess spawned yet
+            miner._mining_task = asyncio.ensure_future(handler())
+            task = miner._mining_task
+            await asyncio.sleep(0)
+
+            miner.disable()
+
+            self.assertFalse(miner.enabled)
+            self.assertIsNone(miner._mining_task)
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+            self.assertTrue(task.cancelled())
+
+        asyncio.run(go())
+
+    def test_restart_after_termination_resumes_mining(self):
+        # Regression: after a mining session ends (subprocess signaled to stop),
+        # self.process must be reset so the next start() spawns a fresh
+        # subprocess.  Without the reset, mine_new_block posts work to the dead
+        # subprocess and mining silently never resumes.
+        async def create(coinbase_addr=None, retry=True):
+            # session 1 stops at 2 blocks, session 2 at 4
+            if len(self.added_blocks) >= self.stop_at:
+                return None
+            return RootBlock(
+                RootBlockHeader(create_time=int(time.time())),
+                tracking_data="{}".encode("utf-8"),
+            )
+
+        async def add(block):
+            self.added_blocks.append(block)
+
+        miner = self.miner_gen(ConsensusType.POW_DOUBLESHA256, create, add)
+
+        async def session():
+            task = miner._mine_new_block_async()
+            if task is not None:
+                await task
+
+        # session 1
+        self.stop_at = 2
+        asyncio.run(session())
+        self.assertEqual(len(self.added_blocks), 2)
+        # process handle cleared after the subprocess terminated
+        self.assertIsNone(miner.process)
+
+        # session 2 (restart): mining must actually resume and add more blocks
+        self.stop_at = 4
+        miner.enabled = True
+        asyncio.run(session())
+        self.assertEqual(len(self.added_blocks), 4)
+        self.assertIsNone(miner.process)
+
     def test_simulate_mine_handle_block_exception(self):
         i = 0
 

--- a/quarkchain/cluster/tests/test_miner.py
+++ b/quarkchain/cluster/tests/test_miner.py
@@ -170,6 +170,38 @@ class TestMiner(unittest.TestCase):
         self.assertEqual(len(self.added_blocks), 4)
         self.assertIsNone(miner.process)
 
+    def test_disable_during_block_creation_prevents_rogue_subprocess(self):
+        # Race: an in-flight mine_new_block task is suspended at
+        # `await create_block_async_func`.  While suspended, disable() runs and
+        # the old subprocess is reaped (self.process reset to None).  When the
+        # task resumes it must re-check self.enabled and bail out; otherwise it
+        # would spawn a fresh subprocess that disable() has already finished
+        # tearing down and can no longer stop, leaving an unstoppable miner.
+        miner = self.miner_gen(ConsensusType.POW_DOUBLESHA256, None, None)
+
+        async def create(coinbase_addr=None, retry=True):
+            # mimic disable() + subprocess reaping landing mid-await
+            miner.process = object()  # a subprocess was running
+            miner.disable()  # signals the subprocess, flips enabled to False
+            miner.process = None  # handle_mined_block reaps the subprocess
+            return RootBlock(
+                RootBlockHeader(create_time=int(time.time())),
+                tracking_data="{}".encode("utf-8"),
+            )
+
+        miner.create_block_async_func = create
+
+        async def go():
+            task = miner._mine_new_block_async()
+            if task is not None:
+                await task
+
+        asyncio.run(go())
+        # bailed out after the await: no rogue subprocess was spawned
+        self.assertIsNone(miner.process)
+        self.assertFalse(miner.enabled)
+        self.assertEqual(len(self.added_blocks), 0)
+
     def test_simulate_mine_handle_block_exception(self):
         i = 0
 


### PR DESCRIPTION
###  Summary

The miner's disable()/start() cycle was broken in two ways that left mining silently dead after a restart, and the test event-loop fixture leaked one fd per async/sync-test boundary.

### Related Issue
 https://github.com/QuarkChain/pyquarkchain/issues/985

###  Changes

  - miner.py disable() (stale sentinel): when a subprocess is running, signal termination through the input_q sentinel only — do not also cancel the handler task. Cancelling left the subprocess's terminating None unconsumed in output_q, so the next start() read a stale None and exited immediately. The task is now cancelled only in the elif branch where no subprocess exists yet.
  - miner.py handle_mined_block() (dead-process restart): on the terminating None, join() the subprocess and reset self.process = None. Previously self.process was never cleared, so a subsequent start() posted work to the already-exited subprocess and mining silently never resumed. join() also reaps the zombie. Resetting here avoids racing the subprocess's async exit.
  - conftest.py: track and close the gap-filling loop once replaced by an IsolatedAsyncioTestCase loop, bounding the fd leak to one live loop.
  - tests/test_miner.py: regression tests for both disable() branches and the terminate→restart cycle.