### PR TITLE
evm: restore balances after reverting account deletion

### DIFF
--- a/quarkchain/evm/state.py
+++ b/quarkchain/evm/state.py
@@ -192,7 +192,7 @@ class TokenBalances:
     def reset(self, journal):
         pre_balance = self._balances
         self._balances = {}
-        journal.append(lambda: setattr(self, "_balance", pre_balance))
+        journal.append(lambda: setattr(self, "_balances", pre_balance))
         pre_token_trie = self.token_trie
         self.token_trie = None
         journal.append(lambda: setattr(self, "token_trie", pre_token_trie))

--- a/quarkchain/evm/tests/test_token_balances.py
+++ b/quarkchain/evm/tests/test_token_balances.py
@@ -1,7 +1,7 @@
 import pytest
 
 from quarkchain.db import InMemoryDb
-from quarkchain.evm.state import TokenBalances, BLANK_ROOT
+from quarkchain.evm.state import State, TokenBalances, BLANK_ROOT
 from quarkchain.utils import token_id_encode
 
 
@@ -232,8 +232,49 @@ def test_reset_balance_in_trie_and_revert():
     b.reset(journal)
     assert b.is_blank()
     assert b.to_dict() == {}
-    for op in journal:
-        op()
+    # unwind LIFO, the order State.revert uses
+    while journal:
+        journal.pop()()
     assert not b.is_blank()
     assert b.to_dict() == mapping
     assert b._balances != {}
+
+
+def test_reset_balance_in_dict_and_revert():
+    db = InMemoryDb()
+    b = TokenBalances(b"", db)
+    mapping = {token_id_encode("Q" + chr(65 + i)): int(i * 1e3) + 42 for i in range(3)}
+    b._balances = mapping.copy()
+    b.commit()
+    # below the trie threshold, so balances stay in the in-memory map
+    assert b.token_trie is None
+
+    journal = []
+    b.set_balance(journal, 999, 999)
+    b.reset(journal)
+    assert b.is_blank()
+    assert b.to_dict() == {}
+
+    while journal:
+        journal.pop()()
+    assert not b.is_blank()
+    for token_id, bal in mapping.items():
+        assert b.balance(token_id) == bal
+    # undoing a set_balance writes the previous value back, so an entry the
+    # account never had before ends up holding zero
+    assert b.balance(999) == 0
+
+
+def test_del_account_and_revert_restores_balances():
+    state = State()
+    addr = b"\x01" * 20
+    token = token_id_encode("QKC")
+    state.set_token_balance(addr, token, 100)
+    state.commit()
+
+    snapshot = state.snapshot()
+    state.del_account(addr)
+    assert state.get_balance(addr, token) == 0
+
+    state.revert(snapshot)
+    assert state.get_balance(addr, token) == 100


### PR DESCRIPTION
This PR fixes account-deletion rollback so token balances are not lost.

## What

Restore an account's token balances when its deletion is reverted due to a misspelled attribute (`_balance` instead of `_balances`).
- Corrected the compact balance format used by most accounts.
- Keep current node behavior and state roots unchanged because account deletion is not reverted in the current transaction flow.

## Test

- Delete and revert a funded account, then verify its balance is restored.
- Exercise both compact and trie-backed balance storage using the same last-in-first-out order as state rollback.