### PR TITLE
P2: Harden RPC timeouts, cancellation cleanup, and concurrency limits

### DIFF
--- a/quarkchain/cluster/jsonrpc.py
+++ b/quarkchain/cluster/jsonrpc.py
@@ -44,6 +44,28 @@ DEFAULT_GASPRICE = 10 * denoms.gwei
 # TODO: revisit this parameter
 JSON_RPC_CLIENT_REQUEST_MAX_SIZE = 16 * 1024 * 1024
 
+# Keep public RPC overload protection independent of the cluster config.
+JSON_RPC_MAX_CONCURRENCY = 64
+JSON_RPC_QUEUE_TIMEOUT = 1
+JSON_RPC_REQUEST_TIMEOUT = 30
+
+# A timed-out read can be cancelled safely.  A write may already have changed
+# cluster state before it reaches an await point, so cancelling it would leave
+# the caller with an unknown partial result.  Keep these handlers running after
+# the HTTP deadline and report that the operation may still be in progress.
+JSON_RPC_WRITE_METHODS = frozenset(
+    {
+        "sendTransaction",
+        "sendRawTransaction",
+        "eth_sendRawTransaction",
+        "submitWork",
+        "addBlock",
+        "createTransactions",
+        "setTargetBlockTime",
+        "setMining",
+    }
+)
+
 
 EMPTY_TX_ID = "0x" + "0" * Constant.TX_ID_HEX_LENGTH
 
@@ -512,6 +534,8 @@ class JSONRPCHttpServer:
         self.env = env
         self.master = master_server
         self.counters = dict()
+        self._request_semaphore = asyncio.Semaphore(JSON_RPC_MAX_CONCURRENCY)
+        self._dispatch_tasks = set()
 
         # Bind RPC handler functions to this instance
         self.handlers = RpcMethods()
@@ -537,14 +561,70 @@ class JSONRPCHttpServer:
             self.counters[method] += 1
         else:
             self.counters[method] = 1
-        # Use asyncio.shield to prevent the handler from being cancelled when
-        # aiohttp server loses connection to client
-        response = await asyncio.shield(self.handlers.dispatch(d))
+        semaphore = self._request_semaphore
+        acquired = False
+        try:
+            await asyncio.wait_for(
+                semaphore.acquire(), JSON_RPC_QUEUE_TIMEOUT
+            )
+            acquired = True
+            dispatch_task = asyncio.create_task(self.handlers.dispatch(d))
+        except asyncio.TimeoutError:
+            Logger.warning_every_sec("JSON-RPC server busy; rejecting request", 1)
+            return self.__error_response(d, "Server busy")
+        except BaseException:
+            if acquired:
+                semaphore.release()
+            raise
+
+        self._dispatch_tasks.add(dispatch_task)
+        dispatch_task.add_done_callback(self.__dispatch_done)
+
+        # Read handlers can be cancelled at the deadline.  Writes are shielded
+        # so a client timeout cannot interrupt a state-changing operation.
+        is_write = isinstance(method, str) and method in JSON_RPC_WRITE_METHODS
+        dispatch_wait = (
+            asyncio.shield(dispatch_task)
+            if is_write
+            else dispatch_task
+        )
+        try:
+            response = await asyncio.wait_for(
+                dispatch_wait, JSON_RPC_REQUEST_TIMEOUT
+            )
+        except asyncio.TimeoutError:
+            Logger.warning_every_sec("JSON-RPC request timed out", 1)
+            message = "Request timeout"
+            if is_write:
+                message += "; operation may still be in progress"
+            return self.__error_response(d, message)
+
         if response is None:
             return web.Response()
         if "error" in response:
             Logger.error(response)
         return web.json_response(response)
