### PR TITLE
Pin the dependencies in `requirements.txt` to the exact package versions currently used by: `mainnet1.7.0-beta`

### DIFF
--- a/quarkchain/cluster/tests/test_utils.py
+++ b/quarkchain/cluster/tests/test_utils.py
@@ -301,10 +301,20 @@ class Cluster:
 
 
 def get_next_port():
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-        s.bind(("", 0))
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        return s.getsockname()[1]
+    # Do not reuse a port during this pytest process.  bind(0) releases the
+    # port immediately, while a cancelled async connection from a previous
+    # test may still be attempting its protocol handshake.
+    if not hasattr(get_next_port, "_allocated_ports"):
+        get_next_port._allocated_ports = set()
+
+    while True:
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            s.bind(("", 0))
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            port = s.getsockname()[1]
+        if port not in get_next_port._allocated_ports:
+            get_next_port._allocated_ports.add(port)
+            return port
 
 
 async def create_test_clusters(

--- a/quarkchain/cluster/tests/test_utils.py
+++ b/quarkchain/cluster/tests/test_utils.py
@@ -307,7 +307,7 @@ def get_next_port():
     if not hasattr(get_next_port, "_allocated_ports"):
         get_next_port._allocated_ports = set()
 
-    while True:
+    for _ in range(100):
         with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
             s.bind(("", 0))
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -315,6 +315,7 @@ def get_next_port():
         if port not in get_next_port._allocated_ports:
             get_next_port._allocated_ports.add(port)
             return port
+    raise RuntimeError("could not find an unused port after 100 attempts")
 
 
 async def create_test_clusters(

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ eth-utils==6.0.0
 eth-keys==0.7.0
 eth-bloom==3.1.0
 httpx==0.28.1
-setuptools==82.0.1
+setuptools==83.0.0
 numpy==2.4.6
 psutil==7.2.2
 rocksdict==0.3.29

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,32 +1,32 @@
-aiohttp>=3.9,<4
-aiohttp_cors>=0.7.0,<1
-aioprocessing>=2.0,<3
-cachetools>=5,<8
-coincurve>=19.0.1,<22
-decorator>=5,<6
-ecdsa>=0.18,<1
-eth-hash[pycryptodome]>=0.5,<0.9
-eth-utils>=2.3,<7
-eth-keys>=0.5,<1
-eth-bloom>=2.0,<4
-httpx>=0.28,<1
-setuptools>=80.8.0,<83
-numpy>=1.26,<3
-psutil>=6,<8
-rocksdict>=0.3.24,<1
-requests>=2.28.0,<3
-py_ecc>=7,<9
-pytest-timeout>=2.0.1,<3
-websockets>=12,<17
+aiohttp==3.14.1
+aiohttp-cors==0.8.1
+aioprocessing==2.0.1
+cachetools==7.1.4
+coincurve==21.0.0
+decorator==5.3.1
+ecdsa==0.19.2
+eth-hash[pycryptodome]==0.8.0
+eth-utils==6.0.0
+eth-keys==0.7.0
+eth-bloom==3.1.0
+httpx==0.28.1
+setuptools==82.0.1
+numpy==2.4.6
+psutil==7.2.2
+rocksdict==0.3.29
+requests==2.34.2
+py-ecc==8.0.0
+pytest-timeout==2.4.0
+websockets==16.0
 
 # p2p
-async-upnp-client>=0.38,<1
-pytest>=8,<10
-pytest-asyncio>=0.23,<2
-cryptography>=42,<47
-rlp>=3,<5
+async-upnp-client==0.47.0
+pytest==9.1.0
+pytest-asyncio==1.4.0
+cryptography==46.0.7
+rlp==4.1.0
 
 # pyethapp/accounts.py dependency
-pbkdf2>=1.3,<2
+pbkdf2==1.3
 
 pyethash @ git+https://github.com/QuarkChain/ethash.git@907b7d8064d3be09536e754bbf469b442f2e213d

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.14.1
+aiohttp==3.14.3
 aiohttp-cors==0.8.1
 aioprocessing==2.0.1
 cachetools==7.1.4


### PR DESCRIPTION
## Summary

Pin the dependencies in `requirements.txt` to the exact package versions currently used by: `quarkchaindocker/pyquarkchain:mainnet1.7.0-beta`

## Motivation

The previous version ranges allowed dependency resolution to change over time, which could produce an environment different from the tested mainnet Docker image.

Using the package versions from `mainnet1.7.0-beta` provides:

- A reproducible Python environment
- Dependency versions already exercised by the existing Docker image tests
- A stable baseline for reviewing and testing the Python 3.13 compatibility changes
- Reduced risk from unreviewed dependency upgrades

## Changes

- Replaced dependency version ranges in `requirements.txt` with exact versions from the running `mainnet1.7.0-beta` container.
- Kept `pyethash` pinned to commit: `907b7d8064d3be09536e754bbf469b442f2e213d`
- No application or consensus logic was changed.

### Dependency Version and Security Review

Most dependencies are pinned to the versions installed in the `mainnet1.7.0-beta` image. 
The following packages were reviewed separately because they were either upgraded for security fixes 
or retained after confirming that the reported vulnerabilities have no reachable attack path in pyquarkchain.

| Package | `mainnet1.7.0-beta` | This PR | Decision and rationale |
| --- | --- | --- | --- |
| `setuptools` | `82.0.1` | `83.0.0` | Upgraded to the patched version for `GHSA-h35f-9h28-mq5c` / `CVE-2026-59890`. The issue concerns Unicode normalization collisions bypassing `MANIFEST.in` exclusions when building an sdist on macOS. The current deployment flow is not exposed, but upgrading the build/install tooling is low risk and prevents accidental inclusion of excluded files in future source distributions. `setuptools` is used by `setup.py`; it is not used to compile `ethash` or `qkchash`. |
| `aiohttp` | `3.14.1` | `3.14.3` | Upgraded because `3.14.1` is affected by known security advisories, including `PYSEC-2026-3545` / `CVE-2026-69244`. `3.14.3` contains the corresponding upstream security fixes. The upgrade exposed a test-only port-reuse race, which is addressed by the `get_next_port()` helper change described below. |
| `cryptography` | `46.0.7` | `46.0.7` | Kept unchanged. The reviewed advisories affect X.509 chain verification, wildcard DNS constraint verification, PKCS#7/S/MIME decryption, or specific bundled OpenSSL APIs. pyquarkchain uses `cryptography` for secp256k1 ECDH, AES-CTR/ECB, HMAC, and constant-time comparison, and does not expose the affected certificate, PKCS#7/S/MIME, CMS, QUIC, OCSP/CMP, DHX, or AES-OCB/SIV paths. No reachable attack path was identified in the current code. |
| `ecdsa` | `0.19.2` | `0.19.2` | Kept unchanged. Version `0.19.2` already fixes the malformed-DER private-key parsing issue described by `GHSA-9f5j-8jwj-x28g`. The unfixed Minerva advisory (`GHSA-wj6h-64fc-37mp`) concerns P-256 timing behavior, while pyquarkchain uses `SECP256k1` and does not use the affected `sign_digest()` path. No additional version upgrade is available or required for the current usage. |

### Test fix for aiohttp upgrade from `3.14.1` to `3.14.3`.

The upgrade changes the timing of asynchronous connection cleanup and cancellation. As a result, an existing test race is exposed: an old P2P connection may still send its `HELLO` packet after the port is released and reused by a Cluster RPC server, causing `KeyError: 0`.

The previous version usually passed because the old connection was closed before the port was reused. The test helper now prevents port reuse within the same pytest process. No production code changes are required.

## Verification

The following verification has been completed:

- Built and pushed `quarkchaindocker/pyquarkchain:mainnet1.7.0-gamma` with the updated `requirements.txt`.
- Started a node using the `mainnet1.7.0-gamma` image and confirmed that it runs and synchronizes with the network.

### Reviewer Verification

Reviewers can independently verify the change with the following steps:

1. Start a container using `quarkchaindocker/pyquarkchain:mainnet1.7.0-beta`, inspect its installed package versions, and confirm that the direct dependencies match the versions pinned in `requirements.txt`.

   ```bash
   docker run --rm \
     quarkchaindocker/pyquarkchain:mainnet1.7.0-beta \
     python -m pip freeze --all
   ```

2. Start a node using `quarkchaindocker/pyquarkchain:mainnet1.7.0-gamma` and confirm that it starts successfully, connects to peers, and continues synchronizing blocks without dependency or runtime errors.