### PR TITLE
Dockerfile: support private repository builds with BuildKit secrets

### DIFF
--- a/mainnet/singularity/Dockerfile
+++ b/mainnet/singularity/Dockerfile
@@ -1,15 +1,10 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.13-slim 
-LABEL maintainer="quarkchain"
-
-ARG GIT_REPOSITORY=https://github.com/QuarkChain/pyquarkchain.git
-ARG GIT_TAG=master
+FROM python:3.13-slim AS base
 
 RUN apt-get update && apt-get install -y \
     build-essential \
     gcc \
-    git \
     curl \
     libssl3 \
     libbz2-1.0 \
@@ -21,6 +16,14 @@ RUN apt-get update && apt-get install -y \
     zlib1g \
     vim \
   && rm -rf /var/lib/apt/lists/*
+
+FROM base AS builder
+
+ARG GIT_REPOSITORY=https://github.com/QuarkChain/pyquarkchain.git
+ARG GIT_TAG=master
+
+RUN apt-get update && apt-get install -y git \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip
 
@@ -36,7 +39,7 @@ WORKDIR /code/pyquarkchain
 
 RUN echo "checkout to $GIT_TAG" && git checkout "$GIT_TAG"
 
-RUN pip install -r requirements.txt
+RUN pip install --prefix=/install -r requirements.txt
 
 RUN curl -fsSL https://s3-us-west-2.amazonaws.com/pyqkcmainnet/libqkchash.so -o /code/pyquarkchain/qkchash/libqkchash.so
 
@@ -44,6 +47,12 @@ RUN rm -rf /code/pyquarkchain/.git \
  && apt-get purge -y git \
  && apt-get autoremove -y
 
+FROM base AS runtime
+
+COPY --from=builder /install /usr/local
+COPY --from=builder /code/pyquarkchain /code/pyquarkchain
+
+WORKDIR /code/pyquarkchain
 
 EXPOSE 22 38291 38391 38491
 ENV PYTHONPATH=/code/pyquarkchain

--- a/mainnet/singularity/Dockerfile
+++ b/mainnet/singularity/Dockerfile
@@ -1,10 +1,15 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.13-slim AS base
+FROM python:3.13-slim 
+LABEL maintainer="quarkchain"
+
+ARG GIT_REPOSITORY=https://github.com/QuarkChain/pyquarkchain.git
+ARG GIT_TAG=master
 
 RUN apt-get update && apt-get install -y \
     build-essential \
     gcc \
+    git \
     curl \
     libssl3 \
     libbz2-1.0 \
@@ -17,14 +22,6 @@ RUN apt-get update && apt-get install -y \
     vim \
   && rm -rf /var/lib/apt/lists/*
 
-FROM base AS builder
-
-ARG GIT_REPOSITORY=https://github.com/QuarkChain/pyquarkchain.git
-ARG GIT_TAG=master
-
-RUN apt-get update && apt-get install -y git \
- && rm -rf /var/lib/apt/lists/*
-
 RUN pip install --upgrade pip
 
 RUN --mount=type=secret,id=github_token,required=false \
@@ -35,24 +32,14 @@ RUN --mount=type=secret,id=github_token,required=false \
     else \
         git clone "$GIT_REPOSITORY" /code/pyquarkchain; \
     fi
+
 WORKDIR /code/pyquarkchain
 
 RUN echo "checkout to $GIT_TAG" && git checkout "$GIT_TAG"
 
-RUN pip install --prefix=/install -r requirements.txt
+RUN pip install -r requirements.txt
 
 RUN curl -fsSL https://s3-us-west-2.amazonaws.com/pyqkcmainnet/libqkchash.so -o /code/pyquarkchain/qkchash/libqkchash.so
-
-RUN rm -rf /code/pyquarkchain/.git \
- && apt-get purge -y git \
- && apt-get autoremove -y
-
-FROM base AS runtime
-
-COPY --from=builder /install /usr/local
-COPY --from=builder /code/pyquarkchain /code/pyquarkchain
-
-WORKDIR /code/pyquarkchain
 
 EXPOSE 22 38291 38391 38491
 ENV PYTHONPATH=/code/pyquarkchain

--- a/mainnet/singularity/Dockerfile
+++ b/mainnet/singularity/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM python:3.13-slim 
 LABEL maintainer="quarkchain"
 
@@ -22,7 +24,14 @@ RUN apt-get update && apt-get install -y \
 
 RUN pip install --upgrade pip
 
-RUN git clone "$GIT_REPOSITORY" /code/pyquarkchain
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then \
+        GIT_AUTH="$(printf 'x-access-token:%s' "$(cat /run/secrets/github_token)" | base64 | tr -d '\n')"; \
+        git -c http.extraHeader="Authorization: Basic $GIT_AUTH" \
+            clone "$GIT_REPOSITORY" /code/pyquarkchain; \
+    else \
+        git clone "$GIT_REPOSITORY" /code/pyquarkchain; \
+    fi
 WORKDIR /code/pyquarkchain
 
 RUN echo "checkout to $GIT_TAG" && git checkout "$GIT_TAG"
@@ -30,6 +39,10 @@ RUN echo "checkout to $GIT_TAG" && git checkout "$GIT_TAG"
 RUN pip install -r requirements.txt
 
 RUN curl -fsSL https://s3-us-west-2.amazonaws.com/pyqkcmainnet/libqkchash.so -o /code/pyquarkchain/qkchash/libqkchash.so
+
+RUN rm -rf /code/pyquarkchain/.git \
+ && apt-get purge -y git \
+ && apt-get autoremove -y
 
 
 EXPOSE 22 38291 38391 38491

--- a/mainnet/singularity/Dockerfile
+++ b/mainnet/singularity/Dockerfile
@@ -25,9 +25,13 @@ RUN apt-get update && apt-get install -y \
 RUN pip install --upgrade pip
 
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then \
+    if ! printf '%s\n' "$GIT_REPOSITORY" \
+        | grep -Eiq '^https://github\.com/QuarkChain/[^/]+(\.git)?$'; then \
+        echo "GIT_REPOSITORY must be under the QuarkChain organization on GitHub" >&2; \
+        exit 1; \
+    elif [ -s /run/secrets/github_token ]; then \
         GIT_AUTH="$(printf 'x-access-token:%s' "$(cat /run/secrets/github_token)" | base64 | tr -d '\n')"; \
-        git -c http.extraHeader="Authorization: Basic $GIT_AUTH" \
+        git -c http.https://github.com/.extraHeader="Authorization: Basic $GIT_AUTH" \
             clone "$GIT_REPOSITORY" /code/pyquarkchain; \
     else \
         git clone "$GIT_REPOSITORY" /code/pyquarkchain; \

--- a/mainnet/singularity/Dockerfile
+++ b/mainnet/singularity/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.13-slim 
 LABEL maintainer="quarkchain"
 
+ARG GIT_REPOSITORY=https://github.com/QuarkChain/pyquarkchain.git
+ARG GIT_TAG=master
+
 RUN apt-get update && apt-get install -y \
     build-essential \
     gcc \
@@ -19,11 +22,10 @@ RUN apt-get update && apt-get install -y \
 
 RUN pip install --upgrade pip
 
-RUN git clone https://github.com/QuarkChain/pyquarkchain.git /code/pyquarkchain
+RUN git clone "$GIT_REPOSITORY" /code/pyquarkchain
 WORKDIR /code/pyquarkchain
 
-ARG GIT_TAG
-RUN echo "checkout to $GIT_TAG" && git checkout $GIT_TAG
+RUN echo "checkout to $GIT_TAG" && git checkout "$GIT_TAG"
 
 RUN pip install -r requirements.txt
 

--- a/mainnet/singularity/README.md
+++ b/mainnet/singularity/README.md
@@ -10,7 +10,7 @@ the default revision is `master`:
 ```bash
 docker build \
   -f mainnet/singularity/Dockerfile \
-  -t pyquarkchain:master \
+  -t "<docker image name>" \
   .
 ```
 
@@ -23,17 +23,31 @@ organization uses SSO, authorize the token for that organization as well.
 Provide the token as a BuildKit secret so it is not stored in an image layer or
 passed as a Docker build argument:
 
+For Bash:
+
 ```bash
 read -rsp "GitHub token: " GITHUB_TOKEN
 echo
 export GITHUB_TOKEN
+```
 
+For zsh:
+
+```zsh
+read -rs "GITHUB_TOKEN?GitHub token: "
+echo
+export GITHUB_TOKEN
+```
+
+Then build the image:
+
+```sh
 docker build \
   --secret id=github_token,env=GITHUB_TOKEN \
   -f mainnet/singularity/Dockerfile \
   --build-arg GIT_REPOSITORY=https://github.com/QuarkChain/pyquarkchain-hot-fix.git \
-  --build-arg GIT_TAG=fix/create2-gas \
-  -t pyquarkchain:hotfix \
+  --build-arg GIT_TAG="<branch>" \
+  -t "<docker image name>" \
   .
 
 unset GITHUB_TOKEN

--- a/mainnet/singularity/README.md
+++ b/mainnet/singularity/README.md
@@ -9,6 +9,7 @@ the default revision is `master`:
 
 ```bash
 docker build \
+  --no-cache \
   -f mainnet/singularity/Dockerfile \
   -t "<docker image name>" \
   .
@@ -21,29 +22,20 @@ For a fine-grained token, grant `Contents: Read-only` permission. If the
 organization uses SSO, authorize the token for that organization as well.
 
 Provide the token as a BuildKit secret so it is not stored in an image layer or
-passed as a Docker build argument:
+passed as a Docker build argument. `GIT_REPOSITORY` must be an HTTPS repository
+under the `QuarkChain` organization; the organization and repository URL are
+case-insensitive, and the `.git` suffix is optional.
 
-For Bash:
+Run the following commands in Bash or zsh:
 
 ```bash
-read -rsp "GitHub token: " GITHUB_TOKEN
+printf "GitHub token: "
+read -rs GITHUB_TOKEN
 echo
 export GITHUB_TOKEN
-```
 
-For zsh:
-
-```zsh
-read -rs "GITHUB_TOKEN?GitHub token: "
-echo
-export GITHUB_TOKEN
-```
-
-Then build the image:
-
-```sh
 docker build \
-  --no-cache
+  --no-cache \
   --secret id=github_token,env=GITHUB_TOKEN \
   -f mainnet/singularity/Dockerfile \
   --build-arg GIT_REPOSITORY=https://github.com/QuarkChain/pyquarkchain-hot-fix.git \
@@ -54,5 +46,5 @@ docker build \
 unset GITHUB_TOKEN
 ```
 
-`GIT_TAG` may be a branch, tag, or commit SHA. Use a full commit SHA for a
-reproducible production image.
+`GIT_TAG` may be a branch, tag, or commit SHA. Use a full commit SHA to pin the
+source revision.

--- a/mainnet/singularity/README.md
+++ b/mainnet/singularity/README.md
@@ -43,6 +43,7 @@ Then build the image:
 
 ```sh
 docker build \
+  --no-cache
   --secret id=github_token,env=GITHUB_TOKEN \
   -f mainnet/singularity/Dockerfile \
   --build-arg GIT_REPOSITORY=https://github.com/QuarkChain/pyquarkchain-hot-fix.git \

--- a/mainnet/singularity/README.md
+++ b/mainnet/singularity/README.md
@@ -1,0 +1,43 @@
+# Singularity Docker Image
+
+Run the following commands from the repository root.
+
+## Build from the public repository
+
+The default repository is `https://github.com/QuarkChain/pyquarkchain.git`, and
+the default revision is `master`:
+
+```bash
+docker build \
+  -f mainnet/singularity/Dockerfile \
+  -t pyquarkchain:master \
+  .
+```
+
+## Build from a private repository
+
+Create a GitHub personal access token with read access to the target repository.
+For a fine-grained token, grant `Contents: Read-only` permission. If the
+organization uses SSO, authorize the token for that organization as well.
+
+Provide the token as a BuildKit secret so it is not stored in an image layer or
+passed as a Docker build argument:
+
+```bash
+read -rsp "GitHub token: " GITHUB_TOKEN
+echo
+export GITHUB_TOKEN
+
+docker build \
+  --secret id=github_token,env=GITHUB_TOKEN \
+  -f mainnet/singularity/Dockerfile \
+  --build-arg GIT_REPOSITORY=https://github.com/QuarkChain/pyquarkchain-hot-fix.git \
+  --build-arg GIT_TAG=fix/create2-gas \
+  -t pyquarkchain:hotfix \
+  .
+
+unset GITHUB_TOKEN
+```
+
+`GIT_TAG` may be a branch, tag, or commit SHA. Use a full commit SHA for a
+reproducible production image.


### PR DESCRIPTION
## Summary

- Support cloning private GitHub repositories during Docker builds.
- Pass the GitHub token through a BuildKit secret instead of a build argument.
- Keep unauthenticated cloning available for public repositories.
- Remove Git metadata and Git tooling after the image is built.
- Document public and private repository build commands.

## Usage

```bash
printf "GitHub token: "
read -rs GITHUB_TOKEN
echo
export GITHUB_TOKEN

docker build \
  --no-cache \
  --secret id=github_token,env=GITHUB_TOKEN \
  -f mainnet/singularity/Dockerfile \
  --build-arg GIT_REPOSITORY=https://github.com/QuarkChain/pyquarkchain-hot-fix.git \
  --build-arg GIT_TAG="<branch>" \
  -t "<docker image name>" \
  .

unset GITHUB_TOKEN
```

The GitHub token requires read access to the target repository. For a fine-grained PAT, `Contents: Read-only` is sufficient.

## Security

The token is mounted only for the clone command and is not stored in a Docker build argument or image layer.

## Verification

- Successfully cloned the private hot-fix repository using a BuildKit secret.
- `git diff --check` passes.