+
+    def __dispatch_done(self, task):
+        self._dispatch_tasks.discard(task)
+        self._request_semaphore.release()
+        if not task.cancelled():
+            # Retrieve exceptions when the HTTP client disconnected while the
+            # shielded dispatch task was still running.
+            task.exception()
+
+    @staticmethod
+    def __error_response(request_json, message):
+        if isinstance(request_json, dict) and "id" not in request_json:
+            return web.Response()
+        req_id = request_json.get("id") if isinstance(request_json, dict) else None
+        return web.json_response(
+            {
+                "jsonrpc": "2.0",
+                "error": {"code": -32000, "message": message},
+                "id": req_id,
+            }
+        )
 
     async def start(self):
         app = web.Application(client_max_size=JSON_RPC_CLIENT_REQUEST_MAX_SIZE)

--- a/quarkchain/cluster/master.py
+++ b/quarkchain/cluster/master.py
@@ -92,6 +92,7 @@ from quarkchain.utils import Logger, check
 from quarkchain.cluster.cluster_config import ClusterConfig
 from quarkchain.constants import (
     SYNC_TIMEOUT,
+    SYNC_MINOR_BLOCK_LIST_TIMEOUT,
     ROOT_BLOCK_BATCH_SIZE,
     ROOT_BLOCK_HEADER_LIST_LIMIT,
 )
@@ -313,7 +314,20 @@ class SyncTask:
             )
             future_list.append(future)
 
-        result_list = await asyncio.gather(*future_list)
+        timeout = (
+            SYNC_MINOR_BLOCK_LIST_TIMEOUT
+            + SYNC_TIMEOUT
+        )
+        try:
+            result_list = await asyncio.wait_for(
+                asyncio.gather(*future_list), timeout
+            )
+        except asyncio.TimeoutError as e:
+            raise RuntimeError(
+                "Timed out syncing minor blocks from slaves after {} seconds".format(
+                    timeout
+                )
+            ) from e
         for result in result_list:
             if result is Exception:
                 raise RuntimeError(

--- a/quarkchain/cluster/slave.py
+++ b/quarkchain/cluster/slave.py
@@ -75,7 +75,7 @@ from quarkchain.cluster.rpc import (
     SlaveInfo,
 )
 from quarkchain.cluster.shard import Shard, PeerShardConnection
-from quarkchain.constants import SYNC_TIMEOUT
+from quarkchain.constants import SYNC_MINOR_BLOCK_LIST_TIMEOUT, SYNC_TIMEOUT
 from quarkchain.core import Branch, TypedTransaction, Address, Log
 from quarkchain.core import (
     CrossShardTransactionList,
@@ -495,7 +495,10 @@ class MasterConnection(ClusterConnection):
                 (
                     add_block_success,
                     coinbase_amount_list,
-                ) = await self.slave_server.add_block_list_for_sync(block_chain)
+                ) = await asyncio.wait_for(
+                    self.slave_server.add_block_list_for_sync(block_chain),
+                    SYNC_MINOR_BLOCK_LIST_TIMEOUT,
+                )
                 if not add_block_success:
                     raise RuntimeError(
                         "Failed to add minor blocks for syncing root block"

--- a/quarkchain/cluster/tests/test_cluster.py
+++ b/quarkchain/cluster/tests/test_cluster.py
@@ -1,6 +1,6 @@
 import asyncio
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from eth_keys.datatypes import PrivateKey
 
@@ -10,6 +10,7 @@ from quarkchain.cluster.p2p_commands import (
     GetMinorBlockHeaderListWithSkipRequest,
     Direction,
 )
+from quarkchain.cluster.master import SyncTask
 from quarkchain.cluster.shard import Shard
 from quarkchain.cluster.tests.test_utils import (
     create_transfer_transaction,
@@ -2708,3 +2709,48 @@ class TestAddBlockCancellation(unittest.IsolatedAsyncioTestCase):
 
         result = await asyncio.wait_for(waiter_task, timeout=5.0)
         self.assertFalse(result, "Waiter for an interrupted block should return False")
+
+    async def test_cancelled_add_block_list_for_sync_cleans_up_futures(self):
+        shard = self._make_shard()
+        block = _make_finalized_shard_block(shard.state)
+        block_hash = block.header.get_hash()
+        broadcast_started = asyncio.Event()
+
+        async def hanging_broadcast(*args, **kwargs):
+            broadcast_started.set()
+            await asyncio.sleep(9999)
+
+        shard.slave.batch_broadcast_xshard_tx_list = hanging_broadcast
+        task = asyncio.create_task(shard.add_block_list_for_sync([block]))
+        await broadcast_started.wait()
+        task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+
+        self.assertNotIn(block_hash, shard.add_block_futures)
+
+
+class TestRootSyncTimeout(unittest.IsolatedAsyncioTestCase):
+    async def test_sync_minor_blocks_times_out_waiting_for_slave(self):
+        task = SyncTask.__new__(SyncTask)
+        task.root_state = MagicMock()
+        task.root_state.db.contain_minor_block_by_hash.return_value = False
+        task.master_server = MagicMock()
+        task.peer = MagicMock()
+
+        pending_response = asyncio.get_running_loop().create_future()
+        slave_connection = MagicMock()
+        slave_connection.write_rpc_request.return_value = pending_response
+        task.master_server.get_slave_connection.return_value = slave_connection
+
+        header = MagicMock()
+        header.get_hash.return_value = bytes(32)
+
+        with patch("quarkchain.cluster.master.SYNC_TIMEOUT", 0):
+            with patch("quarkchain.cluster.master.SYNC_MINOR_BLOCK_LIST_TIMEOUT", 0.01):
+                with self.assertRaisesRegex(
+                    RuntimeError, "Timed out syncing minor blocks from slaves"
+                ):
+                    await task._SyncTask__sync_minor_blocks([header])
+
+        self.assertTrue(pending_response.cancelled())

--- a/quarkchain/cluster/tests/test_jsonrpc.py
+++ b/quarkchain/cluster/tests/test_jsonrpc.py
@@ -1,6 +1,8 @@
+import asyncio
 import json
 import unittest
 from contextlib import asynccontextmanager
+from unittest.mock import patch
 import aiohttp
 import rlp
 import websockets
@@ -2259,6 +2261,25 @@ async def _protocol_echo(self, value):
     return value
 
 
+async def _protocol_slow(self, delay):
+    started = getattr(self, "_test_handler_started", None)
+    if started is not None:
+        started.set()
+    await asyncio.sleep(delay)
+    return "done"
+
+
+async def _protocol_slow_write(self, delay):
+    started = getattr(self, "_test_write_handler_started", None)
+    if started is not None:
+        started.set()
+    await asyncio.sleep(delay)
+    completed = getattr(self, "_test_write_handler_completed", None)
+    if completed is not None:
+        completed.set()
+    return "done"
+
+
 @asynccontextmanager
 async def jrpc_protocol_server_context():
     """Start a standalone JSON-RPC HTTP server with no MasterServer.
@@ -2274,6 +2295,8 @@ async def jrpc_protocol_server_context():
 
     methods = RpcMethods()
     methods.add(_protocol_echo, name="echo")
+    methods.add(_protocol_slow, name="slow")
+    methods.add(_protocol_slow_write, name="slowWrite")
 
     server = JSONRPCHttpServer(env, None, 38391, "127.0.0.1", methods)
     await server.start()
@@ -2305,6 +2328,123 @@ class TestJSONRPCProtocol(unittest.IsolatedAsyncioTestCase):
       - a notification (no "id") that errors must produce no response body
       - error responses are returned with HTTP 200
     """
+
+    async def test_request_timeout_releases_concurrency_slot(self):
+        with patch("quarkchain.cluster.jsonrpc.JSON_RPC_REQUEST_TIMEOUT", 0.01), patch(
+            "quarkchain.cluster.jsonrpc.JSON_RPC_MAX_CONCURRENCY", 1
+        ):
+            async with jrpc_protocol_server_context():
+
+                status, text = await post_raw(
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "slow",
+                            "params": [1],
+                            "id": 1,
+                        }
+                    )
+                )
+                self.assertEqual(status, 200)
+                response = json.loads(text)
+                self.assertEqual(response["error"]["code"], -32000)
+                self.assertEqual(response["error"]["message"], "Request timeout")
+
+                status, text = await post_raw(
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "echo",
+                            "params": ["ok"],
+                            "id": 2,
+                        }
+                    )
+                )
+                self.assertEqual(status, 200)
+                self.assertEqual(json.loads(text)["result"], "ok")
+
+    async def test_write_timeout_does_not_cancel_handler(self):
+        with patch("quarkchain.cluster.jsonrpc.JSON_RPC_REQUEST_TIMEOUT", 0.01), patch(
+            "quarkchain.cluster.jsonrpc.JSON_RPC_MAX_CONCURRENCY", 1
+        ), patch("quarkchain.cluster.jsonrpc.JSON_RPC_WRITE_METHODS", {"slowWrite"}):
+            async with jrpc_protocol_server_context() as server:
+                server._test_write_handler_started = asyncio.Event()
+                server._test_write_handler_completed = asyncio.Event()
+
+                status, text = await post_raw(
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "slowWrite",
+                            "params": [0.2],
+                            "id": 1,
+                        }
+                    )
+                )
+                self.assertEqual(status, 200)
+                response = json.loads(text)
+                self.assertEqual(response["error"]["code"], -32000)
+                self.assertIn("may still be in progress", response["error"]["message"])
+
+                await asyncio.wait_for(
+                    server._test_write_handler_started.wait(), timeout=1
+                )
+                await asyncio.wait_for(
+                    server._test_write_handler_completed.wait(), timeout=1
+                )
+
+                status, text = await post_raw(
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "echo",
+                            "params": ["after-write"],
+                            "id": 2,
+                        }
+                    )
+                )
+                self.assertEqual(status, 200)
+                self.assertEqual(json.loads(text)["result"], "after-write")
+
+    async def test_concurrency_limit_rejects_queued_request(self):
+        with patch("quarkchain.cluster.jsonrpc.JSON_RPC_REQUEST_TIMEOUT", 2), patch(
+            "quarkchain.cluster.jsonrpc.JSON_RPC_QUEUE_TIMEOUT", 0.01
+        ), patch("quarkchain.cluster.jsonrpc.JSON_RPC_MAX_CONCURRENCY", 1):
+            async with jrpc_protocol_server_context() as server:
+                server._test_handler_started = asyncio.Event()
+
+                first_request = asyncio.create_task(
+                    post_raw(
+                        json.dumps(
+                            {
+                                "jsonrpc": "2.0",
+                                "method": "slow",
+                                "params": [1],
+                                "id": 1,
+                            }
+                        )
+                    )
+                )
+                await server._test_handler_started.wait()
+
+                status, text = await post_raw(
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "echo",
+                            "params": ["rejected"],
+                            "id": 2,
+                        }
+                    )
+                )
+                self.assertEqual(status, 200)
+                response = json.loads(text)
+                self.assertEqual(response["error"]["code"], -32000)
+                self.assertEqual(response["error"]["message"], "Server busy")
+
+                first_status, first_text = await first_request
+                self.assertEqual(first_status, 200)
+                self.assertEqual(json.loads(first_text)["result"], "done")
 
     async def test_malformed_json_returns_parse_error(self):
         async with jrpc_protocol_server_context():

--- a/quarkchain/cluster/tests/test_protocol.py
+++ b/quarkchain/cluster/tests/test_protocol.py
@@ -6,12 +6,15 @@ from quarkchain.cluster.protocol import ClusterConnection, P2PConnection
 from quarkchain.cluster.protocol import ClusterMetadata, P2PMetadata
 from quarkchain.env import DEFAULT_ENV
 from quarkchain.core import uint32, Branch, Serializable
+from quarkchain.protocol import ConnectionState
+from quarkchain.p2p.p2p_manager import SecurePeer
 
 FORWARD_BRANCH = Branch(123)
 EMPTY_BRANCH = Branch(456)
 PEER_ID = b"\xab" * 32
 CLUSTER_PEER_ID = 123
 OP = 66
+OP_RESPONSE = 67
 RPC_ID = 123456
 
 
@@ -31,7 +34,7 @@ async def handle_package(connection, package):
     return package
 
 
-OP_SER_MAP = {OP: DummyPackage}
+OP_SER_MAP = {OP: DummyPackage, OP_RESPONSE: DummyPackage}
 OP_RPC_MAP = {OP: (OP, handle_package)}
 
 
@@ -63,6 +66,65 @@ class DummyClusterConnection(ClusterConnection):
 
 
 class TestP2PConnection(unittest.TestCase):
+    def test_cancelled_rpc_future_is_removed(self):
+        reader = AsyncMock()
+        writer = MagicMock()
+
+        async def run():
+            conn = DummyP2PConnection(DEFAULT_ENV, reader, writer)
+            conn.state = ConnectionState.ACTIVE
+            future = conn.write_rpc_request(OP, DummyPackage(999))
+            self.assertEqual(list(conn.rpc_future_map), [1])
+
+            future.cancel()
+            await asyncio.sleep(0)
+            self.assertNotIn(1, conn.rpc_future_map)
+            self.assertIn(1, conn._cancelled_rpc_ids)
+
+        asyncio.run(run())
+
+    def test_late_response_for_cancelled_rpc_is_ignored(self):
+        reader = AsyncMock()
+        writer = MagicMock()
+
+        async def run():
+            conn = DummyP2PConnection(DEFAULT_ENV, reader, writer)
+            conn.state = ConnectionState.ACTIVE
+            future = conn.write_rpc_request(OP, DummyPackage(999))
+            future.cancel()
+            await asyncio.sleep(0)
+
+            response = bytearray([OP_RESPONSE])
+            response += (1).to_bytes(8, byteorder="big")
+            response += DummyPackage(1000).serialize()
+            await conn.handle_metadata_and_raw_data(P2PMetadata(EMPTY_BRANCH), response)
+
+            self.assertFalse(conn.is_closed())
+            self.assertNotIn(1, conn.rpc_future_map)
+            self.assertNotIn(1, conn._cancelled_rpc_ids)
+
+        asyncio.run(run())
+
+    def test_abort_in_flight_rpcs_ignores_cancelled_future(self):
+        reader = AsyncMock()
+        writer = MagicMock()
+
+        async def run():
+            conn = DummyP2PConnection(DEFAULT_ENV, reader, writer)
+            conn.state = ConnectionState.ACTIVE
+            future = conn.write_rpc_request(OP, DummyPackage(999))
+            future.cancel()
+
+            # The cancellation callback runs on the next event-loop turn in
+            # production, so the RPC can still be present during disconnect.
+            SecurePeer.abort_in_flight_rpcs(conn)
+            await asyncio.sleep(0)
+
+            self.assertTrue(future.cancelled())
+            self.assertEqual(conn.rpc_future_map, {})
+
+        asyncio.run(run())
+
     def test_forward(self):
         meta = P2PMetadata(FORWARD_BRANCH)
         metaBytes = meta.serialize()

--- a/quarkchain/constants.py
+++ b/quarkchain/constants.py
@@ -23,6 +23,9 @@ ROOT_BLOCK_HEADER_LIST_LIMIT = 500
 
 SYNC_TIMEOUT = 30
 
+# Maximum time spent processing a batch of minor blocks after download.
+SYNC_MINOR_BLOCK_LIST_TIMEOUT = 300
+
 BLOCK_UNCOMMITTED = 0  # The other slaves and the master may not have the block info
 BLOCK_COMMITTING = 1  # The block info is propagating to other slaves and the master
 BLOCK_COMMITTED = 2  # The other slaves and the master have received the block info

--- a/quarkchain/p2p/p2p_manager.py
+++ b/quarkchain/p2p/p2p_manager.py
@@ -277,7 +277,10 @@ class SecurePeer(Peer):
 
     def abort_in_flight_rpcs(self):
         for rpc_id, future in self.rpc_future_map.items():
-            future.set_exception(RuntimeError("{}: connection abort".format(self.name)))
+            if not future.done():
+                future.set_exception(
+                    RuntimeError("{}: connection abort".format(self.name))
+                )
         AbstractConnection.aborted_rpc_count += len(self.rpc_future_map)
         self.rpc_future_map.clear()
 

--- a/quarkchain/protocol.py
+++ b/quarkchain/protocol.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections import deque
 from enum import Enum
 
 from quarkchain.core import Serializable
@@ -30,6 +31,7 @@ class Metadata(Serializable):
 class AbstractConnection:
     conn_id = 0
     aborted_rpc_count = 0
+    _MAX_CANCELLED_RPC_IDS = 1024
 
     @classmethod
     def __get_next_connection_id(cls):
@@ -52,6 +54,8 @@ class AbstractConnection:
         self.peer_rpc_id = -1
         self.rpc_id = 0  # 0 is for non-rpc (fire-and-forget)
         self.rpc_future_map = dict()
+        self._cancelled_rpc_ids = set()
+        self._cancelled_rpc_id_order = deque()
         self.active_event = asyncio.Event()
         self.close_event = asyncio.Event()
         self.metadata_class = metadata_class
@@ -110,9 +114,31 @@ class AbstractConnection:
         self.rpc_id += 1
         rpc_id = self.rpc_id
         self.rpc_future_map[rpc_id] = rpc_future
+        rpc_future.add_done_callback(
+            lambda future, rpc_id=rpc_id: self.__rpc_future_done(rpc_id, future)
+        )
 
         self.write_command(op, cmd, rpc_id, metadata)
         return rpc_future
+
+    def __rpc_future_done(self, rpc_id, future):
+        if not future.cancelled():
+            return
+
+        # A timeout/cancellation can happen without a response ever arriving.
+        # Remove the future immediately so a dead peer cannot grow this map.
+        if self.rpc_future_map.get(rpc_id) is not future:
+            return
+        del self.rpc_future_map[rpc_id]
+
+        # The remote handler may still send a response after the local waiter
+        # has timed out. Remember a bounded number of such IDs so that response
+        # is ignored instead of being treated as a protocol violation.
+        self._cancelled_rpc_ids.add(rpc_id)
+        self._cancelled_rpc_id_order.append(rpc_id)
+        if len(self._cancelled_rpc_id_order) > self._MAX_CANCELLED_RPC_IDS:
+            expired_rpc_id = self._cancelled_rpc_id_order.popleft()
+            self._cancelled_rpc_ids.discard(expired_rpc_id)
 
     def __write_rpc_response(self, op, cmd, rpc_id, metadata):
         self.write_command(op, cmd, rpc_id, metadata)
@@ -152,12 +178,14 @@ class AbstractConnection:
             await self.__handle_rpc_request(op, cmd, rpc_id, metadata)
         else:
             # Check if it is a valid RPC response
-            if rpc_id not in self.rpc_future_map:
+            future = self.rpc_future_map.pop(rpc_id, None)
+            if future is None:
+                if rpc_id in self._cancelled_rpc_ids:
+                    self._cancelled_rpc_ids.discard(rpc_id)
+                    return
                 raise RuntimeError(
                     "{}: unexpected rpc response {}".format(self.name, rpc_id)
                 )
-            future = self.rpc_future_map[rpc_id]
-            del self.rpc_future_map[rpc_id]
             if not future.cancelled():
                 future.set_result((op, cmd, rpc_id))
 


### PR DESCRIPTION
## Summary

Prevent cancelled or stalled RPCs from leaking resources, bound minor-block sync time, and protect the HTTP JSON-RPC server from unbounded concurrent requests.

## Changes

- Clean up cancelled RPC futures and safely ignore late responses.
- Add timeouts for minor-block synchronization.
- Add concurrency and timeout protection to the HTTP JSON-RPC server.
- Add regression tests for cancellation, timeout, and overload handling.

## Testing

- `python -m pytest`
  - 417 items passed
